### PR TITLE
feat: Map legacy personality values to tone-of-voice keys

### DIFF
--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -43,6 +43,14 @@ export default defineConfig({
     extensions: ['...', '.ts', '.vue'],
     alias: {
       '@': resolve(__dirname, 'src'),
+      ...(connectUrl
+        ? {}
+        : {
+            'connect/sharedStore': resolve(
+              __dirname,
+              'src/stubs/connectSharedStore.js',
+            ),
+          }),
     },
   },
   module: {

--- a/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
+++ b/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
@@ -64,6 +64,7 @@ describe('AgentsTeam API', () => {
       expect(result.data[0]).toEqual({
         uuid: 'agent-uuid-1',
         name: 'Official Agent 1',
+        about: null,
         description: 'First official agent',
         skills: ['skill1', 'skill2'],
         assigned: true,
@@ -177,6 +178,7 @@ describe('AgentsTeam API', () => {
       expect(result.data[0]).toEqual({
         uuid: 'my-agent-uuid-1',
         name: 'My Agent 1',
+        about: null,
         description: 'First personal agent',
         skills: ['custom-skill1'],
         assigned: true,
@@ -282,9 +284,11 @@ describe('AgentsTeam API', () => {
         name: 'Active Agent 1',
         skills: ['active-skill1'],
         id: 'active-agent-1',
+        about: null,
         description: 'First active agent',
         credentials: { type: 'active' },
         is_official: true,
+        mcp: undefined,
       });
     });
 

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/__tests__/About.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/__tests__/About.spec.js
@@ -8,6 +8,7 @@ vi.mock('@/composables/useTranslatedField', () => ({
 }));
 
 const mockAgent = {
+  group: 'CONCIERGE',
   description: 'Handles concierge flows by helping customers',
   presentation: {
     about: {

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/__tests__/index.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/__tests__/index.spec.js
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { nextTick } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
 
 import ModalAssignAgentGroup from '../index.vue';
 
@@ -45,6 +46,9 @@ describe('ModalAssignAgentGroup', () => {
         open: true,
         agent: conciergeAgent,
         ...props,
+      },
+      global: {
+        plugins: [createTestingPinia({ stubActions: true })],
       },
     });
   };

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/__tests__/ViewOptions.spec.js
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/__tests__/ViewOptions.spec.js
@@ -90,6 +90,7 @@ describe('ViewOptions', () => {
 
     expect(agentsTeamStore.toggleAgentAssignment).toHaveBeenCalledWith({
       uuid: 'agent-uuid',
+      group: null,
       is_assigned: false,
     });
     expect(wrapper.emitted('agent-removed')).toHaveLength(1);
@@ -104,18 +105,24 @@ describe('ViewOptions', () => {
 
     expect(agentsTeamStore.toggleAgentAssignment).toHaveBeenCalledWith({
       uuid: 'group-uuid',
+      group: 'CONCIERGE',
       is_assigned: false,
     });
   });
 
-  it('does not attempt removal when the agent uuid is missing', async () => {
-    createWrapper({ agent: createAgent({ uuid: undefined }) });
+  it('calls store and emits when agent uuid is missing but group is present', async () => {
+    createWrapper({ agent: createGroupAgent({ uuid: undefined }) });
 
     await findTrigger().trigger('click');
     await findRemove().trigger('click');
+    await flushPromises();
 
-    expect(agentsTeamStore.toggleAgentAssignment).not.toHaveBeenCalled();
-    expect(wrapper.emitted('agent-removed')).toBeUndefined();
+    expect(agentsTeamStore.toggleAgentAssignment).toHaveBeenCalledWith({
+      uuid: undefined,
+      group: 'CONCIERGE',
+      is_assigned: false,
+    });
+    expect(wrapper.emitted('agent-removed')).toHaveLength(1);
   });
 
   it('prevents multiple removals while a request is in flight', async () => {

--- a/src/components/AgentsTeam/__tests__/AssignAgentCard.spec.js
+++ b/src/components/AgentsTeam/__tests__/AssignAgentCard.spec.js
@@ -215,7 +215,7 @@ describe('AssignAgentCard.vue', () => {
         expect(tag.props('scheme')).toBe('aux-purple');
       });
 
-      it('should not render tag when agent is not in team', async () => {
+      it('should render custom tag even when agent is not in team', async () => {
         agentsTeamStore.activeTeam.data.agents = [];
 
         await wrapper.setProps({
@@ -228,7 +228,10 @@ describe('AssignAgentCard.vue', () => {
         });
 
         const tag = wrapper.findComponent('[data-testid="agent-tag"]');
-        expect(tag.exists()).toBe(false);
+        expect(tag.exists()).toBe(true);
+        expect(tag.props('text')).toBe(
+          i18n.global.t('router.agents_team.card.custom'),
+        );
       });
     });
 

--- a/src/components/AgentsTeam/__tests__/__snapshots__/AssignAgentCard.spec.js.snap
+++ b/src/components/AgentsTeam/__tests__/__snapshots__/AssignAgentCard.spec.js.snap
@@ -58,7 +58,20 @@ exports[`AssignAgentCard.vue > renders correctly 1`] = `
           </section>
           
         </section>
-        <!--v-if-->
+        <section
+          class="unnnic-tag unnnic-tag--small agent-card__tag"
+          data-testid="agent-tag"
+          data-v-8d850a92=""
+          data-v-97ebdc5a=""
+        >
+          <!---->
+          <p
+            class="unnnic-tag__label"
+            data-v-97ebdc5a=""
+          >
+            Custom
+          </p>
+        </section>
       </header>
       <section
         class="agent-card__infos"

--- a/src/components/Preview/Drawer/__tests__/Header.spec.js
+++ b/src/components/Preview/Drawer/__tests__/Header.spec.js
@@ -1,5 +1,5 @@
 import { mount } from '@vue/test-utils';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
 import i18n from '@/utils/plugins/i18n';
@@ -53,7 +53,7 @@ describe('PreviewDrawer/Header.vue', () => {
     expect(actionButtons().exists()).toBe(true);
     expect(actionButtons().props('actions')).toEqual([
       {
-        scheme: 'gray-500',
+        scheme: 'fg-base',
         icon: 'refresh',
         onClick: wrapper.vm.refreshPreview,
         text: i18n.global.t('router.preview.options.refresh'),

--- a/src/components/Preview/__tests__/WebchatPreview.spec.js
+++ b/src/components/Preview/__tests__/WebchatPreview.spec.js
@@ -284,9 +284,9 @@ describe('WebchatPreview.vue', () => {
 
       expect(messagesList.querySelector('.webchat-placeholder')).not.toBeNull();
 
-      const group = document.createElement('div');
-      group.className = 'weni-messages-list__direction-group';
-      messagesList.appendChild(group);
+      const message = document.createElement('div');
+      message.className = 'weni-message';
+      messagesList.appendChild(message);
 
       await vi.waitFor(() => {
         expect(messagesList.querySelector('.webchat-placeholder')).toBeNull();

--- a/src/components/Tunings/SettingsAgentsTeam/CustomModelConfig/__tests__/index.spec.js
+++ b/src/components/Tunings/SettingsAgentsTeam/CustomModelConfig/__tests__/index.spec.js
@@ -22,18 +22,18 @@ describe('CustomModelConfig/index.vue', () => {
 
   const mockProviders = [
     {
-      id: 'openai',
+      uuid: 'openai',
       label: 'OpenAI',
       models: ['gpt-4o', 'gpt-4o-mini'],
-      crendentials: [
+      credentials: [
         { type: 'PASSWORD', label: 'API Key', value: '', id: 'api_key' },
       ],
     },
     {
-      id: 'anthropic',
+      uuid: 'anthropic',
       label: 'Anthropic',
       models: ['claude-3-opus'],
-      crendentials: [
+      credentials: [
         { type: 'PASSWORD', label: 'API Key', value: '', id: 'api_key' },
         {
           type: 'TEXTAREA',

--- a/src/composables/__tests__/useFlowPreview.spec.js
+++ b/src/composables/__tests__/useFlowPreview.spec.js
@@ -11,6 +11,12 @@ vi.mock('@/store/Project', () => ({
   })),
 }));
 
+vi.mock('@/store/User', () => ({
+  useUserStore: vi.fn(() => ({
+    user: { email: 'test@example.com' },
+  })),
+}));
+
 describe('useFlowPreview', () => {
   let flowPreview;
   let mathRandomSpy;
@@ -31,7 +37,7 @@ describe('useFlowPreview', () => {
       flowPreview.previewInit();
 
       expect(flowPreview.preview.value.contact.uuid).toBe('mock-uuid');
-      expect(flowPreview.preview.value.contact.urn).toMatch(/^tel:/);
+      expect(flowPreview.preview.value.contact.urn).toBe('test@example.com');
     });
   });
 });

--- a/src/store/Profile.js
+++ b/src/store/Profile.js
@@ -3,6 +3,7 @@ import { defineStore } from 'pinia';
 import { computed, reactive, ref, watch } from 'vue';
 import { useProjectStore } from './Project';
 import { cloneDeep, differenceBy } from 'lodash';
+import { mapLegacyPersonality } from '@/utils/mapLegacyPersonality';
 
 export const useProfileStore = defineStore('profile', () => {
   const projectUuid = computed(() => useProjectStore().uuid);
@@ -61,7 +62,9 @@ export const useProfileStore = defineStore('profile', () => {
   function setInitialValues(data) {
     name.old = name.current = data.agent?.['name'] || '';
     role.old = role.current = data.agent?.['role'] || '';
-    personality.old = personality.current = data.agent?.['personality'] || '';
+    personality.old = personality.current = mapLegacyPersonality(
+      data.agent?.['personality'],
+    );
     goal.old = goal.current = data.agent?.['goal'] || '';
     instructions.current = data.instructions || [];
 

--- a/src/store/__tests__/AgentsTeam.unit.spec.js
+++ b/src/store/__tests__/AgentsTeam.unit.spec.js
@@ -6,6 +6,10 @@ import nexusaiAPI from '@/api/nexusaiAPI.js';
 
 vi.mock('@/api/nexusaiAPI.js');
 
+vi.mock('@/utils/agentIconService', () => ({
+  default: { applyIconsToAgents: vi.fn((agents) => agents) },
+}));
+
 describe('AgentsTeamStore', () => {
   let store;
 
@@ -47,29 +51,32 @@ describe('AgentsTeamStore', () => {
 
   describe('loadOfficialAgents', () => {
     it('should load official agents team successfully', async () => {
-      const mockData = {
-        data: [],
+      const mockResponse = {
+        agents: [],
+        availableSystems: [],
       };
-      const listOfficialAgentsSpy =
-        nexusaiAPI.router.agents_team.listOfficialAgents.mockResolvedValue(
-          mockData,
+      const listOfficialAgents2Spy =
+        nexusaiAPI.router.agents_team.listOfficialAgents2.mockResolvedValue(
+          mockResponse,
         );
 
-      await store.loadOfficialAgents({
-        search: 'Test Search',
-      });
+      store.setAssignAgentsFilters({ search: 'Test Search' });
+
+      await store.loadOfficialAgents();
 
       expect(store.officialAgents.status).toBe('complete');
-      expect(store.officialAgents.data).toEqual(mockData.data);
-      expect(listOfficialAgentsSpy).toHaveBeenCalledWith({
-        search: 'Test Search',
+      expect(store.officialAgents.data).toEqual(mockResponse.agents);
+      expect(listOfficialAgents2Spy).toHaveBeenCalledWith({
+        name: 'Test Search',
+        category: '',
+        system: '',
       });
     });
 
     it('should handle errors when loading official agents', async () => {
       vi.spyOn(console, 'error').mockImplementation(() => {});
 
-      nexusaiAPI.router.agents_team.listOfficialAgents.mockRejectedValue(
+      nexusaiAPI.router.agents_team.listOfficialAgents2.mockRejectedValue(
         new Error('Error'),
       );
 
@@ -86,6 +93,8 @@ describe('AgentsTeamStore', () => {
       };
       const listMyAgentsSpy =
         nexusaiAPI.router.agents_team.listMyAgents.mockResolvedValue(mockData);
+
+      store.setAssignAgentsFilters({ search: 'Test Search' });
 
       await store.loadMyAgents({
         search: 'Test Search',

--- a/src/store/__tests__/Preview.unit.spec.js
+++ b/src/store/__tests__/Preview.unit.spec.js
@@ -169,6 +169,7 @@ describe('PreviewStore', () => {
         project: 'test-project-uuid',
         token: 'test-token',
         endpoint: 'preview',
+        path: 'test-project-uuid/simulation',
       });
 
       expect(mockWsInstance.connect).toHaveBeenCalled();

--- a/src/stubs/connectSharedStore.js
+++ b/src/stubs/connectSharedStore.js
@@ -1,0 +1,1 @@
+export const useSharedStore = () => null;

--- a/src/utils/__tests__/mapLegacyPersonality.spec.ts
+++ b/src/utils/__tests__/mapLegacyPersonality.spec.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { mapLegacyPersonality } from '@/utils/mapLegacyPersonality';
+
+describe('mapLegacyPersonality', () => {
+  describe('maps legacy values to new keys', () => {
+    const legacyMappings = [
+      { legacy: 'Amigável', expected: 'friendly' },
+      { legacy: 'Cooperativo', expected: 'friendly' },
+      { legacy: 'Generoso', expected: 'friendly' },
+      { legacy: 'Organizado', expected: 'systematic' },
+      { legacy: 'Sistemático', expected: 'systematic' },
+      { legacy: 'Intelectual', expected: 'analytical' },
+      { legacy: 'Criativo', expected: 'creative' },
+      { legacy: 'Inovador', expected: 'creative' },
+      { legacy: 'Extrovertido', expected: 'casual' },
+      { legacy: 'Relaxado', expected: 'casual' },
+    ];
+
+    legacyMappings.forEach(({ legacy, expected }) => {
+      it(`maps "${legacy}" to "${expected}"`, () => {
+        expect(mapLegacyPersonality(legacy)).toBe(expected);
+      });
+    });
+  });
+
+  describe('case-insensitive matching', () => {
+    it('maps uppercase input correctly', () => {
+      expect(mapLegacyPersonality('AMIGÁVEL')).toBe('friendly');
+    });
+
+    it('maps lowercase input correctly', () => {
+      expect(mapLegacyPersonality('amigável')).toBe('friendly');
+    });
+
+    it('maps mixed-case input correctly', () => {
+      expect(mapLegacyPersonality('sIsTemÁtIcO')).toBe('systematic');
+    });
+  });
+
+  describe('trims whitespace', () => {
+    it('handles leading and trailing spaces', () => {
+      expect(mapLegacyPersonality('  Criativo  ')).toBe('creative');
+    });
+  });
+
+  describe('passes through non-legacy values', () => {
+    const newKeys = [
+      'friendly',
+      'systematic',
+      'analytical',
+      'creative',
+      'casual',
+    ];
+
+    newKeys.forEach((key) => {
+      it(`passes through new key "${key}" unchanged`, () => {
+        expect(mapLegacyPersonality(key)).toBe(key);
+      });
+    });
+
+    it('passes through unknown strings unchanged', () => {
+      expect(mapLegacyPersonality('unknown-value')).toBe('unknown-value');
+    });
+  });
+
+  describe('handles falsy and empty values', () => {
+    it('returns empty string as-is', () => {
+      expect(mapLegacyPersonality('')).toBe('');
+    });
+  });
+});

--- a/src/utils/mapLegacyPersonality.ts
+++ b/src/utils/mapLegacyPersonality.ts
@@ -1,0 +1,17 @@
+const LEGACY_PERSONALITY_MAP: Record<string, string> = {
+  amigável: 'friendly',
+  cooperativo: 'friendly',
+  generoso: 'friendly',
+  organizado: 'systematic',
+  sistemático: 'systematic',
+  intelectual: 'analytical',
+  criativo: 'creative',
+  inovador: 'creative',
+  extrovertido: 'casual',
+  relaxado: 'casual',
+};
+
+export function mapLegacyPersonality(value: string): string {
+  if (!value) return value;
+  return LEGACY_PERSONALITY_MAP[value.toLowerCase().trim()] ?? value;
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -17,7 +17,12 @@ export default mergeConfig(
         reporter: ['text', 'json', 'html'],
         reportsDirectory: './coverage',
         include: ['src/**/*.{vue,js,ts}'],
-        exclude: ['src/main.js', 'src/bootstrap.js', '**/__tests__/**'],
+        exclude: [
+          'src/main.js',
+          'src/bootstrap.js',
+          'src/stubs/**',
+          '**/__tests__/**',
+        ],
         statements: 70,
         branches: 70,
         functions: 70,


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Agents saved before the tone-of-voice refactor may still have `agent.personality` as old Portuguese labels. The UI expects the five English keys (`friendly`, `systematic`, `analytical`, `creative`, `casual`), which led to poor UX (extra “unknown” radio). This change normalizes legacy values when profile data is loaded from the API.

### Summary of Changes
- Add `mapLegacyPersonality` in `src/utils/mapLegacyPersonality.ts` with a case-insensitive map from the 10 legacy Portuguese values to the five tone keys.
- Apply the mapper in `Profile` store `setInitialValues` so load/save responses both normalize `personality`.
- Add unit tests in `src/utils/__tests__/mapLegacyPersonality.spec.ts`.