### PR TITLE
[NEXUS-5127] - feat: Custom agent modal assignment

### DIFF
--- a/src/api/nexus/AgentsTeam.js
+++ b/src/api/nexus/AgentsTeam.js
@@ -159,15 +159,9 @@ export const AgentsTeam = {
     };
   },
 
-  async toggleAgentAssignment({
-    agentUuid,
-    is_assigned,
-    mcp_config,
-    credentials,
-  }) {
+  async toggleAgentAssignment({ agentUuid, is_assigned, mcp_config }) {
     const body = { assigned: is_assigned };
     if (mcp_config !== undefined) body.mcp_config = mcp_config;
-    if (credentials !== undefined) body.credentials = credentials;
 
     const { data } = await request.$http.patch(
       `api/project/${projectUuid.value}/assign/${agentUuid}`,

--- a/src/api/nexus/AgentsTeam.js
+++ b/src/api/nexus/AgentsTeam.js
@@ -159,12 +159,19 @@ export const AgentsTeam = {
     };
   },
 
-  async toggleAgentAssignment({ agentUuid, is_assigned }) {
+  async toggleAgentAssignment({
+    agentUuid,
+    is_assigned,
+    mcp_config,
+    credentials,
+  }) {
+    const body = { assigned: is_assigned };
+    if (mcp_config !== undefined) body.mcp_config = mcp_config;
+    if (credentials !== undefined) body.credentials = credentials;
+
     const { data } = await request.$http.patch(
       `api/project/${projectUuid.value}/assign/${agentUuid}`,
-      {
-        assigned: is_assigned,
-      },
+      body,
       {
         hideGenericErrorAlert: true,
       },

--- a/src/components/AgentsTeam/AgentModalHeader.vue
+++ b/src/components/AgentsTeam/AgentModalHeader.vue
@@ -25,10 +25,10 @@
 
 <script setup lang="ts">
 import AgentIcon from '@/components/AgentsTeam/AgentIcon.vue';
-import { AgentGroup } from '@/store/types/Agents.types';
+import { Agent, AgentGroup } from '@/store/types/Agents.types';
 
 defineProps<{
-  agent: AgentGroup;
+  agent: AgentGroup | Agent;
 }>();
 </script>
 

--- a/src/components/AgentsTeam/AssignAgents/AssignAgentCard.vue
+++ b/src/components/AgentsTeam/AssignAgents/AssignAgentCard.vue
@@ -23,7 +23,7 @@
       >
         <UnnnicButton
           class="assign-agent-card__assign-button"
-          :text="assignButtonText"
+          :text="$t('agents.assign_agents.view_details')"
           :disabled="agent.assigned"
           :loading="isAssigning"
           @click="handleAssignButton"
@@ -67,15 +67,9 @@ const isAssigning = ref(false);
 const isModalAssignAgentOpen = ref(false);
 const isDeleteAgentModalOpen = ref(false);
 
-const assignButtonText = computed(() => {
-  return props.agent.presentation
-    ? i18n.global.t('agents.assign_agents.view_details')
-    : i18n.global.t('agents.assign_agents.assign_button');
-});
-
 const assignAgentHeaderActions = computed(() => [
   {
-    scheme: 'feedback-critical',
+    scheme: 'fg-critical',
     icon: 'delete',
     text: i18n.global.t('router.agents_team.card.delete_agent'),
     onClick: toggleDeleteAgentModal,

--- a/src/components/AgentsTeam/AssignAgents/AssignAgentCard.vue
+++ b/src/components/AgentsTeam/AssignAgents/AssignAgentCard.vue
@@ -32,13 +32,6 @@
     </template>
   </AgentCard>
 
-  <AssignAgentDrawer
-    v-model="isAssignDrawerOpen"
-    :agent="agent"
-    :isAssigning="isDrawerAssigning"
-    @assign="toggleDrawerAssigning"
-  />
-
   <ModalAssignAgentGroup
     v-model:open="isModalAssignAgentOpen"
     :agent="agent"
@@ -53,13 +46,9 @@
 <script setup>
 import { computed, ref } from 'vue';
 
-import { useAgentsTeamStore } from '@/store/AgentsTeam';
-import { useTuningsStore } from '@/store/Tunings';
-
 import useAgentSystems from '@/composables/useAgentSystems';
 
 import AgentCard from '../AgentCard.vue';
-import AssignAgentDrawer from '../AssignAgentDrawer.vue';
 import ModalAssignAgentGroup from './ModalAssignAgentGroup/index.vue';
 import DeleteAgentModal from '../DeleteAgentModal.vue';
 import ContentItemActions from '@/components/ContentItemActions.vue';
@@ -74,12 +63,7 @@ const props = defineProps({
   },
 });
 
-const agentsTeamStore = useAgentsTeamStore();
-const tuningsStore = useTuningsStore();
-
-const isAssignDrawerOpen = ref(false);
 const isAssigning = ref(false);
-const isDrawerAssigning = ref(false);
 const isModalAssignAgentOpen = ref(false);
 const isDeleteAgentModalOpen = ref(false);
 
@@ -91,7 +75,7 @@ const assignButtonText = computed(() => {
 
 const assignAgentHeaderActions = computed(() => [
   {
-    scheme: 'aux-red-500',
+    scheme: 'feedback-critical',
     icon: 'delete',
     text: i18n.global.t('router.agents_team.card.delete_agent'),
     onClick: toggleDeleteAgentModal,
@@ -102,51 +86,10 @@ async function toggleDeleteAgentModal() {
   isDeleteAgentModalOpen.value = !isDeleteAgentModalOpen.value;
 }
 
-async function toggleDrawer() {
-  isAssignDrawerOpen.value = !isAssignDrawerOpen.value;
-}
-
-async function assignAgent() {
-  isAssigning.value = true;
-
-  try {
-    const { status } = await agentsTeamStore.toggleAgentAssignment({
-      uuid: props.agent.uuid,
-      is_assigned: true,
-    });
-
-    if (status === 'success') {
-      if (props.agent.credentials?.length)
-        await tuningsStore.fetchCredentials();
-    }
-  } catch (error) {
-    console.error(error);
-  } finally {
-    isAssigning.value = false;
-  }
-}
-
 function handleAssignButton() {
   if (!props.agent.assigned) {
-    if (props.agent.presentation) {
-      isModalAssignAgentOpen.value = true;
-      return;
-    }
-
-    if (props.agent.credentials?.length > 0) {
-      toggleDrawer();
-      return;
-    }
+    isModalAssignAgentOpen.value = true;
   }
-
-  assignAgent();
-}
-
-async function toggleDrawerAssigning() {
-  isDrawerAssigning.value = true;
-  await assignAgent();
-  isDrawerAssigning.value = false;
-  toggleDrawer();
 }
 </script>
 

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/ConstantsStepContent.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/ConstantsStepContent.vue
@@ -4,23 +4,16 @@
     data-testid="constants-step"
   >
     <p class="modal-assign-agent__constants-step-title">
-      {{ $t('agents.assign_agents.setup.constants.title', { agent: agentName }) }}
+      {{
+        $t('agents.assign_agents.setup.constants.title', { agent: agentName })
+      }}
     </p>
 
     <ConstantsForm
-      v-if="constants?.length"
       v-model:constantsValues="constantsValues"
       :constants="constants"
       data-testid="constants-step-form"
     />
-
-    <p
-      v-else
-      class="modal-assign-agent__constants-step-empty"
-      data-testid="constants-step-empty"
-    >
-      {{ $t('agents.assign_agents.setup.constants.not_required') }}
-    </p>
   </section>
 </template>
 
@@ -62,11 +55,6 @@ const constantsValues = defineModel<Record<string, ConstantValue>>(
   &-title {
     color: $unnnic-color-fg-emphasized;
     font: $unnnic-font-display-3;
-  }
-
-  &-empty {
-    color: $unnnic-color-fg-base;
-    font: $unnnic-font-body;
   }
 }
 </style>

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/ConstantsStepContent.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/ConstantsStepContent.vue
@@ -1,0 +1,72 @@
+<template>
+  <section
+    class="modal-assign-agent__constants-step"
+    data-testid="constants-step"
+  >
+    <p class="modal-assign-agent__constants-step-title">
+      {{ $t('agents.assign_agents.setup.constants.title', { agent: agentName }) }}
+    </p>
+
+    <ConstantsForm
+      v-if="constants?.length"
+      v-model:constantsValues="constantsValues"
+      :constants="constants"
+      data-testid="constants-step-form"
+    />
+
+    <p
+      v-else
+      class="modal-assign-agent__constants-step-empty"
+      data-testid="constants-step-empty"
+    >
+      {{ $t('agents.assign_agents.setup.constants.not_required') }}
+    </p>
+  </section>
+</template>
+
+<script setup lang="ts">
+import ConstantsForm from './ConstantsForm.vue';
+
+import { AgentConstantField } from '@/store/types/Agents.types';
+
+type ConstantValue = string | string[] | boolean;
+
+defineOptions({
+  name: 'ConstantsStepContent',
+});
+
+defineProps<{
+  agentName: string;
+  constants: AgentConstantField[];
+}>();
+
+const constantsValues = defineModel<Record<string, ConstantValue>>(
+  'constantsValues',
+  {
+    required: true,
+    default: () => ({}),
+  },
+);
+</script>
+
+<style scoped lang="scss">
+.modal-assign-agent__constants-step {
+  overflow: auto;
+
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-4;
+
+  padding: $unnnic-space-6;
+
+  &-title {
+    color: $unnnic-color-fg-emphasized;
+    font: $unnnic-font-display-3;
+  }
+
+  &-empty {
+    color: $unnnic-color-fg-base;
+    font: $unnnic-font-body;
+  }
+}
+</style>

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/CustomCredentialsStepContent.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/CustomCredentialsStepContent.vue
@@ -1,0 +1,55 @@
+<template>
+  <section
+    class="modal-assign-agent__custom-credentials-step"
+    data-testid="custom-credentials-step"
+  >
+    <p class="modal-assign-agent__custom-credentials-step-title">
+      {{ $t('agents.assign_agents.setup.custom_credentials.title') }}
+    </p>
+
+    <Credentials
+      v-model:credentialValues="credentialValues"
+      :credentials="credentials"
+      data-testid="custom-credentials-step-credentials"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import Credentials from './CredentialsStepContent/Credentials.vue';
+
+import { AgentCredential } from '@/store/types/Agents.types';
+
+defineOptions({
+  name: 'CustomCredentialsStepContent',
+});
+
+defineProps<{
+  credentials: AgentCredential[];
+}>();
+
+const credentialValues = defineModel<Record<string, string>>(
+  'credentialValues',
+  {
+    required: true,
+    default: () => ({}),
+  },
+);
+</script>
+
+<style scoped lang="scss">
+.modal-assign-agent__custom-credentials-step {
+  overflow: auto;
+
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-4;
+
+  padding: $unnnic-space-6;
+
+  &-title {
+    color: $unnnic-color-fg-emphasized;
+    font: $unnnic-font-display-3;
+  }
+}
+</style>

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/About.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/About.vue
@@ -52,9 +52,9 @@ import { computed } from 'vue';
 import Skill from '@/components/AgentsTeam/Skill.vue';
 import useAgentSystems from '@/composables/useAgentSystems';
 import useTranslatedField from '@/composables/useTranslatedField';
-import type { AgentGroup } from '@/store/types/Agents.types';
+import type { Agent, AgentGroup } from '@/store/types/Agents.types';
 
-const GROUP_DOCS = {
+const GROUP_DOCS: Record<string, string> = {
   ORDER_PAYMENT: '/docs/Payment_Agent.pdf',
   FEEDBACK: '/docs/Feedback_Recorder.pdf',
   ORDER_CANCELLATION: '/docs/Order_Cancellation_Agent.pdf',
@@ -64,7 +64,7 @@ const GROUP_DOCS = {
 };
 
 const props = defineProps<{
-  agent: AgentGroup;
+  agent: AgentGroup | Agent;
 }>();
 
 type SystemBadge = {
@@ -75,17 +75,19 @@ type SystemBadge = {
 const { getSystemsObjects } = useAgentSystems();
 const translateField = useTranslatedField();
 
-const documentationUrl = computed(
-  () => GROUP_DOCS[props.agent.group.toUpperCase()] ?? null,
-);
+const documentationUrl = computed(() => {
+  const group = (props.agent as AgentGroup).group;
+  if (!group) return null;
+  return GROUP_DOCS[group.toUpperCase()] ?? null;
+});
 
-const aboutDescription = computed(
-  () =>
-    translateField(props.agent.presentation?.about) ?? props.agent.description,
-);
+const aboutDescription = computed(() => {
+  const presentationAbout = (props.agent as AgentGroup).presentation?.about;
+  return translateField(presentationAbout) ?? props.agent.description;
+});
 
 const systemBadges = computed<SystemBadge[]>(() => {
-  const agentSystems = props.agent?.systems ?? [];
+  const agentSystems = (props.agent as AgentGroup).systems ?? [];
   const systems = getSystemsObjects(agentSystems) || [];
 
   return systems.map((system) => ({

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/index.vue
@@ -3,6 +3,10 @@
     :class="[
       'modal-assign-agent__start-setup',
       { 'modal-assign-agent__start-setup--loading': isLoading },
+      {
+        'modal-assign-agent__start-setup--with-conversation':
+          conversationExample.length,
+      },
     ]"
     data-testid="start-setup"
   >
@@ -14,12 +18,13 @@
       />
 
       <MCPs
-        v-if="agent.MCPs?.length"
-        :mcps="agent.MCPs || []"
+        v-if="agentMCPs.length"
+        :mcps="agentMCPs"
         data-testid="start-setup-mcps-section"
       />
 
       <ConversationExample
+        v-if="conversationExample.length"
         :conversationExample="conversationExample"
         :agentName="agent.name"
         data-testid="start-setup-conversation-section"
@@ -31,7 +36,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
-import type { AgentGroup } from '@/store/types/Agents.types';
+import type { Agent, AgentGroup } from '@/store/types/Agents.types';
 import useTranslatedField from '@/composables/useTranslatedField';
 
 import About from './About.vue';
@@ -41,7 +46,7 @@ import StartSetupSkeleton from './StartSetupSkeleton.vue';
 
 const props = withDefaults(
   defineProps<{
-    agent: AgentGroup;
+    agent: AgentGroup | Agent;
     isLoading?: boolean;
   }>(),
   {
@@ -51,9 +56,12 @@ const props = withDefaults(
 
 const translateField = useTranslatedField();
 
-const conversationExample = computed(
-  () => translateField(props.agent.presentation?.conversation_example) ?? [],
-);
+const conversationExample = computed(() => {
+  const presentation = (props.agent as AgentGroup).presentation;
+  return translateField(presentation?.conversation_example) ?? [];
+});
+
+const agentMCPs = computed(() => (props.agent as AgentGroup).MCPs ?? []);
 </script>
 
 <style lang="scss" scoped>
@@ -63,9 +71,12 @@ const conversationExample = computed(
   padding: $unnnic-space-6;
 
   display: grid;
-  grid-template-columns: 4fr 3fr;
-  grid-template-rows: auto 1fr;
   gap: $unnnic-space-4;
+
+  &--with-conversation {
+    grid-template-columns: 4fr 3fr;
+    grid-template-rows: auto 1fr;
+  }
 
   &--loading {
     grid-template-columns: 1fr;

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/ConstantsStepContent.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/ConstantsStepContent.spec.js
@@ -38,23 +38,13 @@ describe('ConstantsStepContent', () => {
 
   const findRoot = () => wrapper.find('[data-testid="constants-step"]');
   const findForm = () => wrapper.find('[data-testid="constants-step-form"]');
-  const findEmpty = () => wrapper.find('[data-testid="constants-step-empty"]');
 
   it('renders root section', () => {
     expect(findRoot().exists()).toBe(true);
   });
 
-  it('renders form when there are constants', () => {
+  it('renders form', () => {
     expect(findForm().exists()).toBe(true);
-    expect(findEmpty().exists()).toBe(false);
-  });
-
-  it('renders empty state when there are no constants', () => {
-    wrapper.unmount();
-    wrapper = createWrapper({ constants: [] });
-
-    expect(findEmpty().exists()).toBe(true);
-    expect(findForm().exists()).toBe(false);
   });
 
   it('passes agent name to title key', () => {

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/ConstantsStepContent.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/ConstantsStepContent.spec.js
@@ -1,0 +1,76 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+import ConstantsStepContent from '../ConstantsStepContent.vue';
+
+const constantsFixture = [
+  {
+    name: 'country',
+    label: 'Country',
+    type: 'TEXT',
+    is_required: true,
+    default_value: 'BRA',
+  },
+];
+
+function createWrapper(props = {}) {
+  return shallowMount(ConstantsStepContent, {
+    props: {
+      agentName: 'Custom Agent',
+      constants: constantsFixture,
+      constantsValues: {},
+      ...props,
+    },
+  });
+}
+
+describe('ConstantsStepContent', () => {
+  let wrapper;
+
+  beforeEach(() => {
+    wrapper = createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  const findRoot = () => wrapper.find('[data-testid="constants-step"]');
+  const findForm = () => wrapper.find('[data-testid="constants-step-form"]');
+  const findEmpty = () => wrapper.find('[data-testid="constants-step-empty"]');
+
+  it('renders root section', () => {
+    expect(findRoot().exists()).toBe(true);
+  });
+
+  it('renders form when there are constants', () => {
+    expect(findForm().exists()).toBe(true);
+    expect(findEmpty().exists()).toBe(false);
+  });
+
+  it('renders empty state when there are no constants', () => {
+    wrapper.unmount();
+    wrapper = createWrapper({ constants: [] });
+
+    expect(findEmpty().exists()).toBe(true);
+    expect(findForm().exists()).toBe(false);
+  });
+
+  it('passes agent name to title key', () => {
+    const title = findRoot().find('p');
+    expect(title.text()).toContain('Custom Agent');
+  });
+
+  it('forwards constants and updates back to v-model', async () => {
+    const formComponent = wrapper.findComponent({ name: 'ConstantsForm' });
+    expect(formComponent.props('constants')).toEqual(constantsFixture);
+
+    formComponent.vm.$emit('update:constantsValues', { country: 'BRA' });
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('update:constantsValues')).toEqual([
+      [{ country: 'BRA' }],
+    ]);
+  });
+});

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/index.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/index.spec.js
@@ -25,7 +25,15 @@ const officialAgentFixture = {
   name: 'Concierge',
   is_official: true,
   systems: ['VTEX', 'SYNERISE'],
-  MCPs: [],
+  MCPs: [
+    {
+      name: 'VTEX MCP',
+      description: 'VTEX integration',
+      system: 'VTEX',
+      credentials: [{ name: 'token', label: 'API Token' }],
+      constants: [],
+    },
+  ],
   agents: [
     {
       uuid: 'variant-vtex',
@@ -35,6 +43,16 @@ const officialAgentFixture = {
   ],
 };
 
+const officialAgentWithoutMCPsFixture = {
+  uuid: 'official-no-mcps',
+  name: 'Debug Reverse Agent',
+  is_official: true,
+  group: null,
+  systems: [],
+  MCPs: [],
+  credentials: [{ name: 'token', label: 'Token Aftersale API' }],
+};
+
 const customAgentFixture = {
   uuid: 'custom-agent-uuid',
   name: 'Custom Agent',
@@ -42,6 +60,24 @@ const customAgentFixture = {
   constants: [
     { name: 'country', label: 'Country', type: 'TEXT', is_required: true },
   ],
+  credentials: [{ name: 'api_key', label: 'API Key' }],
+};
+
+const customAgentOnlyConstantsFixture = {
+  uuid: 'custom-agent-only-constants',
+  name: 'Constants Only Agent',
+  is_official: false,
+  constants: [
+    { name: 'country', label: 'Country', type: 'TEXT', is_required: true },
+  ],
+  credentials: [],
+};
+
+const customAgentOnlyCredentialsFixture = {
+  uuid: 'custom-agent-only-credentials',
+  name: 'Credentials Only Agent',
+  is_official: false,
+  constants: [],
   credentials: [{ name: 'api_key', label: 'API Key' }],
 };
 
@@ -56,6 +92,14 @@ const createOfficialAssignmentState = () => ({
   resetAssignment: vi.fn(),
   submitAssignment: vi.fn().mockResolvedValue(true),
 });
+
+const mockMCPWithCredentials = {
+  name: 'VTEX MCP',
+  description: 'VTEX integration',
+  system: 'VTEX',
+  credentials: [{ name: 'token', label: 'API Token' }],
+  constants: [],
+};
 
 const createCustomAssignmentState = () => ({
   config: ref({
@@ -99,8 +143,8 @@ describe('ModalAssignAgentGroupFlow - official agent', () => {
     await findNextButton().trigger('click');
     await flushPromises();
 
-    assignmentState.config.value.MCP = { name: 'Mock MCP' };
-    assignmentState.config.value.mcp_config = { apiKey: 'value' };
+    assignmentState.config.value.MCP = mockMCPWithCredentials;
+    assignmentState.config.value.mcp_config = {};
     assignmentState.config.value.credentials = { token: 'secret' };
     await nextTick();
 
@@ -165,11 +209,20 @@ describe('ModalAssignAgentGroupFlow - official agent', () => {
     it('does not submit the assignment if the final step is not completed', async () => {
       await advanceToStepThree();
 
-      assignmentState.config.value.credentials = { token: '' };
+      assignmentState.config.value.credentials = {};
       await nextTick();
 
       expect(findNextButton().attributes('disabled')).toBeDefined();
       expect(assignmentState.submitAssignment).not.toHaveBeenCalled();
+    });
+
+    it('disables next button when credentials are empty object', async () => {
+      await advanceToStepThree();
+
+      assignmentState.config.value.credentials = {};
+      await nextTick();
+
+      expect(findNextButton().attributes('disabled')).toBeDefined();
     });
 
     it('does not submit the assignment if the isSubmitting is true', async () => {
@@ -217,8 +270,8 @@ describe('ModalAssignAgentGroupFlow - official agent', () => {
 
       expect(wrapper.vm.stepIndex).toBe(2);
 
-      assignmentState.config.value.MCP = { name: 'Mock MCP' };
-      assignmentState.config.value.mcp_config = { apiKey: 'value' };
+      assignmentState.config.value.MCP = mockMCPWithCredentials;
+      assignmentState.config.value.mcp_config = {};
       await nextTick();
 
       await findNextButton().trigger('click');
@@ -264,7 +317,7 @@ describe('ModalAssignAgentGroupFlow - official agent', () => {
   });
 });
 
-describe('ModalAssignAgentGroupFlow - custom agent', () => {
+describe('ModalAssignAgentGroupFlow - custom agent with both constants and credentials', () => {
   let wrapper;
   let assignmentState;
 
@@ -311,7 +364,7 @@ describe('ModalAssignAgentGroupFlow - custom agent', () => {
     );
   });
 
-  it('uses 2 steps for custom agents', () => {
+  it('uses 2 steps for custom agents with both constants and credentials', () => {
     expect(wrapper.vm.totalSteps).toBe(2);
   });
 
@@ -346,5 +399,188 @@ describe('ModalAssignAgentGroupFlow - custom agent', () => {
 
     expect(assignmentState.submitAssignment).toHaveBeenCalledTimes(1);
     expect(wrapper.emitted('update:open')).toEqual([[false]]);
+  });
+});
+
+describe('ModalAssignAgentGroupFlow - custom agent with only constants', () => {
+  let wrapper;
+  let assignmentState;
+
+  const createWrapper = () => {
+    assignmentState = createCustomAssignmentState();
+    useCustomAgentAssignmentMock.mockReturnValue(assignmentState);
+
+    wrapper = shallowMount(ModalAssignAgentGroupFlow, {
+      props: {
+        agent: customAgentOnlyConstantsFixture,
+        open: true,
+      },
+    });
+  };
+
+  const constantsStep = () =>
+    wrapper.findComponent({ name: 'ConstantsStepContent' });
+  const customCredentialsStep = () =>
+    wrapper.findComponent({ name: 'CustomCredentialsStepContent' });
+  const findNextButton = () =>
+    wrapper.find('[data-testid="modal-concierge-right-button"]');
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('uses 1 step when agent has only constants', () => {
+    expect(wrapper.vm.totalSteps).toBe(1);
+  });
+
+  it('renders constants step and skips credentials step', () => {
+    expect(constantsStep().exists()).toBe(true);
+    expect(customCredentialsStep().exists()).toBe(false);
+  });
+
+  it('submits directly after filling constants', async () => {
+    assignmentState.config.value.constants = { country: 'BRA' };
+    await nextTick();
+
+    await findNextButton().trigger('click');
+    await flushPromises();
+
+    expect(assignmentState.submitAssignment).toHaveBeenCalledTimes(1);
+    expect(wrapper.emitted('update:open')).toEqual([[false]]);
+  });
+});
+
+describe('ModalAssignAgentGroupFlow - custom agent with only credentials', () => {
+  let wrapper;
+  let assignmentState;
+
+  const createWrapper = () => {
+    assignmentState = createCustomAssignmentState();
+    useCustomAgentAssignmentMock.mockReturnValue(assignmentState);
+
+    wrapper = shallowMount(ModalAssignAgentGroupFlow, {
+      props: {
+        agent: customAgentOnlyCredentialsFixture,
+        open: true,
+      },
+    });
+  };
+
+  const constantsStep = () =>
+    wrapper.findComponent({ name: 'ConstantsStepContent' });
+  const customCredentialsStep = () =>
+    wrapper.findComponent({ name: 'CustomCredentialsStepContent' });
+  const findNextButton = () =>
+    wrapper.find('[data-testid="modal-concierge-right-button"]');
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('uses 1 step when agent has only credentials', () => {
+    expect(wrapper.vm.totalSteps).toBe(1);
+  });
+
+  it('renders credentials step directly and skips constants step', () => {
+    expect(customCredentialsStep().exists()).toBe(true);
+    expect(constantsStep().exists()).toBe(false);
+  });
+
+  it('submits directly after filling credentials', async () => {
+    assignmentState.config.value.credentials = { api_key: 'token' };
+    await nextTick();
+
+    await findNextButton().trigger('click');
+    await flushPromises();
+
+    expect(assignmentState.submitAssignment).toHaveBeenCalledTimes(1);
+    expect(wrapper.emitted('update:open')).toEqual([[false]]);
+  });
+
+  it('disables next button when credentials are empty', () => {
+    expect(findNextButton().attributes('disabled')).toBeDefined();
+  });
+
+  it('disables next button when credentials object is empty', async () => {
+    assignmentState.config.value.credentials = {};
+    await nextTick();
+
+    expect(findNextButton().attributes('disabled')).toBeDefined();
+  });
+});
+
+describe('ModalAssignAgentGroupFlow - official agent without MCPs', () => {
+  let wrapper;
+  let assignmentState;
+
+  const createWrapper = () => {
+    assignmentState = createCustomAssignmentState();
+    useCustomAgentAssignmentMock.mockReturnValue(assignmentState);
+
+    wrapper = shallowMount(ModalAssignAgentGroupFlow, {
+      props: {
+        agent: officialAgentWithoutMCPsFixture,
+        open: true,
+      },
+    });
+  };
+
+  const constantsStep = () =>
+    wrapper.findComponent({ name: 'ConstantsStepContent' });
+  const customCredentialsStep = () =>
+    wrapper.findComponent({ name: 'CustomCredentialsStepContent' });
+  const mcpStep = () => wrapper.findComponent({ name: 'MCPStepContent' });
+  const findNextButton = () =>
+    wrapper.find('[data-testid="modal-concierge-right-button"]');
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('uses simple flow (no MCP step) for official agent without MCPs', () => {
+    expect(mcpStep().exists()).toBe(false);
+  });
+
+  it('uses 1 step when official agent has only credentials', () => {
+    expect(wrapper.vm.totalSteps).toBe(1);
+  });
+
+  it('renders credentials step directly', () => {
+    expect(customCredentialsStep().exists()).toBe(true);
+    expect(constantsStep().exists()).toBe(false);
+  });
+
+  it('uses customAssignment composable instead of officialAssignment', () => {
+    expect(useCustomAgentAssignmentMock).toHaveBeenCalled();
+  });
+
+  it('submits directly after filling credentials', async () => {
+    assignmentState.config.value.credentials = { token: 'secret' };
+    await nextTick();
+
+    await findNextButton().trigger('click');
+    await flushPromises();
+
+    expect(assignmentState.submitAssignment).toHaveBeenCalledTimes(1);
+    expect(wrapper.emitted('update:open')).toEqual([[false]]);
+  });
+
+  it('disables next button when credentials are empty', () => {
+    expect(findNextButton().attributes('disabled')).toBeDefined();
   });
 });

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/index.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/index.spec.js
@@ -11,13 +11,19 @@ vi.mock('vue-i18n', () => ({
 }));
 
 const useOfficialAgentAssignmentMock = vi.hoisted(() => vi.fn());
+const useCustomAgentAssignmentMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/composables/useOfficialAgentAssignment', () => ({
   default: (...args) => useOfficialAgentAssignmentMock(...args),
 }));
 
-const agentFixture = {
+vi.mock('@/composables/useCustomAgentAssignment', () => ({
+  default: (...args) => useCustomAgentAssignmentMock(...args),
+}));
+
+const officialAgentFixture = {
   name: 'Concierge',
+  is_official: true,
   systems: ['VTEX', 'SYNERISE'],
   MCPs: [],
   agents: [
@@ -29,7 +35,17 @@ const agentFixture = {
   ],
 };
 
-const createAssignmentState = () => ({
+const customAgentFixture = {
+  uuid: 'custom-agent-uuid',
+  name: 'Custom Agent',
+  is_official: false,
+  constants: [
+    { name: 'country', label: 'Country', type: 'TEXT', is_required: true },
+  ],
+  credentials: [{ name: 'api_key', label: 'API Key' }],
+};
+
+const createOfficialAssignmentState = () => ({
   config: ref({
     system: 'VTEX',
     MCP: null,
@@ -41,17 +57,27 @@ const createAssignmentState = () => ({
   submitAssignment: vi.fn().mockResolvedValue(true),
 });
 
-describe('ModalAssignAgentGroupFlow', () => {
+const createCustomAssignmentState = () => ({
+  config: ref({
+    constants: {},
+    credentials: {},
+  }),
+  isSubmitting: ref(false),
+  resetAssignment: vi.fn(),
+  submitAssignment: vi.fn().mockResolvedValue(true),
+});
+
+describe('ModalAssignAgentGroupFlow - official agent', () => {
   let wrapper;
   let assignmentState;
 
   const createWrapper = (props = {}) => {
-    assignmentState = createAssignmentState();
+    assignmentState = createOfficialAssignmentState();
     useOfficialAgentAssignmentMock.mockReturnValue(assignmentState);
 
     wrapper = shallowMount(ModalAssignAgentGroupFlow, {
       props: {
-        agent: agentFixture,
+        agent: officialAgentFixture,
         open: true,
         ...props,
       },
@@ -235,5 +261,90 @@ describe('ModalAssignAgentGroupFlow', () => {
         'agents.assign_agents.setup.finish_button',
       );
     });
+  });
+});
+
+describe('ModalAssignAgentGroupFlow - custom agent', () => {
+  let wrapper;
+  let assignmentState;
+
+  const createWrapper = (props = {}) => {
+    assignmentState = createCustomAssignmentState();
+    useCustomAgentAssignmentMock.mockReturnValue(assignmentState);
+
+    wrapper = shallowMount(ModalAssignAgentGroupFlow, {
+      props: {
+        agent: customAgentFixture,
+        open: true,
+        ...props,
+      },
+    });
+  };
+
+  const constantsStep = () =>
+    wrapper.findComponent({ name: 'ConstantsStepContent' });
+  const customCredentialsStep = () =>
+    wrapper.findComponent({ name: 'CustomCredentialsStepContent' });
+  const findNextButton = () =>
+    wrapper.find('[data-testid="modal-concierge-right-button"]');
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('renders the constants step first', () => {
+    expect(constantsStep().exists()).toBe(true);
+    expect(customCredentialsStep().exists()).toBe(false);
+  });
+
+  it('does not render official-only steps', () => {
+    expect(wrapper.findComponent({ name: 'SystemStepContent' }).exists()).toBe(
+      false,
+    );
+    expect(wrapper.findComponent({ name: 'MCPStepContent' }).exists()).toBe(
+      false,
+    );
+  });
+
+  it('uses 2 steps for custom agents', () => {
+    expect(wrapper.vm.totalSteps).toBe(2);
+  });
+
+  it('disables next when required constant is missing', () => {
+    expect(findNextButton().attributes('disabled')).toBeDefined();
+  });
+
+  it('advances to credentials step when constants are filled', async () => {
+    assignmentState.config.value.constants = { country: 'BRA' };
+    await nextTick();
+
+    expect(findNextButton().attributes('disabled')).toBe('false');
+
+    await findNextButton().trigger('click');
+    await flushPromises();
+
+    expect(customCredentialsStep().exists()).toBe(true);
+    expect(constantsStep().exists()).toBe(false);
+  });
+
+  it('submits the assignment on the credentials step', async () => {
+    assignmentState.config.value.constants = { country: 'BRA' };
+    await nextTick();
+    await findNextButton().trigger('click');
+    await flushPromises();
+
+    assignmentState.config.value.credentials = { api_key: 'token' };
+    await nextTick();
+
+    await findNextButton().trigger('click');
+    await flushPromises();
+
+    expect(assignmentState.submitAssignment).toHaveBeenCalledTimes(1);
+    expect(wrapper.emitted('update:open')).toEqual([[false]]);
   });
 });

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
@@ -39,21 +39,24 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, toRef, type Component } from 'vue';
+import { computed, ref, toRef, type Component, type Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import {
   Agent,
   AgentConstantField,
+  AgentCredential,
   AgentGroup,
   AgentMCP,
 } from '@/store/types/Agents.types';
 
 import useOfficialAgentAssignment, {
+  type ConciergeAssignmentConfig,
   type MCPConfigValues,
 } from '@/composables/useOfficialAgentAssignment';
 import useCustomAgentAssignment, {
   type ConstantsValues,
+  type CustomAssignmentConfig,
 } from '@/composables/useCustomAgentAssignment';
 
 import SystemStepContent from './SystemStepContent.vue';
@@ -87,38 +90,43 @@ const stepIndex = ref<number>(1);
 const resolvedAgentDetails = computed(() => props.agentDetails ?? props.agent);
 const isOfficial = computed(() => Boolean(props.agent?.is_official));
 
+const officialAgent = computed(() => props.agent as AgentGroup);
+const customAgent = computed(() => props.agent as Agent);
+
 const hasSystems = computed(() => {
   if (!isOfficial.value) return false;
-  const systems = (resolvedAgentDetails.value as AgentGroup)?.systems;
+  const systems =
+    (resolvedAgentDetails.value as AgentGroup)?.systems ??
+    officialAgent.value.systems;
   return Array.isArray(systems) && systems.length > 0;
 });
 
+const hasMCPs =
+  isOfficial.value &&
+  Array.isArray(officialAgent.value.MCPs) &&
+  officialAgent.value.MCPs.length > 0;
+
 const stepSequence = computed<StepKey[]>(() => {
-  if (!isOfficial.value) {
-    return [Step.Constants, Step.CustomCredentials];
+  if (hasMCPs) {
+    return hasSystems.value
+      ? [Step.System, Step.MCP, Step.Credentials]
+      : [Step.MCP, Step.Credentials];
   }
-  return hasSystems.value
-    ? [Step.System, Step.MCP, Step.Credentials]
-    : [Step.MCP, Step.Credentials];
+  const steps: StepKey[] = [];
+  if (customAgent.value.constants?.length) steps.push(Step.Constants);
+  if (customAgent.value.credentials?.length) steps.push(Step.CustomCredentials);
+  return steps;
 });
+
 const totalSteps = computed(() => stepSequence.value.length);
 const isNextLoading = ref(false);
 
-const officialAgentRef = toRef(() => props.agent as AgentGroup);
-const customAgentRef = toRef(() => props.agent as Agent);
+const { config, isSubmitting, resetAssignment, submitAssignment } = hasMCPs
+  ? useOfficialAgentAssignment(toRef(() => officialAgent.value))
+  : useCustomAgentAssignment(toRef(() => customAgent.value));
 
-const officialAssignment = isOfficial.value
-  ? useOfficialAgentAssignment(officialAgentRef)
-  : null;
-const customAssignment = isOfficial.value
-  ? null
-  : useCustomAgentAssignment(customAgentRef);
-
-const isSubmitting = computed(() =>
-  isOfficial.value
-    ? officialAssignment!.isSubmitting.value
-    : customAssignment!.isSubmitting.value,
-);
+const officialConfig = config as Ref<ConciergeAssignmentConfig>;
+const customConfig = config as Ref<CustomAssignmentConfig>;
 
 const { t } = useI18n();
 const setupTranslations = (key: string) =>
@@ -146,84 +154,61 @@ const stepComponents: Record<StepKey, Component> = {
 const currentStepKey = computed<StepKey>(
   () => stepSequence.value[stepIndex.value - 1],
 );
-
-const officialStepProps = computed(() => {
-  const config = officialAssignment!.config;
-  const agentDetails = resolvedAgentDetails.value as AgentGroup;
+const currentStepProps = computed(() => {
+  const officialDetails = resolvedAgentDetails.value as AgentGroup | undefined;
   const selectedSystemMCPs =
-    agentDetails?.MCPs?.filter((mcp) => mcp.system === config.value.system) ||
-    [];
+    officialDetails?.MCPs?.filter(
+      (mcp) => mcp.system === officialConfig.value.system,
+    ) || [];
 
-  return {
+  const stepProps: Partial<Record<StepKey, Record<string, unknown>>> = {
     [Step.System]: {
-      systems: (props.agent as AgentGroup).systems,
-      MCPs: agentDetails?.MCPs,
-      selectedSystem: config.value.system,
+      systems: officialAgent.value.systems,
+      MCPs: officialDetails?.MCPs,
+      selectedSystem: officialConfig.value.system,
       'onUpdate:selectedSystem': (nextSystem: string) => {
-        config.value.system = nextSystem;
+        officialConfig.value.system = nextSystem;
       },
     },
     [Step.MCP]: {
-      MCPs: hasSystems.value ? selectedSystemMCPs : agentDetails?.MCPs,
-      selectedMCP: config.value.MCP,
-      selectedMCPConstantsValues: config.value.mcp_config,
+      MCPs: hasSystems.value ? selectedSystemMCPs : officialDetails?.MCPs,
+      selectedMCP: officialConfig.value.MCP,
+      selectedMCPConstantsValues: officialConfig.value.mcp_config,
       'onUpdate:selectedMCP': (nextMCP: AgentMCP | null) => {
-        config.value.MCP = nextMCP;
+        officialConfig.value.MCP = nextMCP;
       },
       'onUpdate:selectedMCPConstantsValues': (nextValues: MCPConfigValues) => {
-        config.value.mcp_config = nextValues;
+        officialConfig.value.mcp_config = nextValues;
       },
     },
     [Step.Credentials]: {
-      selectedSystem: config.value.system,
-      selectedMCP: config.value.MCP,
-      credentialValues: config.value.credentials,
+      selectedSystem: officialConfig.value.system,
+      selectedMCP: officialConfig.value.MCP,
+      credentialValues: officialConfig.value.credentials,
       'onUpdate:credentialValues': (nextValues: Record<string, string>) => {
-        config.value.credentials = nextValues;
+        officialConfig.value.credentials = nextValues;
       },
     },
-  } as Partial<Record<StepKey, Record<string, unknown>>>;
-});
-
-const customStepProps = computed(() => {
-  const config = customAssignment!.config;
-  const customAgent = props.agent as Agent;
-
-  return {
     [Step.Constants]: {
-      agentName: customAgent.name,
-      constants: customAgent.constants ?? [],
-      constantsValues: config.value.constants,
+      agentName: customAgent.value.name,
+      constants: customAgent.value.constants ?? [],
+      constantsValues: customConfig.value.constants,
       'onUpdate:constantsValues': (nextValues: ConstantsValues) => {
-        config.value.constants = nextValues;
+        customConfig.value.constants = nextValues;
       },
     },
     [Step.CustomCredentials]: {
-      credentials: customAgent.credentials ?? [],
-      credentialValues: config.value.credentials,
+      credentials: customAgent.value.credentials ?? [],
+      credentialValues: customConfig.value.credentials,
       'onUpdate:credentialValues': (nextValues: Record<string, string>) => {
-        config.value.credentials = nextValues;
+        customConfig.value.credentials = nextValues;
       },
     },
-  } as Partial<Record<StepKey, Record<string, unknown>>>;
-});
-
-const currentStepProps = computed(() => {
-  const propsByStep = isOfficial.value
-    ? officialStepProps.value
-    : customStepProps.value;
-  return propsByStep[currentStepKey.value] ?? {};
-});
-
-const isNextDisabled = computed(() => {
-  const isSomeValueMissing = (
-    values: Record<string, string | string[] | boolean>,
-  ) => {
-    return Object.values(values).some(
-      (value) => value === '' || value === undefined,
-    );
   };
 
+  return stepProps[currentStepKey.value] ?? {};
+});
+const isNextDisabled = computed(() => {
   const isSomeRequiredFieldMissing = (
     fields: AgentConstantField[] = [],
     values: Record<string, string | string[] | boolean> = {},
@@ -238,40 +223,45 @@ const isNextDisabled = computed(() => {
     });
   };
 
-  if (isOfficial.value) {
-    const config = officialAssignment!.config;
-    const stepDisabled: Partial<Record<StepKey, () => boolean>> = {
-      [Step.MCP]: () =>
-        !config.value.MCP ||
-        isSomeRequiredFieldMissing(
-          config.value.MCP?.constants,
-          config.value.mcp_config,
-        ),
-      [Step.Credentials]: () =>
-        isSomeValueMissing(config.value.credentials) || isSubmitting.value,
-    };
+  const areAllCredentialsFilled = (
+    fields: AgentCredential[] = [],
+    values: Record<string, string> = {},
+  ) => {
+    return fields.every((field) => {
+      const value = values[field.name];
+      return value !== '' && value !== undefined;
+    });
+  };
 
-    return stepDisabled[currentStepKey.value]?.();
-  }
-
-  const config = customAssignment!.config;
-  const customAgent = props.agent as Agent;
   const stepDisabled: Partial<Record<StepKey, () => boolean>> = {
+    [Step.MCP]: () =>
+      !officialConfig.value.MCP ||
+      isSomeRequiredFieldMissing(
+        officialConfig.value.MCP?.constants,
+        officialConfig.value.mcp_config,
+      ),
+    [Step.Credentials]: () =>
+      !areAllCredentialsFilled(
+        officialConfig.value.MCP?.credentials,
+        officialConfig.value.credentials,
+      ) || isSubmitting.value,
     [Step.Constants]: () =>
-      isSomeRequiredFieldMissing(customAgent.constants, config.value.constants),
+      isSomeRequiredFieldMissing(
+        customAgent.value.constants,
+        customConfig.value.constants,
+      ),
     [Step.CustomCredentials]: () =>
-      isSomeValueMissing(config.value.credentials) || isSubmitting.value,
+      !areAllCredentialsFilled(
+        customAgent.value.credentials,
+        customConfig.value.credentials,
+      ) || isSubmitting.value,
   };
 
   return stepDisabled[currentStepKey.value]?.();
 });
 function resetFlow() {
   stepIndex.value = 1;
-  if (isOfficial.value) {
-    officialAssignment!.resetAssignment();
-  } else {
-    customAssignment!.resetAssignment();
-  }
+  resetAssignment();
 }
 function closeModal() {
   emit('update:open', false);
@@ -283,47 +273,33 @@ async function handleNext() {
     stepIndex.value++;
     return;
   }
-  const submit = isOfficial.value
-    ? officialAssignment!.submitAssignment
-    : customAssignment!.submitAssignment;
-  const hasFinished = await submit();
+  const hasFinished = await submitAssignment();
   if (hasFinished) {
     closeModal();
   }
 }
 
-const stepCleanupHandlers = computed<Partial<Record<StepKey, () => void>>>(
-  () => {
-    if (isOfficial.value) {
-      const config = officialAssignment!.config;
-      return {
-        [Step.MCP]: () => {
-          config.value.mcp_config = {};
-          config.value.MCP = null;
-        },
-        [Step.Credentials]: () => {
-          config.value.credentials = {};
-          config.value.MCP = null;
-        },
-      };
-    }
-
-    const config = customAssignment!.config;
-    return {
-      [Step.Constants]: () => {
-        config.value.constants = {};
-      },
-      [Step.CustomCredentials]: () => {
-        config.value.credentials = {};
-      },
-    };
+const stepCleanupHandlers: Partial<Record<StepKey, () => void>> = {
+  [Step.MCP]: () => {
+    officialConfig.value.mcp_config = {};
+    officialConfig.value.MCP = null;
   },
-);
+  [Step.Credentials]: () => {
+    officialConfig.value.credentials = {};
+    officialConfig.value.MCP = null;
+  },
+  [Step.Constants]: () => {
+    customConfig.value.constants = {};
+  },
+  [Step.CustomCredentials]: () => {
+    customConfig.value.credentials = {};
+  },
+};
 
 function handleBack() {
   if (isSubmitting.value) return;
 
-  stepCleanupHandlers.value[currentStepKey.value]?.();
+  stepCleanupHandlers[currentStepKey.value]?.();
 
   if (stepIndex.value > 1) {
     stepIndex.value--;

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
@@ -42,21 +42,31 @@
 import { computed, ref, toRef, type Component } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { AgentGroup, AgentMCP } from '@/store/types/Agents.types';
+import {
+  Agent,
+  AgentConstantField,
+  AgentGroup,
+  AgentMCP,
+} from '@/store/types/Agents.types';
 
 import useOfficialAgentAssignment, {
   type MCPConfigValues,
 } from '@/composables/useOfficialAgentAssignment';
+import useCustomAgentAssignment, {
+  type ConstantsValues,
+} from '@/composables/useCustomAgentAssignment';
 
 import SystemStepContent from './SystemStepContent.vue';
 import MCPStepContent from './MCPStepContent/index.vue';
 import CredentialsStepContent from './CredentialsStepContent/index.vue';
+import ConstantsStepContent from './ConstantsStepContent.vue';
+import CustomCredentialsStepContent from './CustomCredentialsStepContent.vue';
 
 const emit = defineEmits(['update:open']);
 
 const props = defineProps<{
-  agent: AgentGroup;
-  agentDetails?: AgentGroup | null;
+  agent: AgentGroup | Agent;
+  agentDetails?: AgentGroup | Agent | null;
 }>();
 
 defineModel('open', {
@@ -68,26 +78,47 @@ const Step = {
   System: 'system',
   MCP: 'mcp',
   Credentials: 'credentials',
+  Constants: 'constants',
+  CustomCredentials: 'custom_credentials',
 } as const;
 type StepKey = (typeof Step)[keyof typeof Step];
 
 const stepIndex = ref<number>(1);
 const resolvedAgentDetails = computed(() => props.agentDetails ?? props.agent);
+const isOfficial = computed(() => Boolean(props.agent?.is_official));
+
 const hasSystems = computed(() => {
-  const systems = resolvedAgentDetails.value?.systems ?? props.agent.systems;
+  if (!isOfficial.value) return false;
+  const systems = (resolvedAgentDetails.value as AgentGroup)?.systems;
   return Array.isArray(systems) && systems.length > 0;
 });
-const stepSequence = computed<StepKey[]>(() =>
-  hasSystems.value
+
+const stepSequence = computed<StepKey[]>(() => {
+  if (!isOfficial.value) {
+    return [Step.Constants, Step.CustomCredentials];
+  }
+  return hasSystems.value
     ? [Step.System, Step.MCP, Step.Credentials]
-    : [Step.MCP, Step.Credentials],
-);
+    : [Step.MCP, Step.Credentials];
+});
 const totalSteps = computed(() => stepSequence.value.length);
-const agentRef = toRef(props, 'agent');
 const isNextLoading = ref(false);
 
-const { config, isSubmitting, resetAssignment, submitAssignment } =
-  useOfficialAgentAssignment(agentRef);
+const officialAgentRef = toRef(() => props.agent as AgentGroup);
+const customAgentRef = toRef(() => props.agent as Agent);
+
+const officialAssignment = isOfficial.value
+  ? useOfficialAgentAssignment(officialAgentRef)
+  : null;
+const customAssignment = isOfficial.value
+  ? null
+  : useCustomAgentAssignment(customAgentRef);
+
+const isSubmitting = computed(() =>
+  isOfficial.value
+    ? officialAssignment!.isSubmitting.value
+    : customAssignment!.isSubmitting.value,
+);
 
 const { t } = useI18n();
 const setupTranslations = (key: string) =>
@@ -108,36 +139,38 @@ const stepComponents: Record<StepKey, Component> = {
   [Step.System]: SystemStepContent,
   [Step.MCP]: MCPStepContent,
   [Step.Credentials]: CredentialsStepContent,
+  [Step.Constants]: ConstantsStepContent,
+  [Step.CustomCredentials]: CustomCredentialsStepContent,
 };
 
 const currentStepKey = computed<StepKey>(
   () => stepSequence.value[stepIndex.value - 1],
 );
-const currentStepProps = computed(() => {
-  const selectedSystemMCPs =
-    resolvedAgentDetails.value?.MCPs.filter(
-      (mcp) => mcp.system === config.value.system,
-    ) || [];
 
-  const stepProps: Record<StepKey, Record<string, unknown>> = {
+const officialStepProps = computed(() => {
+  const config = officialAssignment!.config;
+  const agentDetails = resolvedAgentDetails.value as AgentGroup;
+  const selectedSystemMCPs =
+    agentDetails?.MCPs?.filter((mcp) => mcp.system === config.value.system) ||
+    [];
+
+  return {
     [Step.System]: {
-      systems: props.agent.systems,
-      MCPs: resolvedAgentDetails.value?.MCPs,
+      systems: (props.agent as AgentGroup).systems,
+      MCPs: agentDetails?.MCPs,
       selectedSystem: config.value.system,
       'onUpdate:selectedSystem': (nextSystem: string) => {
         config.value.system = nextSystem;
       },
     },
     [Step.MCP]: {
-      MCPs: hasSystems.value
-        ? selectedSystemMCPs
-        : resolvedAgentDetails.value?.MCPs,
+      MCPs: hasSystems.value ? selectedSystemMCPs : agentDetails?.MCPs,
       selectedMCP: config.value.MCP,
-      selectedMCPConfigValues: config.value.mcp_config,
+      selectedMCPConstantsValues: config.value.mcp_config,
       'onUpdate:selectedMCP': (nextMCP: AgentMCP | null) => {
         config.value.MCP = nextMCP;
       },
-      'onUpdate:selectedMCPConfigValues': (nextValues: MCPConfigValues) => {
+      'onUpdate:selectedMCPConstantsValues': (nextValues: MCPConfigValues) => {
         config.value.mcp_config = nextValues;
       },
     },
@@ -149,10 +182,39 @@ const currentStepProps = computed(() => {
         config.value.credentials = nextValues;
       },
     },
-  };
-
-  return stepProps[currentStepKey.value] ?? {};
+  } as Partial<Record<StepKey, Record<string, unknown>>>;
 });
+
+const customStepProps = computed(() => {
+  const config = customAssignment!.config;
+  const customAgent = props.agent as Agent;
+
+  return {
+    [Step.Constants]: {
+      agentName: customAgent.name,
+      constants: customAgent.constants ?? [],
+      constantsValues: config.value.constants,
+      'onUpdate:constantsValues': (nextValues: ConstantsValues) => {
+        config.value.constants = nextValues;
+      },
+    },
+    [Step.CustomCredentials]: {
+      credentials: customAgent.credentials ?? [],
+      credentialValues: config.value.credentials,
+      'onUpdate:credentialValues': (nextValues: Record<string, string>) => {
+        config.value.credentials = nextValues;
+      },
+    },
+  } as Partial<Record<StepKey, Record<string, unknown>>>;
+});
+
+const currentStepProps = computed(() => {
+  const propsByStep = isOfficial.value
+    ? officialStepProps.value
+    : customStepProps.value;
+  return propsByStep[currentStepKey.value] ?? {};
+});
+
 const isNextDisabled = computed(() => {
   const isSomeValueMissing = (
     values: Record<string, string | string[] | boolean>,
@@ -162,32 +224,54 @@ const isNextDisabled = computed(() => {
     );
   };
 
-  const isSomeRequiredMCPValueMissing = () => {
-    const mcpConfig = config.value.MCP?.config ?? [];
-    const requiredFieldNames = mcpConfig
+  const isSomeRequiredFieldMissing = (
+    fields: AgentConstantField[] = [],
+    values: Record<string, string | string[] | boolean> = {},
+  ) => {
+    const requiredFieldNames = fields
       .filter((field) => field.is_required)
       .map((field) => field.name);
 
     return requiredFieldNames.some((name) => {
-      const value = config.value.mcp_config[name];
+      const value = values[name];
       return value === '' || value === undefined;
     });
   };
 
+  if (isOfficial.value) {
+    const config = officialAssignment!.config;
+    const stepDisabled: Partial<Record<StepKey, () => boolean>> = {
+      [Step.MCP]: () =>
+        !config.value.MCP ||
+        isSomeRequiredFieldMissing(
+          config.value.MCP?.constants,
+          config.value.mcp_config,
+        ),
+      [Step.Credentials]: () =>
+        isSomeValueMissing(config.value.credentials) || isSubmitting.value,
+    };
+
+    return stepDisabled[currentStepKey.value]?.();
+  }
+
+  const config = customAssignment!.config;
+  const customAgent = props.agent as Agent;
   const stepDisabled: Partial<Record<StepKey, () => boolean>> = {
-    [Step.MCP]: () => {
-      return !config.value.MCP || isSomeRequiredMCPValueMissing();
-    },
-    [Step.Credentials]: () => {
-      return isSomeValueMissing(config.value.credentials) || isSubmitting.value;
-    },
+    [Step.Constants]: () =>
+      isSomeRequiredFieldMissing(customAgent.constants, config.value.constants),
+    [Step.CustomCredentials]: () =>
+      isSomeValueMissing(config.value.credentials) || isSubmitting.value,
   };
 
   return stepDisabled[currentStepKey.value]?.();
 });
 function resetFlow() {
   stepIndex.value = 1;
-  resetAssignment();
+  if (isOfficial.value) {
+    officialAssignment!.resetAssignment();
+  } else {
+    customAssignment!.resetAssignment();
+  }
 }
 function closeModal() {
   emit('update:open', false);
@@ -199,27 +283,47 @@ async function handleNext() {
     stepIndex.value++;
     return;
   }
-  const hasFinished = await submitAssignment();
+  const submit = isOfficial.value
+    ? officialAssignment!.submitAssignment
+    : customAssignment!.submitAssignment;
+  const hasFinished = await submit();
   if (hasFinished) {
     closeModal();
   }
 }
 
-const stepCleanupHandlers: Partial<Record<StepKey, () => void>> = {
-  [Step.MCP]: () => {
-    config.value.mcp_config = {};
-    config.value.MCP = null;
+const stepCleanupHandlers = computed<Partial<Record<StepKey, () => void>>>(
+  () => {
+    if (isOfficial.value) {
+      const config = officialAssignment!.config;
+      return {
+        [Step.MCP]: () => {
+          config.value.mcp_config = {};
+          config.value.MCP = null;
+        },
+        [Step.Credentials]: () => {
+          config.value.credentials = {};
+          config.value.MCP = null;
+        },
+      };
+    }
+
+    const config = customAssignment!.config;
+    return {
+      [Step.Constants]: () => {
+        config.value.constants = {};
+      },
+      [Step.CustomCredentials]: () => {
+        config.value.credentials = {};
+      },
+    };
   },
-  [Step.Credentials]: () => {
-    config.value.credentials = {};
-    config.value.MCP = null;
-  },
-};
+);
 
 function handleBack() {
   if (isSubmitting.value) return;
 
-  stepCleanupHandlers[currentStepKey.value]?.();
+  stepCleanupHandlers.value[currentStepKey.value]?.();
 
   if (stepIndex.value > 1) {
     stepIndex.value--;

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/index.vue
@@ -46,7 +46,7 @@ import { computed, ref, watch } from 'vue';
 
 import { useI18n } from 'vue-i18n';
 
-import { AgentGroup } from '@/store/types/Agents.types';
+import { Agent, AgentGroup } from '@/store/types/Agents.types';
 
 import AgentModalHeader from '@/components/AgentsTeam/AgentModalHeader.vue';
 import ModalAssignAgentGroupStartSetup from './Group/StartSetup/index.vue';
@@ -59,7 +59,7 @@ const { t } = useI18n();
 const emit = defineEmits(['update:open']);
 
 const props = defineProps<{
-  agent: AgentGroup;
+  agent: AgentGroup | Agent;
 }>();
 
 const open = defineModel('open', {
@@ -71,14 +71,24 @@ const agentsTeamStore = useAgentsTeamStore();
 
 const isConfiguringAgentGroup = ref<boolean>(false);
 const isAssigning = ref(false);
-const agentDetails = ref<AgentGroup | null>(null);
+const agentDetails = ref<AgentGroup | Agent | null>(null);
 const isLoadingAgentDetails = ref(false);
 const resolvedAgentDetails = computed(() => agentDetails.value ?? props.agent);
 
 const agentHasSetupSteps = computed(() => {
-  const { MCPs, systems, credentials } = resolvedAgentDetails.value;
+  const details = resolvedAgentDetails.value;
 
-  return MCPs?.length > 0 || systems?.length > 0 || credentials?.length > 0;
+  if (details.is_official) {
+    const { MCPs, systems, credentials } = details as AgentGroup;
+    return (
+      (MCPs?.length ?? 0) > 0 ||
+      (systems?.length ?? 0) > 0 ||
+      (credentials?.length ?? 0) > 0
+    );
+  }
+
+  const { constants, credentials } = details as Agent;
+  return (constants?.length ?? 0) > 0 || (credentials?.length ?? 0) > 0;
 });
 
 const footerButtonText = computed(() => {
@@ -89,15 +99,20 @@ const footerButtonText = computed(() => {
 
 async function fetchAgentDetails() {
   if (isLoadingAgentDetails.value || agentDetails.value) return;
+  if (!props.agent.is_official) return;
+
+  const group = (props.agent as AgentGroup).group;
+  if (!group) return;
 
   try {
     isLoadingAgentDetails.value = true;
     const agentDetailsData =
-      await nexusaiAPI.router.agents_team.getOfficialAgentDetails(
-        props.agent.group,
-      );
+      await nexusaiAPI.router.agents_team.getOfficialAgentDetails(group);
 
-    agentDetails.value = { ...props.agent, ...agentDetailsData };
+    agentDetails.value = {
+      ...(props.agent as AgentGroup),
+      ...agentDetailsData,
+    };
   } finally {
     isLoadingAgentDetails.value = false;
   }
@@ -116,10 +131,17 @@ async function assignAgent() {
   isAssigning.value = true;
 
   try {
-    await agentsTeamStore.toggleAgentAssignment({
-      group: props.agent.group,
-      is_assigned: true,
-    });
+    if (props.agent.is_official) {
+      await agentsTeamStore.toggleAgentAssignment({
+        group: (props.agent as AgentGroup).group,
+        is_assigned: true,
+      });
+    } else {
+      await agentsTeamStore.toggleAgentAssignment({
+        uuid: (props.agent as Agent).uuid,
+        is_assigned: true,
+      });
+    }
     closeAgentModal();
   } finally {
     isAssigning.value = false;

--- a/src/composables/__tests__/useCustomAgentAssignment.spec.ts
+++ b/src/composables/__tests__/useCustomAgentAssignment.spec.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import { createPinia, setActivePinia } from 'pinia';
+
+import useCustomAgentAssignment from '@/composables/useCustomAgentAssignment';
+
+vi.mock('@/api/nexusaiAPI', () => ({
+  default: {
+    router: {
+      agents_team: {
+        toggleAgentAssignment: vi.fn(),
+      },
+    },
+  },
+}));
+
+vi.mock('@weni/unnnic-system', () => ({
+  unnnicToastManager: {
+    error: vi.fn(),
+    success: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('@/utils/plugins/i18n', () => ({
+  default: { global: { t: vi.fn((key) => key) } },
+}));
+
+const addAgentToTeamMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/store/AgentsTeam', () => ({
+  useAgentsTeamStore: () => ({
+    addAgentToTeam: addAgentToTeamMock,
+  }),
+}));
+
+import nexusaiAPI from '@/api/nexusaiAPI';
+import { unnnicToastManager } from '@weni/unnnic-system';
+
+const buildAgent = (overrides = {}) => ({
+  uuid: 'custom-uuid',
+  name: 'Custom Agent',
+  is_official: false,
+  credentials: [
+    { name: 'api_key', label: 'API Key', is_confidential: true },
+    { name: 'base_url', label: 'Base URL', is_confidential: false },
+  ],
+  constants: [],
+  ...overrides,
+});
+
+describe('useCustomAgentAssignment', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('initializes config with empty constants and credentials', () => {
+    const agent = ref(buildAgent());
+    const { config } = useCustomAgentAssignment(agent);
+
+    expect(config.value).toEqual({ constants: {}, credentials: {} });
+  });
+
+  it('resets config and submitting state on resetAssignment', () => {
+    const agent = ref(buildAgent());
+    const { config, isSubmitting, resetAssignment } =
+      useCustomAgentAssignment(agent);
+
+    config.value.constants = { country: 'BRA' };
+    config.value.credentials = { api_key: 'token' };
+    isSubmitting.value = true;
+
+    resetAssignment();
+
+    expect(config.value).toEqual({ constants: {}, credentials: {} });
+    expect(isSubmitting.value).toBe(false);
+  });
+
+  it('submits constants as mcp_config and maps credentials with values', async () => {
+    nexusaiAPI.router.agents_team.toggleAgentAssignment.mockResolvedValue({
+      data: {},
+    });
+
+    const agent = ref(buildAgent());
+    const { config, submitAssignment } = useCustomAgentAssignment(agent);
+
+    config.value.constants = { country: 'BRA' };
+    config.value.credentials = { api_key: 'token' };
+
+    const result = await submitAssignment();
+
+    expect(result).toBe(true);
+    expect(
+      nexusaiAPI.router.agents_team.toggleAgentAssignment,
+    ).toHaveBeenCalledWith({
+      agentUuid: 'custom-uuid',
+      is_assigned: true,
+      mcp_config: { country: 'BRA' },
+      credentials: [
+        {
+          name: 'api_key',
+          label: 'API Key',
+          is_confidential: true,
+          value: 'token',
+        },
+        {
+          name: 'base_url',
+          label: 'Base URL',
+          is_confidential: false,
+          value: '',
+        },
+      ],
+    });
+    expect(addAgentToTeamMock).toHaveBeenCalledWith(agent.value);
+  });
+
+  it('returns false and shows toast when API errors', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    nexusaiAPI.router.agents_team.toggleAgentAssignment.mockRejectedValue(
+      new Error('boom'),
+    );
+
+    const agent = ref(buildAgent());
+    const { submitAssignment, isSubmitting } = useCustomAgentAssignment(agent);
+
+    const result = await submitAssignment();
+
+    expect(result).toBe(false);
+    expect(unnnicToastManager.error).toHaveBeenCalled();
+    expect(isSubmitting.value).toBe(false);
+  });
+
+  it('returns false when agent has no uuid', async () => {
+    const agent = ref(buildAgent({ uuid: '' }));
+    const { submitAssignment } = useCustomAgentAssignment(agent);
+
+    const result = await submitAssignment();
+
+    expect(result).toBe(false);
+    expect(
+      nexusaiAPI.router.agents_team.toggleAgentAssignment,
+    ).not.toHaveBeenCalled();
+  });
+
+  it('returns empty credentials list when agent has none', async () => {
+    nexusaiAPI.router.agents_team.toggleAgentAssignment.mockResolvedValue({
+      data: {},
+    });
+    const agent = ref(buildAgent({ credentials: [] }));
+    const { submitAssignment } = useCustomAgentAssignment(agent);
+
+    await submitAssignment();
+
+    expect(
+      nexusaiAPI.router.agents_team.toggleAgentAssignment,
+    ).toHaveBeenCalledWith(
+      expect.objectContaining({
+        credentials: [],
+      }),
+    );
+  });
+});

--- a/src/composables/__tests__/useCustomAgentAssignment.spec.ts
+++ b/src/composables/__tests__/useCustomAgentAssignment.spec.ts
@@ -27,10 +27,17 @@ vi.mock('@/utils/plugins/i18n', () => ({
 }));
 
 const addAgentToTeamMock = vi.hoisted(() => vi.fn());
+const createCredentialsMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/store/AgentsTeam', () => ({
   useAgentsTeamStore: () => ({
     addAgentToTeam: addAgentToTeamMock,
+  }),
+}));
+
+vi.mock('@/store/Tunings', () => ({
+  useTuningsStore: () => ({
+    createCredentials: createCredentialsMock,
   }),
 }));
 
@@ -80,7 +87,8 @@ describe('useCustomAgentAssignment', () => {
     expect(isSubmitting.value).toBe(false);
   });
 
-  it('submits constants as mcp_config and maps credentials with values', async () => {
+  it('submits credentials separately and constants as mcp_config', async () => {
+    createCredentialsMock.mockResolvedValue(undefined);
     nexusaiAPI.router.agents_team.toggleAgentAssignment.mockResolvedValue({
       data: {},
     });
@@ -94,26 +102,26 @@ describe('useCustomAgentAssignment', () => {
     const result = await submitAssignment();
 
     expect(result).toBe(true);
+    expect(createCredentialsMock).toHaveBeenCalledWith('custom-uuid', [
+      {
+        name: 'api_key',
+        label: 'API Key',
+        is_confidential: true,
+        value: 'token',
+      },
+      {
+        name: 'base_url',
+        label: 'Base URL',
+        is_confidential: false,
+        value: '',
+      },
+    ]);
     expect(
       nexusaiAPI.router.agents_team.toggleAgentAssignment,
     ).toHaveBeenCalledWith({
       agentUuid: 'custom-uuid',
       is_assigned: true,
       mcp_config: { country: 'BRA' },
-      credentials: [
-        {
-          name: 'api_key',
-          label: 'API Key',
-          is_confidential: true,
-          value: 'token',
-        },
-        {
-          name: 'base_url',
-          label: 'Base URL',
-          is_confidential: false,
-          value: '',
-        },
-      ],
     });
     expect(addAgentToTeamMock).toHaveBeenCalledWith(agent.value);
   });
@@ -144,9 +152,10 @@ describe('useCustomAgentAssignment', () => {
     expect(
       nexusaiAPI.router.agents_team.toggleAgentAssignment,
     ).not.toHaveBeenCalled();
+    expect(createCredentialsMock).not.toHaveBeenCalled();
   });
 
-  it('returns empty credentials list when agent has none', async () => {
+  it('does not call createCredentials when agent has no credentials', async () => {
     nexusaiAPI.router.agents_team.toggleAgentAssignment.mockResolvedValue({
       data: {},
     });
@@ -155,12 +164,13 @@ describe('useCustomAgentAssignment', () => {
 
     await submitAssignment();
 
+    expect(createCredentialsMock).not.toHaveBeenCalled();
     expect(
       nexusaiAPI.router.agents_team.toggleAgentAssignment,
-    ).toHaveBeenCalledWith(
-      expect.objectContaining({
-        credentials: [],
-      }),
-    );
+    ).toHaveBeenCalledWith({
+      agentUuid: 'custom-uuid',
+      is_assigned: true,
+      mcp_config: {},
+    });
   });
 });

--- a/src/composables/useCustomAgentAssignment.ts
+++ b/src/composables/useCustomAgentAssignment.ts
@@ -6,6 +6,7 @@ import nexusaiAPI from '@/api/nexusaiAPI';
 import { unnnicToastManager } from '@weni/unnnic-system';
 import i18n from '@/utils/plugins/i18n';
 import { useAgentsTeamStore } from '@/store/AgentsTeam';
+import { useTuningsStore } from '@/store/Tunings';
 
 export type ConstantsValues = Record<string, string | string[] | boolean>;
 
@@ -21,6 +22,7 @@ type CredentialPayload = AgentCredential & {
 export default function useCustomAgentAssignment(agent: Ref<Agent>) {
   const config = ref<CustomAssignmentConfig>(createInitialConfig());
   const agentsTeamStore = useAgentsTeamStore();
+  const tuningsStore = useTuningsStore();
 
   const isSubmitting = ref(false);
 
@@ -55,11 +57,19 @@ export default function useCustomAgentAssignment(agent: Ref<Agent>) {
     isSubmitting.value = true;
 
     try {
+      const credentialsPayload = buildCredentialsPayload();
+
+      if (credentialsPayload.length) {
+        await tuningsStore.createCredentials(
+          agent.value.uuid,
+          credentialsPayload,
+        );
+      }
+
       await nexusaiAPI.router.agents_team.toggleAgentAssignment({
         agentUuid: agent.value.uuid,
         is_assigned: true,
         mcp_config: config.value.constants,
-        credentials: buildCredentialsPayload(),
       });
 
       agentsTeamStore.addAgentToTeam(agent.value);

--- a/src/composables/useCustomAgentAssignment.ts
+++ b/src/composables/useCustomAgentAssignment.ts
@@ -1,0 +1,85 @@
+import { ref, type Ref } from 'vue';
+
+import { Agent, AgentCredential } from '@/store/types/Agents.types';
+
+import nexusaiAPI from '@/api/nexusaiAPI';
+import { unnnicToastManager } from '@weni/unnnic-system';
+import i18n from '@/utils/plugins/i18n';
+import { useAgentsTeamStore } from '@/store/AgentsTeam';
+
+export type ConstantsValues = Record<string, string | string[] | boolean>;
+
+export type CustomAssignmentConfig = {
+  constants: ConstantsValues;
+  credentials: Record<string, string>;
+};
+
+type CredentialPayload = AgentCredential & {
+  value: string;
+};
+
+export default function useCustomAgentAssignment(agent: Ref<Agent>) {
+  const config = ref<CustomAssignmentConfig>(createInitialConfig());
+  const agentsTeamStore = useAgentsTeamStore();
+
+  const isSubmitting = ref(false);
+
+  function createInitialConfig(): CustomAssignmentConfig {
+    return {
+      constants: {},
+      credentials: {},
+    };
+  }
+
+  function resetAssignment() {
+    config.value = createInitialConfig();
+    isSubmitting.value = false;
+  }
+
+  function buildCredentialsPayload(): CredentialPayload[] {
+    if (!agent.value?.credentials?.length) {
+      return [];
+    }
+
+    return agent.value.credentials.map((credential) => ({
+      ...credential,
+      value: config.value.credentials[credential.name] ?? '',
+    }));
+  }
+
+  async function submitAssignment() {
+    if (!agent.value?.uuid) {
+      return false;
+    }
+
+    isSubmitting.value = true;
+
+    try {
+      await nexusaiAPI.router.agents_team.toggleAgentAssignment({
+        agentUuid: agent.value.uuid,
+        is_assigned: true,
+        mcp_config: config.value.constants,
+        credentials: buildCredentialsPayload(),
+      });
+
+      agentsTeamStore.addAgentToTeam(agent.value);
+
+      return true;
+    } catch (error) {
+      console.error('Failed to assign custom agent', error);
+      unnnicToastManager.error(
+        i18n.global.t('router.agents_team.card.error_alert'),
+      );
+      return false;
+    } finally {
+      isSubmitting.value = false;
+    }
+  }
+
+  return {
+    config,
+    isSubmitting,
+    resetAssignment,
+    submitAssignment,
+  };
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -394,6 +394,14 @@
           "title": "Configure {mcp} MCP",
           "description": "This MCP does not require configuration"
         },
+        "constants": {
+          "optional": "optional",
+          "title": "Configure {agent}",
+          "not_required": "This agent does not require configuration"
+        },
+        "custom_credentials": {
+          "title": "Enter credentials"
+        },
         "third_step": {
           "title": "Review the setup and enter credentials",
           "description": "Review the setup and enter your credentials to finish the agent setup",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -396,8 +396,7 @@
         },
         "constants": {
           "optional": "optional",
-          "title": "Configure {agent}",
-          "not_required": "This agent does not require configuration"
+          "title": "Configure {agent}"
         },
         "custom_credentials": {
           "title": "Enter credentials"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -396,8 +396,7 @@
         },
         "constants": {
           "optional": "opcional",
-          "title": "Configurar {agent}",
-          "not_required": "Este agente no requiere configuración"
+          "title": "Configurar {agent}"
         },
         "custom_credentials": {
           "title": "Ingresar credenciales"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -394,6 +394,14 @@
           "title": "Configurar MCP {mcp}",
           "description": "Este MCP no requiere configuración"
         },
+        "constants": {
+          "optional": "opcional",
+          "title": "Configurar {agent}",
+          "not_required": "Este agente no requiere configuración"
+        },
+        "custom_credentials": {
+          "title": "Ingresar credenciales"
+        },
         "third_step": {
           "title": "Revisa la configuración e ingresa las credenciales",
           "description": "Revisa la configuración e ingresa tus credenciales para finalizar la configuración del agente",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -396,8 +396,7 @@
         },
         "constants": {
           "optional": "opcional",
-          "title": "Configurar {agent}",
-          "not_required": "Este agente não requer configuração"
+          "title": "Configurar {agent}"
         },
         "custom_credentials": {
           "title": "Inserir credenciais"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -394,6 +394,14 @@
           "title": "Configurar MCP {mcp}",
           "description": "Este MCP não requer configuração"
         },
+        "constants": {
+          "optional": "opcional",
+          "title": "Configurar {agent}",
+          "not_required": "Este agente não requer configuração"
+        },
+        "custom_credentials": {
+          "title": "Inserir credenciais"
+        },
         "third_step": {
           "title": "Revise a configuração e insira as credenciais",
           "description": "Revise a configuração e insira suas credenciais para finalizar o setup do agente",


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The agent assignment modal (`ModalAssignAgentGroup`) was previously designed to support only official agents. A new requirement was made to extend this modal to support custom (non-official) agents, enabling users to configure constants and credentials for their custom agents through the same assignment flow.

Custom agents have a different data structure:
- Constants and credentials are defined directly on the agent (not within MCPs as with official agents)
- The assignment endpoint needs to receive `mcp_config` for constants
- Credentials are submitted via a separate endpoint

### Summary of Changes

**API Layer:**
- Updated `listMyAgents` to map `mcp_definitions.config` → `constants` and `mcp_definitions.credentials` → `credentials`
- Forced `is_offiForced `is_cial: false` for all agents from the `my-agents` endpoint to ensure correct flow routing
- Extended `toggleAgentAssignment` to accept optional `mcp_config` parameter for custom agents

**Components:**
- Updated `ModalAssignAgentGroup/Group/index.vue` with branching logic based on agent type (`is_official` and `hasMCPs`)
- Created `ConstantsStepContent.vue` for custom agent constants configuration
- Created `CustomCredentialsStepContent.vue` for custom agent credentials configuration
- Updated `StartSetup/index.vue` and `StartSetup/About.vue` to handle both `AgentGroup` and `Agent` types
- Updated `AgentModalHeader.vue` to support both agent types
- Enhanced `ModalAssignAgentGroup/index.vue` to skip setup steps when constants/credentials are not required

**Composables:**
- Created `useCustomAgentAssignment.ts` to manage state and submission logic for custom agent assignments
- Handles credentials submission via `tuningsStore.createCredentials` before agent assignment

**i18n:**
- Added translation keys for custom agent assignment UI

**Tests:**
- Added unit tests for `useCustomAgentAssignment` composable
- Added unit tests for `ConstantsStepContent` and `ConstantsForm` components
- Extended `Group/index.spec.js` with test suites for custom agent flow and official agents without MCPs

### Design Files
- [Design File](https://www.figma.com/design/dypV9U51xgTKfSywY3AbSC/Agents?node-id=9464-4537&m=dev)