### PR TITLE
[NEXUS-5259] - refactor: Standardize agent assignment parameters and unify API calls

### DIFF
--- a/src/api/nexus/AgentsTeam.js
+++ b/src/api/nexus/AgentsTeam.js
@@ -48,10 +48,10 @@ export const AgentsTeam = {
     return data?.available_systems ?? [];
   },
 
-  async toggleOfficialAgentAssignment(payload) {
-    const agentId = payload.group
-      ? `&group=${payload.group}`
-      : `&agent_uuid=${payload.agent_uuid}`;
+  async toggleAgentAssignment(payload) {
+    const agentId = payload.agent_uuid
+      ? `&agent_uuid=${payload.agent_uuid}`
+      : `&group=${payload.group}`;
 
     const { data } = await request.$http.post(
       `/api/v1/official/agents?project_uuid=${projectUuid.value}${agentId}`,
@@ -141,23 +141,6 @@ export const AgentsTeam = {
           }),
         ),
       },
-    };
-  },
-
-  async toggleAgentAssignment({ agentUuid, is_assigned, mcp_config }) {
-    const body = { assigned: is_assigned };
-    if (mcp_config !== undefined) body.mcp_config = mcp_config;
-
-    const { data } = await request.$http.patch(
-      `api/project/${projectUuid.value}/assign/${agentUuid}`,
-      body,
-      {
-        hideGenericErrorAlert: true,
-      },
-    );
-
-    return {
-      data,
     };
   },
 

--- a/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
+++ b/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
@@ -6,7 +6,7 @@ vi.mock('@/api/nexusaiRequest', () => ({
   default: {
     $http: {
       get: vi.fn(),
-      patch: vi.fn(),
+      post: vi.fn(),
     },
   },
 }));
@@ -501,72 +501,89 @@ describe('AgentsTeam API', () => {
   describe('toggleAgentAssignment', () => {
     const mockToggleResponse = {
       data: {
-        success: true,
-        message: 'Agent assignment updated',
-        agent_uuid: 'agent-uuid-123',
         assigned: true,
+        agent: {
+          uuid: 'agent-uuid-123',
+          slug: 'agent-slug',
+        },
       },
     };
 
-    it('should assign agent successfully', async () => {
-      request.$http.patch.mockResolvedValue(mockToggleResponse);
+    it('should call the unified endpoint with agent_uuid', async () => {
+      request.$http.post.mockResolvedValue(mockToggleResponse);
 
-      const result = await AgentsTeam.toggleAgentAssignment({
-        agentUuid: 'agent-uuid-123',
-        is_assigned: true,
-      });
+      const payload = { agent_uuid: 'agent-uuid-123', assigned: true };
+      const result = await AgentsTeam.toggleAgentAssignment(payload);
 
-      expect(request.$http.patch).toHaveBeenCalledWith(
-        `api/project/${mockProjectUuid}/assign/agent-uuid-123`,
-        {
-          assigned: true,
-        },
-        {
-          hideGenericErrorAlert: true,
-        },
+      expect(request.$http.post).toHaveBeenCalledWith(
+        `/api/v1/official/agents?project_uuid=${mockProjectUuid}&agent_uuid=agent-uuid-123`,
+        payload,
+        { hideGenericErrorAlert: true },
       );
 
       expect(result.data).toEqual(mockToggleResponse.data);
     });
 
-    it('should unassign agent successfully', async () => {
-      const unassignResponse = {
-        data: {
-          success: true,
-          message: 'Agent assignment removed',
-          agent_uuid: 'agent-uuid-456',
-          assigned: false,
-        },
-      };
-      request.$http.patch.mockResolvedValue(unassignResponse);
+    it('should call the unified endpoint with group when agent_uuid is missing', async () => {
+      request.$http.post.mockResolvedValue(mockToggleResponse);
 
-      const result = await AgentsTeam.toggleAgentAssignment({
-        agentUuid: 'agent-uuid-456',
-        is_assigned: false,
+      const payload = { group: 'CONCIERGE', assigned: false };
+      await AgentsTeam.toggleAgentAssignment(payload);
+
+      expect(request.$http.post).toHaveBeenCalledWith(
+        `/api/v1/official/agents?project_uuid=${mockProjectUuid}&group=CONCIERGE`,
+        payload,
+        { hideGenericErrorAlert: true },
+      );
+    });
+
+    it('should prefer agent_uuid over group when both are provided', async () => {
+      request.$http.post.mockResolvedValue(mockToggleResponse);
+
+      await AgentsTeam.toggleAgentAssignment({
+        agent_uuid: 'agent-uuid-456',
+        group: 'CONCIERGE',
+        assigned: true,
       });
 
-      expect(request.$http.patch).toHaveBeenCalledWith(
-        `api/project/${mockProjectUuid}/assign/agent-uuid-456`,
-        {
-          assigned: false,
-        },
-        {
-          hideGenericErrorAlert: true,
-        },
-      );
+      const calledUrl = request.$http.post.mock.calls[0][0];
+      expect(calledUrl).toContain('agent_uuid=agent-uuid-456');
+      expect(calledUrl).not.toContain('group=CONCIERGE');
+    });
 
-      expect(result.data).toEqual(unassignResponse.data);
+    it('should send the full payload (including system, mcp, mcp_config, credentials) as body', async () => {
+      request.$http.post.mockResolvedValue(mockToggleResponse);
+
+      const credentials = [
+        { name: 'token', value: 'a', is_confidential: true },
+        { name: 'store_id', value: 'b', is_confidential: false },
+      ];
+
+      const payload = {
+        agent_uuid: 'agent-uuid-123',
+        assigned: true,
+        system: 'vtex',
+        mcp: 'Default',
+        mcp_config: { country: 'BRA' },
+        credentials,
+      };
+
+      await AgentsTeam.toggleAgentAssignment(payload);
+
+      const calledBody = request.$http.post.mock.calls[0][1];
+      expect(calledBody).toEqual(payload);
+      expect(Array.isArray(calledBody.credentials)).toBe(true);
     });
 
     it('should include hideGenericErrorAlert in request config', async () => {
-      request.$http.patch.mockResolvedValue(mockToggleResponse);
+      request.$http.post.mockResolvedValue(mockToggleResponse);
 
       await AgentsTeam.toggleAgentAssignment({
-        agentUuid: 'agent-uuid-123',
-        is_assigned: true,
+        agent_uuid: 'agent-uuid-123',
+        assigned: true,
       });
 
-      const callArgs = request.$http.patch.mock.calls[0];
+      const callArgs = request.$http.post.mock.calls[0];
       expect(callArgs[2]).toEqual({
         hideGenericErrorAlert: true,
       });
@@ -574,33 +591,14 @@ describe('AgentsTeam API', () => {
 
     it('should handle API error', async () => {
       const error = new Error('Failed to toggle agent assignment');
-      request.$http.patch.mockRejectedValue(error);
+      request.$http.post.mockRejectedValue(error);
 
       await expect(
         AgentsTeam.toggleAgentAssignment({
-          agentUuid: 'agent-uuid-123',
-          is_assigned: true,
+          agent_uuid: 'agent-uuid-123',
+          assigned: true,
         }),
       ).rejects.toThrow('Failed to toggle agent assignment');
-    });
-
-    it('should handle missing parameters', async () => {
-      request.$http.patch.mockResolvedValue(mockToggleResponse);
-
-      await AgentsTeam.toggleAgentAssignment({
-        agentUuid: undefined,
-        is_assigned: true,
-      });
-
-      expect(request.$http.patch).toHaveBeenCalledWith(
-        `api/project/${mockProjectUuid}/assign/undefined`,
-        {
-          assigned: true,
-        },
-        {
-          hideGenericErrorAlert: true,
-        },
-      );
     });
   });
 
@@ -663,12 +661,12 @@ describe('AgentsTeam API', () => {
     it('should propagate authentication errors', async () => {
       const authError = new Error('Unauthorized');
       authError.response = { status: 401 };
-      request.$http.patch.mockRejectedValue(authError);
+      request.$http.post.mockRejectedValue(authError);
 
       await expect(
         AgentsTeam.toggleAgentAssignment({
-          agentUuid: 'test-uuid',
-          is_assigned: true,
+          agent_uuid: 'test-uuid',
+          assigned: true,
         }),
       ).rejects.toThrow('Unauthorized');
     });

--- a/src/composables/__tests__/useCustomAgentAssignment.spec.ts
+++ b/src/composables/__tests__/useCustomAgentAssignment.spec.ts
@@ -119,8 +119,8 @@ describe('useCustomAgentAssignment', () => {
     expect(
       nexusaiAPI.router.agents_team.toggleAgentAssignment,
     ).toHaveBeenCalledWith({
-      agentUuid: 'custom-uuid',
-      is_assigned: true,
+      agent_uuid: 'custom-uuid',
+      assigned: true,
       mcp_config: { country: 'BRA' },
     });
     expect(addAgentToTeamMock).toHaveBeenCalledWith(agent.value);
@@ -168,8 +168,8 @@ describe('useCustomAgentAssignment', () => {
     expect(
       nexusaiAPI.router.agents_team.toggleAgentAssignment,
     ).toHaveBeenCalledWith({
-      agentUuid: 'custom-uuid',
-      is_assigned: true,
+      agent_uuid: 'custom-uuid',
+      assigned: true,
       mcp_config: {},
     });
   });

--- a/src/composables/useCustomAgentAssignment.ts
+++ b/src/composables/useCustomAgentAssignment.ts
@@ -67,8 +67,8 @@ export default function useCustomAgentAssignment(agent: Ref<Agent>) {
       }
 
       await nexusaiAPI.router.agents_team.toggleAgentAssignment({
-        agentUuid: agent.value.uuid,
-        is_assigned: true,
+        agent_uuid: agent.value.uuid,
+        assigned: true,
         mcp_config: config.value.constants,
       });
 

--- a/src/composables/useOfficialAgentAssignment.ts
+++ b/src/composables/useOfficialAgentAssignment.ts
@@ -97,9 +97,7 @@ export default function useOfficialAgentAssignment(agent: Ref<AgentGroup>) {
       };
 
       const { data } =
-        await nexusaiAPI.router.agents_team.toggleOfficialAgentAssignment(
-          payload,
-        );
+        await nexusaiAPI.router.agents_team.toggleAgentAssignment(payload);
 
       const constantsWithLabels = Object.fromEntries(
         Object.entries(config.value.mcp_config).map(([key, value]) => {

--- a/src/store/AgentsTeam.ts
+++ b/src/store/AgentsTeam.ts
@@ -203,17 +203,10 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
         throw new Error('Agent not found');
       }
 
-      if (agent.uuid) {
-        await nexusaiAPI.router.agents_team.toggleAgentAssignment({
-          agentUuid: (agent as Agent)?.uuid,
-          is_assigned,
-        });
-      } else {
-        await nexusaiAPI.router.agents_team.toggleOfficialAgentAssignment({
-          group: agent.group,
-          assigned: is_assigned,
-        });
-      }
+      await nexusaiAPI.router.agents_team.toggleAgentAssignment({
+        ...(agent.uuid ? { agent_uuid: agent.uuid } : { group: agent.group }),
+        assigned: is_assigned,
+      });
 
       if (listedAgent) listedAgent.assigned = is_assigned;
 

--- a/src/store/__tests__/AgentsTeam.unit.spec.js
+++ b/src/store/__tests__/AgentsTeam.unit.spec.js
@@ -164,7 +164,7 @@ describe('AgentsTeamStore', () => {
       }
     });
 
-    it('updates agent assignment correctly', async () => {
+    it('updates agent assignment correctly using agent_uuid', async () => {
       const uuid = '123';
       const is_assigned = true;
       const agent = { uuid, assigned: true };
@@ -179,8 +179,8 @@ describe('AgentsTeamStore', () => {
       expect(
         nexusaiAPI.router.agents_team.toggleAgentAssignment,
       ).toHaveBeenCalledWith({
-        agentUuid: uuid,
-        is_assigned,
+        agent_uuid: uuid,
+        assigned: is_assigned,
       });
 
       expect(store.officialAgents.data[0].assigned).toBe(true);
@@ -191,6 +191,27 @@ describe('AgentsTeamStore', () => {
       await store.toggleAgentAssignment({ uuid, is_assigned });
 
       expect(store.myAgents.data[0].assigned).toBe(true);
+    });
+
+    it('uses group when the official agent has no uuid yet', async () => {
+      const is_assigned = true;
+      const agent = { uuid: null, group: 'CONCIERGE', assigned: false };
+      nexusaiAPI.router.agents_team.toggleAgentAssignment.mockResolvedValue({
+        data: { agent: { uuid: 'new-uuid' } },
+      });
+
+      store.officialAgents.data.push(agent);
+
+      await store.toggleAgentAssignment({ group: 'CONCIERGE', is_assigned });
+
+      expect(
+        nexusaiAPI.router.agents_team.toggleAgentAssignment,
+      ).toHaveBeenCalledWith({
+        group: 'CONCIERGE',
+        assigned: is_assigned,
+      });
+
+      expect(store.officialAgents.data[0].assigned).toBe(true);
     });
 
     it('should handle agent not found error when toggling assignment', async () => {


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Summary of Changes
<!--- Describe your changes in detail -->
- Renamed `toggleOfficialAgentAssignment` to `toggleAgentAssignment` for consistency.
- Updated the agent assignment payload structure to use `agent_uuid` and `assigned` instead of `agentUuid` and `is_assigned`.
- Adjusted related API calls and tests to reflect the new parameter names and unified endpoint usage.
- Enhanced test cases to cover scenarios for both agent UUID and group assignment.