### PR TITLE
feat: Improve MCP configuration step with optional fields and auto-selection

### DIFF
--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/MCPConfigForm.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/MCPConfigForm.vue
@@ -7,7 +7,7 @@
       <UnnnicSwitch
         v-if="element.type === 'SWITCH'"
         data-testid="concierge-second-step-switch"
-        :option="element.label"
+        :option="fieldLabel(element)"
         :modelValue="configValues[element.name] ?? false"
         @update:model-value="updateFieldValue(element.name, $event)"
       />
@@ -15,7 +15,7 @@
       <UnnnicSelect
         v-else-if="element.type === 'SELECT'"
         data-testid="concierge-second-step-select"
-        :label="element.label"
+        :label="fieldLabel(element)"
         :options="formatOptions(element.options)"
         :modelValue="getSelectModelValue(element)"
         @update:model-value="updateFieldValue(element.name, $event)"
@@ -24,7 +24,7 @@
       <UnnnicInput
         v-else-if="['NUMBER', 'TEXT', 'INPUT'].includes(element.type)"
         data-testid="concierge-second-step-input"
-        :label="element.label"
+        :label="fieldLabel(element)"
         :modelValue="String(configValues[element.name] ?? '')"
         :nativeType="element.type === 'NUMBER' ? 'number' : 'text'"
         @update:model-value="updateFieldValue(element.name, $event)"
@@ -33,7 +33,7 @@
       <UnnnicCheckboxGroup
         v-else-if="element.type === 'CHECKBOX'"
         data-testid="concierge-second-step-checkbox-group"
-        :label="element.label"
+        :label="fieldLabel(element)"
       >
         <UnnnicCheckbox
           v-for="option in element.options"
@@ -51,7 +51,7 @@
         v-else-if="element.type === 'RADIO'"
         state="vertical"
         data-testid="concierge-second-step-radio-group"
-        :label="element.label"
+        :label="fieldLabel(element)"
         :modelValue="configValues[element.name]"
         @update:model-value="updateFieldValue(element.name, $event)"
       >
@@ -70,6 +70,7 @@
 <script setup lang="ts">
 import { AgentMCP } from '@/store/types/Agents.types';
 import { watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 type MCPConfigField = AgentMCP['config'] extends (infer U)[] ? U : never;
 type MCPConfigValue = string | string[] | boolean;
@@ -84,6 +85,13 @@ const configValues = defineModel<Record<string, MCPConfigValue>>(
     required: true,
   },
 );
+
+const { t } = useI18n();
+
+function fieldLabel(element: MCPConfigField) {
+  if (element.is_required) return element.label;
+  return `${element.label} (${t('agents.assign_agents.setup.mcp_config.optional')})`;
+}
 
 function buildInitialValues(config: MCPConfigField[]) {
   config.forEach((element) => {

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/__tests__/MCPConfigForm.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/__tests__/MCPConfigForm.spec.js
@@ -4,17 +4,25 @@ import { shallowMount } from '@vue/test-utils';
 
 import MCPConfigForm from '../MCPConfigForm.vue';
 
+vi.mock('vue-i18n', () => ({
+  useI18n: () => ({
+    t: vi.fn((key) => key),
+  }),
+}));
+
 const configFixture = [
   {
     name: 'notifications',
     label: 'Notifications',
     type: 'SWITCH',
     default_value: true,
+    is_required: true,
   },
   {
     name: 'channel',
     label: 'Channel',
     type: 'SELECT',
+    is_required: true,
     options: [
       { name: 'Email', value: 'email' },
       { name: 'SMS', value: 'sms' },
@@ -25,17 +33,20 @@ const configFixture = [
     label: 'Threshold',
     type: 'NUMBER',
     default_value: 5,
+    is_required: false,
   },
   {
     name: 'notes',
     label: 'Notes',
     type: 'TEXT',
     default_value: 'Initial note',
+    is_required: true,
   },
   {
     name: 'features',
     label: 'Features',
     type: 'CHECKBOX',
+    is_required: false,
     options: [
       { name: 'Feature A', value: 'feature-a' },
       { name: 'Feature B', value: 'feature-b' },
@@ -45,6 +56,7 @@ const configFixture = [
     name: 'mode',
     label: 'Mode',
     type: 'RADIO',
+    is_required: true,
     options: [
       { name: 'Automatic', value: 'auto' },
       { name: 'Manual', value: 'manual' },

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/__tests__/index.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/__tests__/index.spec.js
@@ -135,9 +135,9 @@ describe('MCPStepContent', () => {
     );
 
   describe('rendering', () => {
-    it('shows placeholder when nothing is selected', () => {
-      expect(findPlaceholder().exists()).toBe(true);
-      expect(findConfigForm().exists()).toBe(false);
+    it('auto-selects the first MCP when none is selected', () => {
+      expect(findPlaceholder().exists()).toBe(false);
+      expect(getSelectedMCP()).toEqual(mcpWithConfig);
     });
 
     it('shows config form when selected MCP has config', async () => {
@@ -175,11 +175,14 @@ describe('MCPStepContent', () => {
     });
 
     it('ignores unchecked selection events', async () => {
-      findMCPSelection().vm.$emit('select', mcpWithConfig, false);
+      const mcpBeforeEvent = getSelectedMCP();
+      const configBeforeEvent = getConfigValues();
+
+      findMCPSelection().vm.$emit('select', mcpWithoutConfig, false);
       await nextTick();
 
-      expect(getSelectedMCP()).toBeNull();
-      expect(getConfigValues()).toEqual({});
+      expect(getSelectedMCP()).toEqual(mcpBeforeEvent);
+      expect(getConfigValues()).toEqual(configBeforeEvent);
     });
   });
 

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/index.vue
@@ -69,10 +69,11 @@ defineOptions({
   name: 'MCPStepContent',
 });
 
-defineProps<{
+const props = defineProps<{
   // eslint-disable-next-line vue/prop-name-casing
   MCPs: AgentMCP[];
 }>();
+
 const selectedMCP = defineModel<AgentMCP | null>('selectedMCP', {
   required: true,
 });
@@ -86,6 +87,17 @@ const selectedMCPConfigValues = defineModel<Record<string, MCPConfigValue>>(
 const selectedMCPConfig = computed<MCPConfigField[]>(() => {
   return (selectedMCP.value?.config ?? []) as MCPConfigField[];
 });
+
+watch(
+  () => props.MCPs,
+  (mcps) => {
+    if (mcps.length && !selectedMCP.value) {
+      handleSelectMCP(mcps[0], true);
+    }
+  },
+  { immediate: true },
+);
+
 watch(
   () => selectedMCP.value,
   (next) => {
@@ -97,11 +109,13 @@ watch(
   },
   { immediate: true },
 );
+
 function handleSelectMCP(MCP: AgentMCP, checked: boolean) {
   if (!checked) return;
   selectedMCP.value = MCP;
   selectedMCPConfigValues.value = buildInitialValues(MCP.config);
 }
+
 function buildInitialValues(config: AgentMCP['config'] = []) {
   return (config as MCPConfigField[]).reduce<Record<string, MCPConfigValue>>(
     (acc, field) => {

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
@@ -165,7 +165,7 @@ const isNextDisabled = computed(() => {
   const isSomeRequiredMCPValueMissing = () => {
     const mcpConfig = config.value.MCP?.config ?? [];
     const requiredFieldNames = mcpConfig
-      .filter((field) => field.required)
+      .filter((field) => field.is_required)
       .map((field) => field.name);
 
     return requiredFieldNames.some((name) => {

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
@@ -162,9 +162,21 @@ const isNextDisabled = computed(() => {
     );
   };
 
+  const isSomeRequiredMCPValueMissing = () => {
+    const mcpConfig = config.value.MCP?.config ?? [];
+    const requiredFieldNames = mcpConfig
+      .filter((field) => field.required)
+      .map((field) => field.name);
+
+    return requiredFieldNames.some((name) => {
+      const value = config.value.mcp_config[name];
+      return value === '' || value === undefined;
+    });
+  };
+
   const stepDisabled: Partial<Record<StepKey, () => boolean>> = {
     [Step.MCP]: () => {
-      return !config.value.MCP || isSomeValueMissing(config.value.mcp_config);
+      return !config.value.MCP || isSomeRequiredMCPValueMissing();
     },
     [Step.Credentials]: () => {
       return isSomeValueMissing(config.value.credentials) || isSubmitting.value;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -373,6 +373,7 @@
           "description": "MCP is a preset of tools that enable agent capabilities"
         },
         "mcp_config": {
+          "optional": "optional",
           "placeholder_title": "Select MCP from the list beside",
           "placeholder_description": "Select the MCP that best matches your scenario and configure it",
           "title": "Configure {mcp} MCP",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -373,6 +373,7 @@
           "description": "MCP es un conjunto de herramientas que habilita las capacidades del agente"
         },
         "mcp_config": {
+          "optional": "opcional",
           "placeholder_title": "Selecciona un MCP en la lista al lado",
           "placeholder_description": "Selecciona el MCP que mejor se adapte a tu escenario y configúralo",
           "title": "Configurar MCP {mcp}",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -373,6 +373,7 @@
           "description": "MCP é um conjunto de ferramentas que habilita as capacidades do agente"
         },
         "mcp_config": {
+          "optional": "opcional",
           "placeholder_title": "Selecione o MCP na lista ao lado",
           "placeholder_description": "Selecione o MCP que melhor se encaixa no seu cenário e configure-o",
           "title": "Configurar MCP {mcp}",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -373,6 +373,7 @@
           "description": "MCP este un set predefinit de instrumente care activează capacitățile agentului"
         },
         "mcp_config": {
+          "optional": "opțional",
           "placeholder_title": "Selectează un MCP din lista alăturată",
           "placeholder_description": "Selectează MCP-ul care se potrivește cel mai bine scenariului tău și configurează-l",
           "title": "Configurare MCP {mcp}",

--- a/src/store/types/Agents.types.ts
+++ b/src/store/types/Agents.types.ts
@@ -76,7 +76,7 @@ export interface AgentMCP {
     name: string;
     label: string;
     default_value: string | boolean | number;
-    required: boolean;
+    is_required: boolean;
     type:
       | 'SELECT'
       | 'INPUT'

--- a/src/store/types/Agents.types.ts
+++ b/src/store/types/Agents.types.ts
@@ -76,6 +76,7 @@ export interface AgentMCP {
     name: string;
     label: string;
     default_value: string | boolean | number;
+    required: boolean;
     type:
       | 'SELECT'
       | 'INPUT'


### PR DESCRIPTION
## Description
### Type of Change

* * [x] Feature
* * [ ] Bugfix
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The MCP configuration step in the agent assignment modal required all fields to be filled before advancing, even when some fields are optional. Additionally, users had to manually select an MCP from the list before configuring it, adding an unnecessary step.

### Summary of Changes

- **Optional field validation:** The "next" button now only validates fields marked as `is_required: true`. Fields with `is_required: false` no longer block progression.
- **Optional label indicator:** Non-required fields display an "(optional)" suffix in their label, translated across all supported languages (EN, PT-BR, ES, RO).
- **Auto-select first MCP:** When entering the MCP step, the first MCP in the list is automatically pre-selected, reducing friction in the setup flow.
- **Updated tests:** Adapted `MCPConfigForm` and `MCPStepContent` tests to reflect the new auto-selection behavior and required field validation logic.