### PR TITLE
[NEXUS-5256] refactor: Replace available agents systems endpoint

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -56,8 +56,9 @@ const managerSelectorStore = useManagerSelectorStore();
 
 async function loadAgentsData() {
   agentsTeamStore.loadMyAgents();
-  // The official agents need to be loaded first to get the available systems to active team
-  await agentsTeamStore.loadOfficialAgents();
+  agentsTeamStore.loadOfficialAgents();
+  // Active team depends on availableSystems to resolve mcp.system
+  await agentsTeamStore.loadAvailableSystems();
   agentsTeamStore.loadActiveTeam();
 }
 

--- a/src/api/nexus/AgentsTeam.js
+++ b/src/api/nexus/AgentsTeam.js
@@ -31,7 +31,7 @@ export const AgentsTeam = {
       params,
     });
 
-    const agents = [...data.new.agents, ...data.legacy].map((agent) => ({
+    const agents = (data?.results ?? []).map((agent) => ({
       ...agent,
       id: agent.slug,
       systems: filterSystems(agent.systems),
@@ -40,8 +40,18 @@ export const AgentsTeam = {
 
     return {
       agents,
-      availableSystems: data?.new?.available_systems,
     };
+  },
+
+  async listOfficialAvailableSystems() {
+    const { data } = await request.$http.get(
+      '/api/v1/official/available-systems',
+      {
+        params: { project_uuid: projectUuid.value },
+      },
+    );
+
+    return data?.available_systems ?? [];
   },
 
   async getOfficialAgentDetails(group) {

--- a/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
+++ b/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
@@ -25,18 +25,16 @@ describe('AgentsTeam API', () => {
   describe('listOfficialAgents', () => {
     const mockOfficialAgentsResponse = {
       data: {
-        new: {
-          agents: [
-            {
-              uuid: 'agent-uuid-1',
-              name: 'Official Agent 1',
-              slug: 'official-agent-1',
-              systems: ['system_a', 'no_system', 'custom'],
-            },
-          ],
-          available_systems: ['system_a', 'system_b'],
-        },
-        legacy: [
+        count: 2,
+        page: 1,
+        page_size: 20,
+        results: [
+          {
+            uuid: 'agent-uuid-1',
+            name: 'Official Agent 1',
+            slug: 'official-agent-1',
+            systems: ['system_a', 'no_system', 'custom'],
+          },
           {
             uuid: 'agent-uuid-2',
             name: 'Official Agent 2',
@@ -66,10 +64,10 @@ describe('AgentsTeam API', () => {
       });
 
       expect(result.agents).toHaveLength(2);
-      expect(result.availableSystems).toEqual(['system_a', 'system_b']);
+      expect(result).not.toHaveProperty('availableSystems');
     });
 
-    it('should merge new and legacy agents and filter system tags', async () => {
+    it('should map agents from results and filter system tags', async () => {
       request.$http.get.mockResolvedValue(mockOfficialAgentsResponse);
 
       const result = await AgentsTeam.listOfficialAgents({});
@@ -84,6 +82,14 @@ describe('AgentsTeam API', () => {
         id: 'official-agent-2',
         systems: ['system_b'],
       });
+    });
+
+    it('should return an empty array when results is missing', async () => {
+      request.$http.get.mockResolvedValue({ data: {} });
+
+      const result = await AgentsTeam.listOfficialAgents({});
+
+      expect(result.agents).toEqual([]);
     });
 
     it('should omit empty filters from params', async () => {
@@ -101,6 +107,57 @@ describe('AgentsTeam API', () => {
       request.$http.get.mockRejectedValue(error);
 
       await expect(AgentsTeam.listOfficialAgents({})).rejects.toThrow(
+        'API Error',
+      );
+    });
+  });
+
+  describe('listOfficialAvailableSystems', () => {
+    const mockAvailableSystemsResponse = {
+      data: {
+        available_systems: [
+          { slug: 'vtex', name: 'VTEX', logo: 'https://example.com/vtex.svg' },
+          { slug: 'another-system', name: 'Another System', logo: null },
+        ],
+      },
+    };
+
+    it('should call the available systems endpoint with project_uuid', async () => {
+      request.$http.get.mockResolvedValue(mockAvailableSystemsResponse);
+
+      await AgentsTeam.listOfficialAvailableSystems();
+
+      expect(request.$http.get).toHaveBeenCalledWith(
+        '/api/v1/official/available-systems',
+        {
+          params: { project_uuid: mockProjectUuid },
+        },
+      );
+    });
+
+    it('should return the available_systems array from the response', async () => {
+      request.$http.get.mockResolvedValue(mockAvailableSystemsResponse);
+
+      const result = await AgentsTeam.listOfficialAvailableSystems();
+
+      expect(result).toEqual(
+        mockAvailableSystemsResponse.data.available_systems,
+      );
+    });
+
+    it('should return an empty array when available_systems is missing', async () => {
+      request.$http.get.mockResolvedValue({ data: {} });
+
+      const result = await AgentsTeam.listOfficialAvailableSystems();
+
+      expect(result).toEqual([]);
+    });
+
+    it('should handle API error', async () => {
+      const error = new Error('API Error');
+      request.$http.get.mockRejectedValue(error);
+
+      await expect(AgentsTeam.listOfficialAvailableSystems()).rejects.toThrow(
         'API Error',
       );
     });

--- a/src/store/AgentsTeam.ts
+++ b/src/store/AgentsTeam.ts
@@ -126,20 +126,30 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
 
       const { system, search, category } = assignAgentsFilters;
 
-      const { agents, availableSystems: availableSystemsResponse } =
-        await nexusaiAPI.router.agents_team.listOfficialAgents({
+      const { agents } = await nexusaiAPI.router.agents_team.listOfficialAgents(
+        {
           name: search,
           category: category?.[0]?.value ?? '',
           system: system === 'ALL_OFFICIAL' ? '' : system,
-        });
+        },
+      );
 
       officialAgents.data = agentIconService.applyIconsToAgents(agents);
-      availableSystems.value = availableSystemsResponse ?? [];
       officialAgents.status = 'complete';
     } catch (error) {
       console.error('error', error);
 
       officialAgents.status = 'error';
+    }
+  }
+
+  async function loadAvailableSystems() {
+    try {
+      availableSystems.value =
+        await nexusaiAPI.router.agents_team.listOfficialAvailableSystems();
+    } catch (error) {
+      console.error('error', error);
+
       availableSystems.value = [];
     }
   }
@@ -294,6 +304,7 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
     addAgentToTeam,
     loadActiveTeam,
     loadOfficialAgents,
+    loadAvailableSystems,
     loadMyAgents,
     toggleAgentAssignment,
     deleteAgent,

--- a/src/store/__tests__/AgentsTeam.unit.spec.js
+++ b/src/store/__tests__/AgentsTeam.unit.spec.js
@@ -53,7 +53,6 @@ describe('AgentsTeamStore', () => {
     it('should load official agents team successfully', async () => {
       const mockResponse = {
         agents: [],
-        availableSystems: [],
       };
       const listOfficialAgentsSpy =
         nexusaiAPI.router.agents_team.listOfficialAgents.mockResolvedValue(
@@ -83,6 +82,41 @@ describe('AgentsTeamStore', () => {
       await store.loadOfficialAgents();
 
       expect(store.officialAgents.status).toBe('error');
+    });
+  });
+
+  describe('loadAvailableSystems', () => {
+    it('should populate availableSystems from the API response', async () => {
+      const mockSystems = [
+        { slug: 'vtex', name: 'VTEX', logo: 'vtex.svg' },
+        { slug: 'another-system', name: 'Another System', logo: null },
+      ];
+      nexusaiAPI.router.agents_team.listOfficialAvailableSystems.mockResolvedValue(
+        mockSystems,
+      );
+
+      await store.loadAvailableSystems();
+
+      expect(store.availableSystems).toEqual(mockSystems);
+    });
+
+    it('should reset availableSystems to an empty array on error', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+
+      store.availableSystems = [
+        { slug: 'vtex', name: 'VTEX', logo: 'vtex.svg' },
+      ];
+
+      nexusaiAPI.router.agents_team.listOfficialAvailableSystems.mockRejectedValue(
+        new Error('Error'),
+      );
+
+      await store.loadAvailableSystems();
+
+      expect(store.availableSystems).toEqual([]);
+      expect(consoleErrorSpy).toHaveBeenCalledWith('error', new Error('Error'));
     });
   });
 


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The official agents endpoint no longer provides `available_systems`. This change loads available systems from the new dedicated endpoint and adapts official agents listing to the new paginated response format.

### Summary of Changes
- Added `listOfficialAvailableSystems` using `/api/v1/official/available-systems`
- Updated `listOfficialAgents` to read agents from `results`
- Moved `availableSystems` loading into a dedicated store action
- Kept active team loading dependent on available systems to resolve `mcp.system`
- Updated API and store unit tests for the new response formats