### PR TITLE
[NEXUS-5127] - refactor: Rename MCP config to constants

### DIFF
--- a/src/api/nexus/AgentsTeam.js
+++ b/src/api/nexus/AgentsTeam.js
@@ -11,6 +11,13 @@ function filterSystems(systems) {
   );
 }
 
+function normalizeMCPs(MCPs = []) {
+  return MCPs.map(({ config, ...mcp }) => ({
+    ...mcp,
+    constants: config ?? [],
+  }));
+}
+
 export const AgentsTeam = {
   async listOfficialAgents({ category, system, name }) {
     const params = cleanParams({
@@ -28,6 +35,7 @@ export const AgentsTeam = {
       ...agent,
       id: agent.slug,
       systems: filterSystems(agent.systems),
+      MCPs: normalizeMCPs(agent.MCPs),
     }));
 
     return {
@@ -51,6 +59,7 @@ export const AgentsTeam = {
     return {
       ...data,
       systems: filterSystems(data.systems),
+      MCPs: normalizeMCPs(data.MCPs),
     };
   },
 
@@ -92,9 +101,8 @@ export const AgentsTeam = {
           description,
           skills,
           assigned,
-          credentials,
-          is_official,
           slug,
+          mcp_definitions,
         }) => ({
           uuid,
           name,
@@ -102,9 +110,10 @@ export const AgentsTeam = {
           description,
           skills,
           assigned,
-          credentials,
-          is_official,
+          credentials: mcp_definitions?.credentials ?? [],
+          is_official: false,
           id: slug,
+          constants: mcp_definitions?.config ?? [],
         }),
       ),
     };
@@ -150,12 +159,19 @@ export const AgentsTeam = {
     };
   },
 
-  async toggleAgentAssignment({ agentUuid, is_assigned }) {
+  async toggleAgentAssignment({
+    agentUuid,
+    is_assigned,
+    mcp_config,
+    credentials,
+  }) {
+    const body = { assigned: is_assigned };
+    if (mcp_config !== undefined) body.mcp_config = mcp_config;
+    if (credentials !== undefined) body.credentials = credentials;
+
     const { data } = await request.$http.patch(
       `api/project/${projectUuid.value}/assign/${agentUuid}`,
-      {
-        assigned: is_assigned,
-      },
+      body,
       {
         hideGenericErrorAlert: true,
       },

--- a/src/api/nexus/AgentsTeam.js
+++ b/src/api/nexus/AgentsTeam.js
@@ -159,19 +159,12 @@ export const AgentsTeam = {
     };
   },
 
-  async toggleAgentAssignment({
-    agentUuid,
-    is_assigned,
-    mcp_config,
-    credentials,
-  }) {
-    const body = { assigned: is_assigned };
-    if (mcp_config !== undefined) body.mcp_config = mcp_config;
-    if (credentials !== undefined) body.credentials = credentials;
-
+  async toggleAgentAssignment({ agentUuid, is_assigned }) {
     const { data } = await request.$http.patch(
       `api/project/${projectUuid.value}/assign/${agentUuid}`,
-      body,
+      {
+        assigned: is_assigned,
+      },
       {
         hideGenericErrorAlert: true,
       },

--- a/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
+++ b/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
@@ -115,9 +115,29 @@ describe('AgentsTeam API', () => {
           description: 'First personal agent',
           skills: ['custom-skill1'],
           assigned: true,
-          credentials: { type: 'custom' },
+          credentials: [{ name: 'ROOT_KEY', label: 'Should be ignored' }],
           is_official: false,
           slug: 'my-agent-1',
+          mcp_definitions: {
+            config: [
+              {
+                name: 'country',
+                label: 'Country',
+                type: 'TEXT',
+                is_required: true,
+                default_value: 'BRA',
+                options: [],
+              },
+            ],
+            credentials: [
+              {
+                name: 'BASE_URL',
+                label: 'Base URL',
+                placeholder: 'https://example.com',
+                is_confidential: false,
+              },
+            ],
+          },
         },
         {
           uuid: 'my-agent-uuid-2',
@@ -125,9 +145,13 @@ describe('AgentsTeam API', () => {
           description: 'Second personal agent',
           skills: ['custom-skill2', 'custom-skill3'],
           assigned: false,
-          credentials: { type: 'bearer' },
+          credentials: [],
           is_official: false,
           slug: 'my-agent-2',
+          mcp_definitions: {
+            config: [],
+            credentials: [],
+          },
         },
       ],
     };
@@ -152,9 +176,26 @@ describe('AgentsTeam API', () => {
         description: 'First personal agent',
         skills: ['custom-skill1'],
         assigned: true,
-        credentials: { type: 'custom' },
+        credentials: [
+          {
+            name: 'BASE_URL',
+            label: 'Base URL',
+            placeholder: 'https://example.com',
+            is_confidential: false,
+          },
+        ],
         is_official: false,
         id: 'my-agent-1',
+        constants: [
+          {
+            name: 'country',
+            label: 'Country',
+            type: 'TEXT',
+            is_required: true,
+            default_value: 'BRA',
+            options: [],
+          },
+        ],
       });
     });
 
@@ -189,10 +230,26 @@ describe('AgentsTeam API', () => {
         expect(agent.description).toBe(originalAgent.description);
         expect(agent.skills).toEqual(originalAgent.skills);
         expect(agent.assigned).toBe(originalAgent.assigned);
-        expect(agent.credentials).toEqual(originalAgent.credentials);
-        expect(agent.is_official).toBe(originalAgent.is_official);
+        expect(agent.credentials).toEqual(
+          originalAgent.mcp_definitions.credentials,
+        );
         expect(agent.id).toBe(originalAgent.slug);
       });
+    });
+
+    it('forces is_official to false even when the API returns true', async () => {
+      request.$http.get.mockResolvedValue({
+        data: [
+          {
+            ...mockMyAgentsResponse.data[0],
+            is_official: true,
+          },
+        ],
+      });
+
+      const result = await AgentsTeam.listMyAgents({});
+
+      expect(result.data[0].is_official).toBe(false);
     });
 
     it('should handle API error', async () => {

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/ConstantsForm.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/ConstantsForm.vue
@@ -1,20 +1,20 @@
 <template>
   <section class="modal-assign-agent__form">
     <template
-      v-for="element in config"
+      v-for="element in constants"
       :key="element.name"
     >
       <UnnnicSwitch
         v-if="element.type === 'SWITCH'"
-        data-testid="concierge-second-step-switch"
+        data-testid="constants-form-switch"
         :option="fieldLabel(element)"
-        :modelValue="configValues[element.name] ?? false"
+        :modelValue="constantsValues[element.name] ?? false"
         @update:model-value="updateFieldValue(element.name, $event)"
       />
 
       <UnnnicSelect
         v-else-if="element.type === 'SELECT'"
-        data-testid="concierge-second-step-select"
+        data-testid="constants-form-select"
         :label="fieldLabel(element)"
         :options="formatOptions(element.options)"
         :modelValue="getSelectModelValue(element)"
@@ -23,22 +23,22 @@
 
       <UnnnicInput
         v-else-if="['NUMBER', 'TEXT', 'INPUT'].includes(element.type)"
-        data-testid="concierge-second-step-input"
+        data-testid="constants-form-input"
         :label="fieldLabel(element)"
-        :modelValue="String(configValues[element.name] ?? '')"
+        :modelValue="String(constantsValues[element.name] ?? '')"
         :nativeType="element.type === 'NUMBER' ? 'number' : 'text'"
         @update:model-value="updateFieldValue(element.name, $event)"
       />
 
       <UnnnicCheckboxGroup
         v-else-if="element.type === 'CHECKBOX'"
-        data-testid="concierge-second-step-checkbox-group"
+        data-testid="constants-form-checkbox-group"
         :label="fieldLabel(element)"
       >
         <UnnnicCheckbox
           v-for="option in element.options"
           :key="option.value || option.name"
-          data-testid="concierge-second-step-checkbox"
+          data-testid="constants-form-checkbox"
           :label="option.name"
           :modelValue="isCheckboxChecked(element.name, option.value)"
           @update:model-value="
@@ -50,15 +50,15 @@
       <UnnnicRadioGroup
         v-else-if="element.type === 'RADIO'"
         state="vertical"
-        data-testid="concierge-second-step-radio-group"
+        data-testid="constants-form-radio-group"
         :label="fieldLabel(element)"
-        :modelValue="configValues[element.name]"
+        :modelValue="constantsValues[element.name]"
         @update:model-value="updateFieldValue(element.name, $event)"
       >
         <UnnnicRadio
           v-for="option in element.options"
           :key="option.value || option.name"
-          data-testid="concierge-second-step-radio"
+          data-testid="constants-form-radio"
           :label="option.name"
           :value="option.value || option.name"
         />
@@ -68,19 +68,19 @@
 </template>
 
 <script setup lang="ts">
-import { AgentMCP } from '@/store/types/Agents.types';
 import { watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-type MCPConfigField = AgentMCP['config'] extends (infer U)[] ? U : never;
-type MCPConfigValue = string | string[] | boolean;
+import { AgentConstantField } from '@/store/types/Agents.types';
+
+type ConstantValue = string | string[] | boolean;
 
 const props = defineProps<{
-  config: MCPConfigField[];
+  constants: AgentConstantField[];
 }>();
 
-const configValues = defineModel<Record<string, MCPConfigValue>>(
-  'configValues',
+const constantsValues = defineModel<Record<string, ConstantValue>>(
+  'constantsValues',
   {
     required: true,
   },
@@ -88,44 +88,44 @@ const configValues = defineModel<Record<string, MCPConfigValue>>(
 
 const { t } = useI18n();
 
-function fieldLabel(element: MCPConfigField) {
+function fieldLabel(element: AgentConstantField) {
   if (element.is_required) return element.label;
-  return `${element.label} (${t('agents.assign_agents.setup.mcp_config.optional')})`;
+  return `${element.label} (${t('agents.assign_agents.setup.constants.optional')})`;
 }
 
-function buildInitialValues(config: MCPConfigField[]) {
-  config.forEach((element) => {
+function buildInitialValues(constants: AgentConstantField[] = []) {
+  constants.forEach((element) => {
     if (element.default_value !== undefined) {
-      configValues.value[element.name] =
-        element.default_value as MCPConfigValue;
+      constantsValues.value[element.name] =
+        element.default_value as ConstantValue;
     }
   });
 }
 
 watch(
-  () => props.config,
+  () => props.constants,
   (newValue) => {
-    buildInitialValues(newValue);
+    buildInitialValues(newValue ?? []);
   },
   { immediate: true },
 );
 
-function updateFieldValue(name: string, value: MCPConfigValue) {
-  configValues.value = {
-    ...configValues.value,
+function updateFieldValue(name: string, value: ConstantValue) {
+  constantsValues.value = {
+    ...constantsValues.value,
     [name]: value,
   };
 }
 
-function formatOptions(options: MCPConfigField['options'] = []) {
+function formatOptions(options: AgentConstantField['options'] = []) {
   return options.map((option) => ({
     label: option.name,
     value: option.value || option.name,
   }));
 }
 
-function getSelectModelValue(field: MCPConfigField) {
-  const value = configValues.value[field.name];
+function getSelectModelValue(field: AgentConstantField) {
+  const value = constantsValues.value[field.name];
   if (typeof value === 'string') return value;
   const option = formatOptions(field.options).find(
     (option) => option.value === value,
@@ -134,13 +134,13 @@ function getSelectModelValue(field: MCPConfigField) {
 }
 
 function isCheckboxChecked(fieldName: string, optionValue: string) {
-  const value = configValues.value[fieldName];
+  const value = constantsValues.value[fieldName];
   if (!Array.isArray(value)) return false;
   return value.includes(optionValue);
 }
 
 function toggleCheckboxValue(fieldName: string, optionValue: string) {
-  const value = configValues.value[fieldName];
+  const value = constantsValues.value[fieldName];
   const nextValue = new Set(Array.isArray(value) ? value : []);
   if (nextValue.has(optionValue)) {
     nextValue.delete(optionValue);
@@ -150,3 +150,13 @@ function toggleCheckboxValue(fieldName: string, optionValue: string) {
   updateFieldValue(fieldName, Array.from(nextValue));
 }
 </script>
+
+<style scoped lang="scss">
+.modal-assign-agent__form {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-4;
+
+  width: 100%;
+}
+</style>

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/__tests__/index.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/__tests__/index.spec.js
@@ -4,10 +4,10 @@ import { shallowMount } from '@vue/test-utils';
 
 import MCPStepContent from '../index.vue';
 
-const mcpWithConfig = {
+const mcpWithConstants = {
   name: 'Search',
   description: 'Search products',
-  config: [
+  constants: [
     { name: 'apiKey', type: 'TEXT' },
     {
       name: 'region',
@@ -36,17 +36,16 @@ const mcpWithConfig = {
   ],
 };
 
-const mcpWithoutConfig = {
+const mcpWithoutConstants = {
   name: 'Inventory',
   description: 'Inventory manager',
-  config: [],
+  constants: [],
 };
 
-const MCPs = [mcpWithConfig, mcpWithoutConfig];
+const MCPs = [mcpWithConstants, mcpWithoutConstants];
 
 function getInitialValues() {
   return {
-    // Mocked fields and values
     apiKey: '',
     region: 'us',
     features: [],
@@ -56,7 +55,9 @@ function getInitialValues() {
 
 function createWrapper(overrides = {}) {
   const selectedMCP = ref(overrides.selectedMCP ?? null);
-  const selectedMCPConfigValues = ref(overrides.selectedMCPConfigValues ?? {});
+  const selectedMCPConstantsValues = ref(
+    overrides.selectedMCPConstantsValues ?? {},
+  );
   let wrapper;
 
   const updateSelectedMCP = (value) => {
@@ -66,11 +67,11 @@ function createWrapper(overrides = {}) {
     }
   };
 
-  const updateConfigValues = (value) => {
-    selectedMCPConfigValues.value = value;
+  const updateConstantsValues = (value) => {
+    selectedMCPConstantsValues.value = value;
     if (wrapper) {
       wrapper.setProps({
-        selectedMCPConfigValues: selectedMCPConfigValues.value,
+        selectedMCPConstantsValues: selectedMCPConstantsValues.value,
       });
     }
   };
@@ -80,16 +81,16 @@ function createWrapper(overrides = {}) {
       props: {
         MCPs,
         selectedMCP: selectedMCP.value,
-        selectedMCPConfigValues: selectedMCPConfigValues.value,
+        selectedMCPConstantsValues: selectedMCPConstantsValues.value,
         'onUpdate:selectedMCP': updateSelectedMCP,
-        'onUpdate:selectedMCPConfigValues': updateConfigValues,
+        'onUpdate:selectedMCPConstantsValues': updateConstantsValues,
         ...overrides,
       },
     });
 
     wrapper.setProps({
       selectedMCP: selectedMCP.value,
-      selectedMCPConfigValues: selectedMCPConfigValues.value,
+      selectedMCPConstantsValues: selectedMCPConstantsValues.value,
     });
 
     return wrapper;
@@ -98,20 +99,21 @@ function createWrapper(overrides = {}) {
   return {
     wrapper: mountComponent(),
     getSelectedMCP: () => selectedMCP.value,
-    getConfigValues: () => selectedMCPConfigValues.value,
+    getConstantsValues: () => selectedMCPConstantsValues.value,
     updateSelectedMCP,
-    updateConfigValues,
+    updateConstantsValues,
   };
 }
 
 describe('MCPStepContent', () => {
   let wrapper;
   let getSelectedMCP;
-  let getConfigValues;
+  let getConstantsValues;
 
   const mountWrapper = (overrides = {}) => {
     wrapper?.unmount();
-    ({ wrapper, getSelectedMCP, getConfigValues } = createWrapper(overrides));
+    ({ wrapper, getSelectedMCP, getConstantsValues } =
+      createWrapper(overrides));
   };
 
   beforeEach(() => {
@@ -125,8 +127,8 @@ describe('MCPStepContent', () => {
 
   const findPlaceholder = () =>
     wrapper.find('[data-testid="concierge-second-step-placeholder"]');
-  const findConfigForm = () =>
-    wrapper.find('[data-testid="concierge-second-step-config-form"]');
+  const findConstantsForm = () =>
+    wrapper.find('[data-testid="concierge-second-step-constants-form"]');
   const findConfigDescription = () =>
     wrapper.find('[data-testid="concierge-second-step-config-description"]');
   const findMCPSelection = () =>
@@ -137,77 +139,77 @@ describe('MCPStepContent', () => {
   describe('rendering', () => {
     it('auto-selects the first MCP when none is selected', () => {
       expect(findPlaceholder().exists()).toBe(false);
-      expect(getSelectedMCP()).toEqual(mcpWithConfig);
+      expect(getSelectedMCP()).toEqual(mcpWithConstants);
     });
 
-    it('shows config form when selected MCP has config', async () => {
+    it('shows constants form when selected MCP has constants', async () => {
       mountWrapper({
-        selectedMCP: mcpWithConfig,
-        selectedMCPConfigValues: getInitialValues(),
+        selectedMCP: mcpWithConstants,
+        selectedMCPConstantsValues: getInitialValues(),
       });
 
       await nextTick();
 
-      expect(findConfigForm().exists()).toBe(true);
+      expect(findConstantsForm().exists()).toBe(true);
       expect(findConfigDescription().exists()).toBe(false);
     });
 
-    it('shows description when selected MCP has no config', async () => {
+    it('shows description when selected MCP has no constants', async () => {
       mountWrapper({
-        selectedMCP: mcpWithoutConfig,
-        selectedMCPConfigValues: {},
+        selectedMCP: mcpWithoutConstants,
+        selectedMCPConstantsValues: {},
       });
 
       await nextTick();
 
       expect(findConfigDescription().exists()).toBe(true);
-      expect(findConfigForm().exists()).toBe(false);
+      expect(findConstantsForm().exists()).toBe(false);
     });
   });
 
   describe('selection handling', () => {
     it('selects MCP and builds initial values when emitted', async () => {
-      findMCPSelection().vm.$emit('select', mcpWithConfig, true);
+      findMCPSelection().vm.$emit('select', mcpWithConstants, true);
       await nextTick();
 
-      expect(getSelectedMCP()).toEqual(mcpWithConfig);
-      expect(getConfigValues()).toEqual(getInitialValues());
+      expect(getSelectedMCP()).toEqual(mcpWithConstants);
+      expect(getConstantsValues()).toEqual(getInitialValues());
     });
 
     it('ignores unchecked selection events', async () => {
       const mcpBeforeEvent = getSelectedMCP();
-      const configBeforeEvent = getConfigValues();
+      const constantsBeforeEvent = getConstantsValues();
 
-      findMCPSelection().vm.$emit('select', mcpWithoutConfig, false);
+      findMCPSelection().vm.$emit('select', mcpWithoutConstants, false);
       await nextTick();
 
       expect(getSelectedMCP()).toEqual(mcpBeforeEvent);
-      expect(getConfigValues()).toEqual(configBeforeEvent);
+      expect(getConstantsValues()).toEqual(constantsBeforeEvent);
     });
   });
 
-  describe('config values initialisation', () => {
-    it('builds values when selected MCP is provided without prior config', async () => {
+  describe('constants values initialisation', () => {
+    it('builds values when selected MCP is provided without prior constants', async () => {
       mountWrapper({
-        selectedMCP: mcpWithConfig,
-        selectedMCPConfigValues: {},
+        selectedMCP: mcpWithConstants,
+        selectedMCPConstantsValues: {},
       });
 
       await nextTick();
 
-      expect(getConfigValues()).toEqual(getInitialValues());
+      expect(getConstantsValues()).toEqual(getInitialValues());
     });
 
-    it('keeps values when config is already present', async () => {
+    it('keeps values when constants are already present', async () => {
       const presetValues = { apiKey: 'abc', region: 'br' };
       mountWrapper({
-        selectedMCP: mcpWithConfig,
-        selectedMCPConfigValues: presetValues,
+        selectedMCP: mcpWithConstants,
+        selectedMCPConstantsValues: presetValues,
       });
 
       await nextTick();
 
-      expect(getConfigValues()).toEqual(presetValues);
+      expect(getConstantsValues()).toEqual(presetValues);
     });
   });
 });

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/index.vue
@@ -1,6 +1,6 @@
 <template>
   <section
-    v-if="MCPs.length"
+    v-if="MCPs?.length"
     class="modal-assign-agent__content"
     data-testid="concierge-second-step"
   >
@@ -23,11 +23,11 @@
         }}
       </p>
 
-      <MCPConfigForm
-        v-if="selectedMCPConfig.length"
-        v-model:configValues="selectedMCPConfigValues"
-        :config="selectedMCPConfig"
-        data-testid="concierge-second-step-config-form"
+      <ConstantsForm
+        v-if="selectedMCPConstants.length"
+        v-model:constantsValues="selectedMCPConstantsValues"
+        :constants="selectedMCPConstants"
+        data-testid="concierge-second-step-constants-form"
       />
 
       <p
@@ -60,10 +60,10 @@
 <script setup lang="ts">
 import { computed, watch } from 'vue';
 import MCPSelection from './MCPSelection.vue';
-import MCPConfigForm from './MCPConfigForm.vue';
-import { AgentMCP } from '@/store/types/Agents.types';
-type MCPConfigField = AgentMCP['config'] extends (infer U)[] ? U : never;
-type MCPConfigValue = string | string[] | boolean;
+import ConstantsForm from '../ConstantsForm.vue';
+import { AgentConstantField, AgentMCP } from '@/store/types/Agents.types';
+
+type ConstantValue = string | string[] | boolean;
 
 defineOptions({
   name: 'MCPStepContent',
@@ -77,21 +77,21 @@ const props = defineProps<{
 const selectedMCP = defineModel<AgentMCP | null>('selectedMCP', {
   required: true,
 });
-const selectedMCPConfigValues = defineModel<Record<string, MCPConfigValue>>(
-  'selectedMCPConfigValues',
+const selectedMCPConstantsValues = defineModel<Record<string, ConstantValue>>(
+  'selectedMCPConstantsValues',
   {
     required: true,
     default: () => ({}),
   },
 );
-const selectedMCPConfig = computed<MCPConfigField[]>(() => {
-  return (selectedMCP.value?.config ?? []) as MCPConfigField[];
+const selectedMCPConstants = computed<AgentConstantField[]>(() => {
+  return selectedMCP.value?.constants ?? [];
 });
 
 watch(
   () => props.MCPs,
   (mcps) => {
-    if (mcps.length && !selectedMCP.value) {
+    if (mcps?.length && !selectedMCP.value) {
       handleSelectMCP(mcps[0], true);
     }
   },
@@ -102,10 +102,10 @@ watch(
   () => selectedMCP.value,
   (next) => {
     if (!next) return;
-    if (Object.keys(selectedMCPConfigValues.value || {}).length) {
+    if (Object.keys(selectedMCPConstantsValues.value || {}).length) {
       return;
     }
-    selectedMCPConfigValues.value = buildInitialValues(next.config);
+    selectedMCPConstantsValues.value = buildInitialValues(next.constants);
   },
   { immediate: true },
 );
@@ -113,25 +113,22 @@ watch(
 function handleSelectMCP(MCP: AgentMCP, checked: boolean) {
   if (!checked) return;
   selectedMCP.value = MCP;
-  selectedMCPConfigValues.value = buildInitialValues(MCP.config);
+  selectedMCPConstantsValues.value = buildInitialValues(MCP.constants);
 }
 
-function buildInitialValues(config: AgentMCP['config'] = []) {
-  return (config as MCPConfigField[]).reduce<Record<string, MCPConfigValue>>(
-    (acc, field) => {
-      if (field.type === 'CHECKBOX') {
-        acc[field.name] = [];
-        return acc;
-      }
-      if (field.type === 'SELECT' || field.type === 'RADIO') {
-        acc[field.name] = field.options?.[0]?.value ?? '';
-        return acc;
-      }
-      acc[field.name] = '';
+function buildInitialValues(constants: AgentConstantField[] = []) {
+  return constants.reduce<Record<string, ConstantValue>>((acc, field) => {
+    if (field.type === 'CHECKBOX') {
+      acc[field.name] = [];
       return acc;
-    },
-    {},
-  );
+    }
+    if (field.type === 'SELECT' || field.type === 'RADIO') {
+      acc[field.name] = field.options?.[0]?.value ?? '';
+      return acc;
+    }
+    acc[field.name] = '';
+    return acc;
+  }, {});
 }
 </script>
 
@@ -147,14 +144,6 @@ function buildInitialValues(config: AgentMCP['config'] = []) {
   & > :first-child {
     border-right: 1px solid $unnnic-color-border-soft;
   }
-}
-
-.modal-assign-agent__form {
-  display: flex;
-  flex-direction: column;
-  gap: $unnnic-space-4;
-
-  width: 100%;
 }
 
 .modal-assign-agent__config-placeholder,

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/ConstantsForm.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/ConstantsForm.spec.js
@@ -1,8 +1,8 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
 import { shallowMount } from '@vue/test-utils';
 
-import MCPConfigForm from '../MCPConfigForm.vue';
+import ConstantsForm from '../ConstantsForm.vue';
 
 vi.mock('vue-i18n', () => ({
   useI18n: () => ({
@@ -10,7 +10,7 @@ vi.mock('vue-i18n', () => ({
   }),
 }));
 
-const configFixture = [
+const constantsFixture = [
   {
     name: 'notifications',
     label: 'Notifications',
@@ -65,40 +65,40 @@ const configFixture = [
 ];
 
 function createWrapper(props = {}) {
-  let currentValues = props.configValues || {};
+  let currentValues = props.constantsValues || {};
   let wrapper;
 
   const mountWrapper = () => {
-    wrapper = shallowMount(MCPConfigForm, {
+    wrapper = shallowMount(ConstantsForm, {
       props: {
-        config: configFixture,
-        configValues: currentValues,
-        'onUpdate:configValues': (nextValues) => {
+        constants: constantsFixture,
+        constantsValues: currentValues,
+        'onUpdate:constantsValues': (nextValues) => {
           currentValues = nextValues;
           if (wrapper) {
-            wrapper.setProps({ configValues: currentValues });
+            wrapper.setProps({ constantsValues: currentValues });
           }
         },
         ...props,
       },
     });
 
-    wrapper.setProps({ configValues: currentValues });
+    wrapper.setProps({ constantsValues: currentValues });
     return wrapper;
   };
 
   return {
     wrapper: mountWrapper(),
-    getConfigValues: () => currentValues,
+    getConstantsValues: () => currentValues,
   };
 }
 
-describe('MCPConfigForm', () => {
+describe('ConstantsForm', () => {
   let wrapper;
-  let getConfigValues;
+  let getConstantsValues;
 
   beforeEach(() => {
-    ({ wrapper, getConfigValues } = createWrapper());
+    ({ wrapper, getConstantsValues } = createWrapper());
   });
 
   afterEach(() => {
@@ -106,10 +106,10 @@ describe('MCPConfigForm', () => {
     vi.clearAllMocks();
   });
 
-  it('initializes config values with defaults', async () => {
+  it('initializes constants values with defaults', async () => {
     await nextTick();
 
-    expect(getConfigValues()).toMatchObject({
+    expect(getConstantsValues()).toMatchObject({
       notifications: true,
       threshold: 5,
       notes: 'Initial note',
@@ -122,7 +122,7 @@ describe('MCPConfigForm', () => {
     switchComponent.vm.$emit('update:model-value', false);
     await nextTick();
 
-    expect(getConfigValues().notifications).toBe(false);
+    expect(getConstantsValues().notifications).toBe(false);
   });
 
   it('handles select changes and clears value when empty', async () => {
@@ -132,11 +132,11 @@ describe('MCPConfigForm', () => {
 
     selectComponent.vm.$emit('update:model-value', 'sms');
     await nextTick();
-    expect(getConfigValues().channel).toBe('sms');
+    expect(getConstantsValues().channel).toBe('sms');
 
     selectComponent.vm.$emit('update:model-value', '');
     await nextTick();
-    expect(getConfigValues().channel).toBe('');
+    expect(getConstantsValues().channel).toBe('');
   });
 
   it('updates text input values', async () => {
@@ -146,27 +146,27 @@ describe('MCPConfigForm', () => {
     textInput.vm.$emit('update:model-value', 'Updated note');
     await nextTick();
 
-    expect(getConfigValues().notes).toBe('Updated note');
+    expect(getConstantsValues().notes).toBe('Updated note');
   });
 
   it('toggles checkbox values', async () => {
     wrapper.vm.toggleCheckboxValue('features', 'feature-a');
     await nextTick();
-    expect(getConfigValues().features).toEqual(['feature-a']);
+    expect(getConstantsValues().features).toEqual(['feature-a']);
 
     wrapper.vm.toggleCheckboxValue('features', 'feature-b');
     await nextTick();
-    expect(getConfigValues().features).toEqual(['feature-a', 'feature-b']);
+    expect(getConstantsValues().features).toEqual(['feature-a', 'feature-b']);
 
     wrapper.vm.toggleCheckboxValue('features', 'feature-a');
     await nextTick();
-    expect(getConfigValues().features).toEqual(['feature-b']);
+    expect(getConstantsValues().features).toEqual(['feature-b']);
   });
 
   it('updates radio selection', async () => {
     wrapper.vm.updateFieldValue('mode', 'manual');
     await nextTick();
 
-    expect(getConfigValues().mode).toBe('manual');
+    expect(getConstantsValues().mode).toBe('manual');
   });
 });

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/McpSection.vue
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/McpSection.vue
@@ -49,7 +49,7 @@ import useTranslatedField from '@/composables/useTranslatedField';
 
 import type {
   AgentAssignedMCP,
-  AgentAssignedMCPConfigValue,
+  AgentAssignedConstantValue,
 } from '@/store/types/Agents.types';
 
 const props = defineProps<{
@@ -64,8 +64,8 @@ const mcpDescription = computed(
 );
 
 const mcpArguments = computed(() => {
-  const configEntries = props.mcp.config || {};
-  return Object.entries(configEntries)
+  const constantsEntries = props.mcp.constants || {};
+  return Object.entries(constantsEntries)
     .filter(([_label, value]) => !isValueEmpty(value))
     .map(([label, value]) => ({
       label,
@@ -73,11 +73,11 @@ const mcpArguments = computed(() => {
     }));
 });
 
-function isValueEmpty(value: AgentAssignedMCPConfigValue) {
+function isValueEmpty(value: AgentAssignedConstantValue) {
   return value === null || value === undefined || value === '';
 }
 
-function formatValue(value: AgentAssignedMCPConfigValue) {
+function formatValue(value: AgentAssignedConstantValue) {
   if (Array.isArray(value)) {
     return formatListToReadable(value);
   }

--- a/src/composables/useAgent.ts
+++ b/src/composables/useAgent.ts
@@ -23,7 +23,7 @@ export default function useAgent() {
         'mcp' in agent && agent.mcp
           ? {
               name: agent.mcp?.name || '',
-              config: agent.mcp?.config || {},
+              constants: agent.mcp?.constants || {},
               description:
                 'description' in agent.mcp ? agent.mcp?.description : null,
               system: getSystemObject(systemName),

--- a/src/composables/useOfficialAgentAssignment.ts
+++ b/src/composables/useOfficialAgentAssignment.ts
@@ -34,7 +34,7 @@ export default function useOfficialAgentAssignment(agent: Ref<AgentGroup>) {
   const translateField = useTranslatedField();
 
   const isSubmitting = ref(false);
-  const hasVTEXSystem = agent.value?.systems.some(
+  const hasVTEXSystem = agent.value?.systems?.some(
     (system) => system.toLowerCase() === 'vtex',
   );
 
@@ -106,10 +106,10 @@ export default function useOfficialAgentAssignment(agent: Ref<AgentGroup>) {
           payload,
         );
 
-      const mcpConfigWithLabels = Object.fromEntries(
+      const constantsWithLabels = Object.fromEntries(
         Object.entries(config.value.mcp_config).map(([key, value]) => {
           const label =
-            config.value.MCP?.config.find((config) => config.name === key)
+            config.value.MCP?.constants.find((field) => field.name === key)
               ?.label || key;
           return [label, value];
         }),
@@ -125,7 +125,7 @@ export default function useOfficialAgentAssignment(agent: Ref<AgentGroup>) {
         mcp: {
           name: config.value.MCP?.name || '',
           description: config.value.MCP?.description || '',
-          config: mcpConfigWithLabels,
+          constants: constantsWithLabels,
         },
       };
 

--- a/src/store/types/Agents.types.ts
+++ b/src/store/types/Agents.types.ts
@@ -31,7 +31,7 @@ export interface AgentCredential {
   is_confidential: boolean;
 }
 
-export type AgentAssignedMCPConfigValue =
+export type AgentAssignedConstantValue =
   | string
   | boolean
   | number
@@ -47,7 +47,7 @@ export interface AgentAssignedSystem {
 export interface AgentAssignedMCP {
   name: string;
   description: TranslatedField<string>;
-  config?: Record<string, AgentAssignedMCPConfigValue>;
+  constants?: Record<string, AgentAssignedConstantValue>;
   system?: AgentAssignedSystem;
 }
 
@@ -68,31 +68,33 @@ export type ConversationMessage = {
   text: string;
 };
 
+export interface AgentConstantField {
+  name: string;
+  label: string;
+  default_value: string | boolean | number;
+  is_required: boolean;
+  type:
+    | 'SELECT'
+    | 'INPUT'
+    | 'CHECKBOX'
+    | 'RADIO'
+    | 'SWITCH'
+    | 'NUMBER'
+    | 'TEXT';
+  options:
+    | {
+        name: string;
+        value: string;
+      }[]
+    | [];
+}
+
 export interface AgentMCP {
   name: string;
   description: TranslatedField<string>;
   system: string;
   credentials?: AgentCredential[];
-  config: {
-    name: string;
-    label: string;
-    default_value: string | boolean | number;
-    is_required: boolean;
-    type:
-      | 'SELECT'
-      | 'INPUT'
-      | 'CHECKBOX'
-      | 'RADIO'
-      | 'SWITCH'
-      | 'NUMBER'
-      | 'TEXT';
-    options:
-      | {
-          name: string;
-          value: string;
-        }[]
-      | [];
-  }[];
+  constants: AgentConstantField[];
 }
 
 export interface AgentGroup {
@@ -128,6 +130,7 @@ export interface Agent {
   is_official: boolean;
   project: string;
   credentials: AgentCredential[] | [];
+  constants?: AgentConstantField[];
   icon: string;
   group?: AgentGroup | null;
   mcp?: AgentAssignedMCP | null;


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Prepares the codebase for supporting custom agent assignment by introducing a unified "constants" concept.

### Summary of Changes
- **Types (`Agents.types.ts`):**
  - Renamed `AgentAssignedMCPConfigValue` → `AgentAssignedConstantValue`
  - Extracted `AgentConstantField` interface from `AgentMCP['config']`
  - Renamed `AgentMCP['config']` → `AgentMCP['constants']`
  - Renamed `AgentAssignedMCP['config']` → `AgentAssignedMCP['constants']`
  - Added optional `constants?: AgentConstantField[]` to `Agent` interface

- **API Layer (`AgentsTeam.js`):**
  - Added `normalizeMCPs` helper to transform `config` → `constants`
  - Updated `listOfficialAgents` and `getOfficialAgentDetails` to use the new naming

- **Components:**
  - Renamed `MCPConfigForm.vue` → `ConstantsForm.vue`
  - Updated all prop names from `config`/`configValues` → `constants`/`constantsValues`
  - Updated `MCPStepContent`, `McpSection`, and related components

- **Composables:**
  - Updated `useOfficialAgentAssignment` and `useAgent` to use `constants` naming

- **Tests:**
  - Updated all affected test files with new naming conventions