### PR TITLE
🐛 Ensure Inter Font Loads Consistently Across All Routes

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,9 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Agent Builder</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,400..600;1,14..32,400..600&display=swap" rel="stylesheet">
 </head>
 
 <body>


### PR DESCRIPTION
## Description

### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The Inter font was loaded exclusively via a CSS `@import` rule inside `@weni/unnnic-system/dist/style.css`. CSS `@import` rules are only honored by browsers when they appear **before any other CSS rules** in a stylesheet. In rspack's dev server and in production builds with code splitting, the order in which CSS chunks are injected is not guaranteed. On routes like `/conversations`, component CSS chunks were being injected before the main chunk CSS that contained the Google Fonts `@import`, causing browsers to silently ignore it. As a result, Inter was not loaded and text fell back to `sans-serif` on those pages, while the homepage (`/agents`) was unaffected because its CSS chunks happened to be injected in a favorable order.

### Summary of Changes
Added Google Fonts `preconnect` and `stylesheet` link tags directly to `index.html`. This moves the Inter font request to HTML parse time, completely independent of rspack's CSS chunk injection order, ensuring Inter is available on every route.

```html
<link rel="preconnect" href="https://fonts.googleapis.com">
<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
<link href="https://fonts.googleapis.com/css2?family=Inter:ital,opsz,wght@0,14..32,400..600;1,14..32,400..600&display=swap" rel="stylesheet">
```