### PR TITLE
fix: Remove official agents before refresh

### DIFF
--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/ViewOptions.vue
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/ViewOptions.vue
@@ -67,13 +67,13 @@ function toggleExpanded() {
 
 async function handleRemoveAgent() {
   if (isRemovingAgent.value) return;
-  if (!props.agent?.uuid) return;
 
   isRemovingAgent.value = true;
 
   try {
     const { status } = await agentsTeamStore.toggleAgentAssignment({
       uuid: props.agent.uuid,
+      group: props.agent.group,
       is_assigned: false,
     });
 

--- a/src/composables/useAgent.ts
+++ b/src/composables/useAgent.ts
@@ -18,12 +18,14 @@ export default function useAgent() {
       is_official: agent.is_official || false,
       about: 'about' in agent ? agent.about : null,
       description: agent.description || '',
+      group: 'group' in agent ? (agent.group as string) : undefined,
       mcp:
         'mcp' in agent && agent.mcp
           ? {
               name: agent.mcp?.name || '',
               config: agent.mcp?.config || {},
-              description: agent.mcp?.description || '',
+              description:
+                'description' in agent.mcp ? agent.mcp?.description : null,
               system: getSystemObject(systemName),
             }
           : null,

--- a/src/store/AgentsTeam.ts
+++ b/src/store/AgentsTeam.ts
@@ -212,26 +212,26 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
         (agent) => agent.uuid === uuid,
       );
 
-      const agent = foundOfficialAgent || foundMyAgent || foundActiveTeamAgent;
+      const listedAgent = foundOfficialAgent || foundMyAgent;
+      const agent = foundActiveTeamAgent || listedAgent;
 
       if (!agent) {
         throw new Error('Agent not found');
       }
 
-      if (assignAgentsView && agent.is_official) {
-        await nexusaiAPI.router.agents_team.toggleOfficialAgentAssignment({
-          group: agent.group,
-          agent_uuid: uuid,
-          assigned: is_assigned,
-        });
-      } else {
+      if (agent.uuid) {
         await nexusaiAPI.router.agents_team.toggleAgentAssignment({
           agentUuid: (agent as Agent)?.uuid,
           is_assigned,
         });
+      } else {
+        await nexusaiAPI.router.agents_team.toggleOfficialAgentAssignment({
+          group: agent.group,
+          assigned: is_assigned,
+        });
       }
 
-      agent.assigned = is_assigned;
+      listedAgent.assigned = is_assigned;
 
       if (is_assigned) {
         addAgentToTeam(agent);

--- a/src/store/types/Agents.types.ts
+++ b/src/store/types/Agents.types.ts
@@ -52,6 +52,7 @@ export interface AgentAssignedMCP {
 }
 
 export interface ActiveTeamAgent {
+  group?: string;
   uuid: string;
   id: string;
   name: string;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Users were unable to remove official agents when integrating them, before refreshing the application.