### PR TITLE
[NEXUS-5259] - refactor: Streamline agent data structure

### DIFF
--- a/src/api/nexus/AgentsTeam.js
+++ b/src/api/nexus/AgentsTeam.js
@@ -91,6 +91,13 @@ export const AgentsTeam = {
         agents: (agents ?? []).map((agent) => ({
           ...agent,
           id: agent.slug,
+          mcps: agent.mcps?.map((mcp) => ({
+            ...mcp,
+            config: Object.entries(mcp.config ?? {}).map(([key, value]) => ({
+              label: key,
+              value,
+            })),
+          })),
         })),
       },
     };

--- a/src/api/nexus/AgentsTeam.js
+++ b/src/api/nexus/AgentsTeam.js
@@ -5,13 +5,6 @@ import { cleanParams } from '@/utils/http';
 
 const projectUuid = computed(() => useProjectStore().uuid);
 
-function normalizeMCPs(mcps = []) {
-  return mcps.map(({ config, ...mcp }) => ({
-    ...mcp,
-    constants: config ?? [],
-  }));
-}
-
 export const AgentsTeam = {
   async listOfficialAgents({ category, system, name }) {
     const params = cleanParams({
@@ -28,8 +21,6 @@ export const AgentsTeam = {
     const agents = (data?.results ?? []).map((agent) => ({
       ...agent,
       id: agent.slug,
-      systems: agent.systems ?? [],
-      mcps: normalizeMCPs(agent.mcps),
     }));
 
     return {
@@ -78,29 +69,10 @@ export const AgentsTeam = {
     );
 
     return {
-      data: data.map(
-        ({
-          uuid,
-          name,
-          about,
-          description,
-          skills,
-          assigned,
-          slug,
-          mcp_definitions,
-        }) => ({
-          uuid,
-          name,
-          about: about ?? null,
-          description,
-          skills,
-          assigned,
-          credentials: mcp_definitions?.credentials ?? [],
-          is_official: false,
-          id: slug,
-          constants: mcp_definitions?.config ?? [],
-        }),
-      ),
+      data: (data ?? []).map((agent) => ({
+        ...agent,
+        id: agent.slug,
+      })),
     };
   },
 
@@ -116,30 +88,10 @@ export const AgentsTeam = {
         manager: {
           id: manager.id || 'manager',
         },
-        agents: agents.map(
-          ({
-            uuid,
-            name,
-            skills,
-            id,
-            about,
-            description,
-            credentials,
-            is_official,
-            slug,
-            mcp,
-          }) => ({
-            uuid,
-            name,
-            skills,
-            id: id || slug,
-            about: about ?? null,
-            description,
-            credentials,
-            is_official,
-            mcp,
-          }),
-        ),
+        agents: (agents ?? []).map((agent) => ({
+          ...agent,
+          id: agent.slug,
+        })),
       },
     };
   },

--- a/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
+++ b/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
@@ -353,17 +353,7 @@ describe('AgentsTeam API', () => {
                 name: 'Default',
                 description: { en: 'Default MCP', pt: '', es: '' },
                 system: 'vtex',
-                config: [
-                  {
-                    name: 'country',
-                    label: 'Country',
-                    type: 'TEXT',
-                    is_required: true,
-                    default_value: 'BRA',
-                    options: [],
-                    value: 'BRA',
-                  },
-                ],
+                config: { country: 'BRA' },
                 credentials: [],
               },
             ],
@@ -402,6 +392,12 @@ describe('AgentsTeam API', () => {
       expect(result.data.agents[0]).toEqual({
         ...mockActiveTeamResponse.data.agents[0],
         id: 'active-agent-1',
+        mcps: [
+          {
+            ...mockActiveTeamResponse.data.agents[0].mcps[0],
+            config: [{ label: 'country', value: 'BRA' }],
+          },
+        ],
       });
     });
 
@@ -458,14 +454,43 @@ describe('AgentsTeam API', () => {
       expect(result.data.agents[0].id).toBe('active-agent-1');
     });
 
-    it('should preserve mcps array passthrough', async () => {
+    it('should transform mcp config object into a labeled array', async () => {
       request.$http.get.mockResolvedValue(mockActiveTeamResponse);
 
       const result = await AgentsTeam.listActiveTeam();
 
-      expect(result.data.agents[0].mcps).toEqual(
-        mockActiveTeamResponse.data.agents[0].mcps,
-      );
+      expect(result.data.agents[0].mcps).toEqual([
+        {
+          ...mockActiveTeamResponse.data.agents[0].mcps[0],
+          config: [{ label: 'country', value: 'BRA' }],
+        },
+      ]);
+    });
+
+    it('should default mcp config to an empty array when missing', async () => {
+      const responseWithoutMcpConfig = {
+        data: {
+          manager: { id: 'manager-id' },
+          agents: [
+            {
+              ...mockActiveTeamResponse.data.agents[0],
+              mcps: [
+                {
+                  name: 'Default',
+                  description: { en: 'Default MCP', pt: '', es: '' },
+                  system: 'vtex',
+                  credentials: [],
+                },
+              ],
+            },
+          ],
+        },
+      };
+      request.$http.get.mockResolvedValue(responseWithoutMcpConfig);
+
+      const result = await AgentsTeam.listActiveTeam();
+
+      expect(result.data.agents[0].mcps[0].config).toEqual([]);
     });
 
     it('should handle API error', async () => {

--- a/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
+++ b/src/api/nexus/__tests__/AgentsTeam.unit.spec.js
@@ -93,7 +93,7 @@ describe('AgentsTeam API', () => {
       expect(result).not.toHaveProperty('availableSystems');
     });
 
-    it('should map agents from results, normalize mcps and pass systems through', async () => {
+    it('should passthrough unified shape and add id alias from slug', async () => {
       request.$http.get.mockResolvedValue(mockOfficialAgentsResponse);
 
       const result = await AgentsTeam.listOfficialAgents({});
@@ -101,12 +101,13 @@ describe('AgentsTeam API', () => {
       expect(result.agents[0]).toMatchObject({
         uuid: 'agent-uuid-1',
         id: 'official-agent-1',
+        slug: 'official-agent-1',
         systems: ['system_a'],
         mcps: [
           expect.objectContaining({
             name: 'Default',
             system: 'system_a',
-            constants: [
+            config: [
               expect.objectContaining({ name: 'REQ_FIELD', is_required: true }),
             ],
           }),
@@ -116,28 +117,6 @@ describe('AgentsTeam API', () => {
         uuid: 'agent-uuid-2',
         id: 'official-agent-2',
         systems: ['system_b'],
-        mcps: [],
-      });
-    });
-
-    it('should default mcps and systems to empty arrays when missing', async () => {
-      request.$http.get.mockResolvedValue({
-        data: {
-          results: [
-            {
-              uuid: 'agent-uuid-3',
-              name: 'Official Agent 3',
-              slug: 'official-agent-3',
-            },
-          ],
-        },
-      });
-
-      const result = await AgentsTeam.listOfficialAgents({});
-
-      expect(result.agents[0]).toMatchObject({
-        id: 'official-agent-3',
-        systems: [],
         mcps: [],
       });
     });
@@ -230,46 +209,52 @@ describe('AgentsTeam API', () => {
         {
           uuid: 'my-agent-uuid-1',
           name: 'My Agent 1',
-          description: 'First personal agent',
-          skills: ['custom-skill1'],
-          assigned: true,
-          credentials: [{ name: 'ROOT_KEY', label: 'Should be ignored' }],
-          is_official: false,
           slug: 'my-agent-1',
-          mcp_definitions: {
-            config: [
-              {
-                name: 'country',
-                label: 'Country',
-                type: 'TEXT',
-                is_required: true,
-                default_value: 'BRA',
-                options: [],
-              },
-            ],
-            credentials: [
-              {
-                name: 'BASE_URL',
-                label: 'Base URL',
-                placeholder: 'https://example.com',
-                is_confidential: false,
-              },
-            ],
-          },
+          group: null,
+          about: { en: 'First personal agent', pt: null, es: null },
+          assigned: true,
+          active: false,
+          is_official: false,
+          category: null,
+          systems: ['custom-system'],
+          mcps: [
+            {
+              name: 'Default',
+              description: { en: 'Default MCP', pt: '', es: '' },
+              system: 'custom-system',
+              config: [
+                {
+                  name: 'country',
+                  label: 'Country',
+                  type: 'TEXT',
+                  is_required: true,
+                  default_value: 'BRA',
+                  options: [],
+                },
+              ],
+              credentials: [
+                {
+                  name: 'BASE_URL',
+                  label: 'Base URL',
+                  placeholder: 'https://example.com',
+                  is_confidential: false,
+                },
+              ],
+            },
+          ],
         },
         {
           uuid: 'my-agent-uuid-2',
           name: 'My Agent 2',
-          description: 'Second personal agent',
-          skills: ['custom-skill2', 'custom-skill3'],
-          assigned: false,
-          credentials: [],
-          is_official: false,
           slug: 'my-agent-2',
-          mcp_definitions: {
-            config: [],
-            credentials: [],
-          },
+          group: null,
+          about: { en: 'Second personal agent', pt: null, es: null },
+          assigned: false,
+          active: false,
+          is_official: false,
+          category: null,
+          systems: [],
+          mcps: [],
         },
       ],
     };
@@ -288,32 +273,8 @@ describe('AgentsTeam API', () => {
 
       expect(result.data).toHaveLength(2);
       expect(result.data[0]).toEqual({
-        uuid: 'my-agent-uuid-1',
-        name: 'My Agent 1',
-        about: null,
-        description: 'First personal agent',
-        skills: ['custom-skill1'],
-        assigned: true,
-        credentials: [
-          {
-            name: 'BASE_URL',
-            label: 'Base URL',
-            placeholder: 'https://example.com',
-            is_confidential: false,
-          },
-        ],
-        is_official: false,
+        ...mockMyAgentsResponse.data[0],
         id: 'my-agent-1',
-        constants: [
-          {
-            name: 'country',
-            label: 'Country',
-            type: 'TEXT',
-            is_required: true,
-            default_value: 'BRA',
-            options: [],
-          },
-        ],
       });
     });
 
@@ -336,7 +297,7 @@ describe('AgentsTeam API', () => {
       expect(result.data[0].name).toBe('My Agent 2');
     });
 
-    it('should transform personal agent data correctly', async () => {
+    it('should add id alias from slug for each agent', async () => {
       request.$http.get.mockResolvedValue(mockMyAgentsResponse);
 
       const result = await AgentsTeam.listMyAgents({});
@@ -345,29 +306,17 @@ describe('AgentsTeam API', () => {
         const originalAgent = mockMyAgentsResponse.data[index];
         expect(agent.uuid).toBe(originalAgent.uuid);
         expect(agent.name).toBe(originalAgent.name);
-        expect(agent.description).toBe(originalAgent.description);
-        expect(agent.skills).toEqual(originalAgent.skills);
-        expect(agent.assigned).toBe(originalAgent.assigned);
-        expect(agent.credentials).toEqual(
-          originalAgent.mcp_definitions.credentials,
-        );
         expect(agent.id).toBe(originalAgent.slug);
+        expect(agent.mcps).toEqual(originalAgent.mcps);
       });
     });
 
-    it('forces is_official to false even when the API returns true', async () => {
-      request.$http.get.mockResolvedValue({
-        data: [
-          {
-            ...mockMyAgentsResponse.data[0],
-            is_official: true,
-          },
-        ],
-      });
+    it('should return an empty array when data is missing', async () => {
+      request.$http.get.mockResolvedValue({ data: null });
 
       const result = await AgentsTeam.listMyAgents({});
 
-      expect(result.data[0].is_official).toBe(false);
+      expect(result.data).toEqual([]);
     });
 
     it('should handle API error', async () => {
@@ -391,20 +340,46 @@ describe('AgentsTeam API', () => {
           {
             uuid: 'active-agent-uuid-1',
             name: 'Active Agent 1',
-            skills: ['active-skill1'],
-            id: 'active-agent-1',
-            description: 'First active agent',
-            credentials: { type: 'active' },
+            slug: 'active-agent-1',
+            group: 'group-1',
+            about: { en: 'First active agent', pt: null, es: null },
+            assigned: true,
+            active: true,
             is_official: true,
+            category: null,
+            systems: ['vtex'],
+            mcps: [
+              {
+                name: 'Default',
+                description: { en: 'Default MCP', pt: '', es: '' },
+                system: 'vtex',
+                config: [
+                  {
+                    name: 'country',
+                    label: 'Country',
+                    type: 'TEXT',
+                    is_required: true,
+                    default_value: 'BRA',
+                    options: [],
+                    value: 'BRA',
+                  },
+                ],
+                credentials: [],
+              },
+            ],
           },
           {
             uuid: 'active-agent-uuid-2',
             name: 'Active Agent 2',
-            skills: ['active-skill2', 'active-skill3'],
-            id: 'active-agent-2',
-            description: 'Second active agent',
-            credentials: { type: 'custom' },
+            slug: 'active-agent-2',
+            group: null,
+            about: { en: 'Second active agent', pt: null, es: null },
+            assigned: true,
+            active: true,
             is_official: false,
+            category: null,
+            systems: [],
+            mcps: [],
           },
         ],
       },
@@ -425,15 +400,8 @@ describe('AgentsTeam API', () => {
 
       expect(result.data.agents).toHaveLength(2);
       expect(result.data.agents[0]).toEqual({
-        uuid: 'active-agent-uuid-1',
-        name: 'Active Agent 1',
-        skills: ['active-skill1'],
+        ...mockActiveTeamResponse.data.agents[0],
         id: 'active-agent-1',
-        about: null,
-        description: 'First active agent',
-        credentials: { type: 'active' },
-        is_official: true,
-        mcp: undefined,
       });
     });
 
@@ -471,21 +439,33 @@ describe('AgentsTeam API', () => {
       expect(result.data.agents).toEqual([]);
     });
 
-    it('should transform active team data correctly', async () => {
+    it('should add id alias from slug when id is missing', async () => {
+      const responseMissingId = {
+        data: {
+          manager: { id: 'manager-id' },
+          agents: [
+            {
+              ...mockActiveTeamResponse.data.agents[0],
+              id: undefined,
+            },
+          ],
+        },
+      };
+      request.$http.get.mockResolvedValue(responseMissingId);
+
+      const result = await AgentsTeam.listActiveTeam();
+
+      expect(result.data.agents[0].id).toBe('active-agent-1');
+    });
+
+    it('should preserve mcps array passthrough', async () => {
       request.$http.get.mockResolvedValue(mockActiveTeamResponse);
 
       const result = await AgentsTeam.listActiveTeam();
 
-      result.data.agents.forEach((agent, index) => {
-        const originalAgent = mockActiveTeamResponse.data.agents[index];
-        expect(agent.uuid).toBe(originalAgent.uuid);
-        expect(agent.name).toBe(originalAgent.name);
-        expect(agent.skills).toEqual(originalAgent.skills);
-        expect(agent.id).toBe(originalAgent.id);
-        expect(agent.description).toBe(originalAgent.description);
-        expect(agent.credentials).toEqual(originalAgent.credentials);
-        expect(agent.is_official).toBe(originalAgent.is_official);
-      });
+      expect(result.data.agents[0].mcps).toEqual(
+        mockActiveTeamResponse.data.agents[0].mcps,
+      );
     });
 
     it('should handle API error', async () => {
@@ -599,41 +579,6 @@ describe('AgentsTeam API', () => {
           assigned: true,
         }),
       ).rejects.toThrow('Failed to toggle agent assignment');
-    });
-  });
-
-  describe('Data transformation', () => {
-    it('should consistently transform agent data across all methods', () => {
-      const originalAgent = {
-        uuid: 'test-uuid',
-        name: 'Test Agent',
-        description: 'Test Description',
-        skills: ['test-skill'],
-        assigned: true,
-        credentials: { type: 'test' },
-        is_official: false,
-        slug: 'test-agent-slug',
-      };
-
-      const transformedAgent = {
-        uuid: originalAgent.uuid,
-        name: originalAgent.name,
-        description: originalAgent.description,
-        skills: originalAgent.skills,
-        assigned: originalAgent.assigned,
-        credentials: originalAgent.credentials,
-        is_official: originalAgent.is_official,
-        id: originalAgent.slug,
-      };
-
-      expect(transformedAgent.id).toBe(originalAgent.slug);
-      expect(transformedAgent.uuid).toBe(originalAgent.uuid);
-      expect(transformedAgent.name).toBe(originalAgent.name);
-      expect(transformedAgent.description).toBe(originalAgent.description);
-      expect(transformedAgent.skills).toEqual(originalAgent.skills);
-      expect(transformedAgent.assigned).toBe(originalAgent.assigned);
-      expect(transformedAgent.credentials).toEqual(originalAgent.credentials);
-      expect(transformedAgent.is_official).toBe(originalAgent.is_official);
     });
   });
 

--- a/src/components/AgentsTeam/AgentCard.vue
+++ b/src/components/AgentsTeam/AgentCard.vue
@@ -118,9 +118,7 @@ const props = defineProps({
 
 const translateField = useTranslatedField();
 
-const description = computed(() => {
-  return translateField(props.agent?.about) || props.agent.description;
-});
+const description = computed(() => translateField(props.agent?.about));
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/AgentsTeam/AgentModalHeader.vue
+++ b/src/components/AgentsTeam/AgentModalHeader.vue
@@ -25,10 +25,10 @@
 
 <script setup lang="ts">
 import AgentIcon from '@/components/AgentsTeam/AgentIcon.vue';
-import { Agent, AgentGroup } from '@/store/types/Agents.types';
+import { Agent } from '@/store/types/Agents.types';
 
 defineProps<{
-  agent: AgentGroup | Agent;
+  agent: Agent;
 }>();
 </script>
 

--- a/src/components/AgentsTeam/AssignAgents/AgentsList/Filters.vue
+++ b/src/components/AgentsTeam/AssignAgents/AgentsList/Filters.vue
@@ -23,18 +23,19 @@
   </section>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { debounce } from 'lodash';
 import { computed, watch } from 'vue';
 
 import i18n from '@/utils/plugins/i18n';
 
 import { useAgentsTeamStore } from '@/store/AgentsTeam';
+import type { AgentCategory } from '@/store/types/Agents.types';
 
 const agentsTeamStore = useAgentsTeamStore();
 
 const categoryOptions = computed(() => {
-  const createCategoryOption = (category) => ({
+  const createCategoryOption = (category: AgentCategory) => ({
     label: i18n.global.t(`agents.assign_agents.filters.category.${category}`),
     value: category,
   });

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/__tests__/index.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/__tests__/index.spec.js
@@ -7,7 +7,7 @@ import MCPStepContent from '../index.vue';
 const mcpWithConstants = {
   name: 'Search',
   description: 'Search products',
-  constants: [
+  config: [
     { name: 'apiKey', type: 'TEXT' },
     {
       name: 'region',
@@ -39,7 +39,7 @@ const mcpWithConstants = {
 const mcpWithoutConstants = {
   name: 'Inventory',
   description: 'Inventory manager',
-  constants: [],
+  config: [],
 };
 
 const MCPs = [mcpWithConstants, mcpWithoutConstants];

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/MCPStepContent/index.vue
@@ -85,7 +85,7 @@ const selectedMCPConstantsValues = defineModel<Record<string, ConstantValue>>(
   },
 );
 const selectedMCPConstants = computed<AgentConstantField[]>(() => {
-  return selectedMCP.value?.constants ?? [];
+  return selectedMCP.value?.config ?? [];
 });
 
 watch(
@@ -105,7 +105,7 @@ watch(
     if (Object.keys(selectedMCPConstantsValues.value || {}).length) {
       return;
     }
-    selectedMCPConstantsValues.value = buildInitialValues(next.constants);
+    selectedMCPConstantsValues.value = buildInitialValues(next.config);
   },
   { immediate: true },
 );
@@ -113,7 +113,7 @@ watch(
 function handleSelectMCP(MCP: AgentMCP, checked: boolean) {
   if (!checked) return;
   selectedMCP.value = MCP;
-  selectedMCPConstantsValues.value = buildInitialValues(MCP.constants);
+  selectedMCPConstantsValues.value = buildInitialValues(MCP.config);
 }
 
 function buildInitialValues(constants: AgentConstantField[] = []) {

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/About.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/About.vue
@@ -52,7 +52,7 @@ import { computed } from 'vue';
 import Skill from '@/components/AgentsTeam/Skill.vue';
 import useAgentSystems from '@/composables/useAgentSystems';
 import useTranslatedField from '@/composables/useTranslatedField';
-import type { Agent, AgentGroup } from '@/store/types/Agents.types';
+import type { Agent } from '@/store/types/Agents.types';
 
 const GROUP_DOCS: Record<string, string> = {
   ORDER_PAYMENT: '/docs/Payment_Agent.pdf',
@@ -64,7 +64,7 @@ const GROUP_DOCS: Record<string, string> = {
 };
 
 const props = defineProps<{
-  agent: AgentGroup | Agent;
+  agent: Agent;
 }>();
 
 type SystemBadge = {
@@ -76,19 +76,15 @@ const { getSystemsObjects } = useAgentSystems();
 const translateField = useTranslatedField();
 
 const documentationUrl = computed(() => {
-  const group = (props.agent as AgentGroup).group;
+  const group = props.agent.group;
   if (!group) return null;
   return GROUP_DOCS[group.toUpperCase()] ?? null;
 });
 
-const aboutDescription = computed(() => {
-  return (
-    translateField(props.agent.about) ?? (props.agent as Agent).description
-  );
-});
+const aboutDescription = computed(() => translateField(props.agent.about));
 
 const systemBadges = computed<SystemBadge[]>(() => {
-  const agentSystems = (props.agent as AgentGroup).systems ?? [];
+  const agentSystems = props.agent.systems ?? [];
   const systems = getSystemsObjects(agentSystems) || [];
 
   return systems.map((system) => ({

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/index.vue
@@ -32,7 +32,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
-import type { Agent, AgentGroup } from '@/store/types/Agents.types';
+import type { Agent } from '@/store/types/Agents.types';
 import useTranslatedField from '@/composables/useTranslatedField';
 
 import About from './About.vue';
@@ -40,17 +40,16 @@ import MCPs from './MCPs.vue';
 import ConversationExample from './ConversationExample.vue';
 
 const props = defineProps<{
-  agent: AgentGroup | Agent;
+  agent: Agent;
 }>();
 
 const translateField = useTranslatedField();
 
-const conversationExample = computed(() => {
-  const conversation = (props.agent as AgentGroup).conversation_example;
-  return translateField(conversation) ?? [];
-});
+const conversationExample = computed(
+  () => translateField(props.agent.conversation_example) ?? [],
+);
 
-const agentMCPs = computed(() => (props.agent as AgentGroup).mcps ?? []);
+const agentMCPs = computed(() => props.agent.mcps ?? []);
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/index.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/__tests__/index.spec.js
@@ -31,7 +31,7 @@ const officialAgentFixture = {
       description: 'VTEX integration',
       system: 'VTEX',
       credentials: [{ name: 'token', label: 'API Token' }],
-      constants: [],
+      config: [],
     },
   ],
 };
@@ -40,28 +40,49 @@ const customAgentFixture = {
   uuid: 'custom-agent-uuid',
   name: 'Custom Agent',
   is_official: false,
-  constants: [
-    { name: 'country', label: 'Country', type: 'TEXT', is_required: true },
+  mcps: [
+    {
+      name: 'Default',
+      description: { en: '', pt: '', es: '' },
+      system: 'custom',
+      config: [
+        { name: 'country', label: 'Country', type: 'TEXT', is_required: true },
+      ],
+      credentials: [{ name: 'api_key', label: 'API Key' }],
+    },
   ],
-  credentials: [{ name: 'api_key', label: 'API Key' }],
 };
 
 const customAgentOnlyConstantsFixture = {
   uuid: 'custom-agent-only-constants',
   name: 'Constants Only Agent',
   is_official: false,
-  constants: [
-    { name: 'country', label: 'Country', type: 'TEXT', is_required: true },
+  mcps: [
+    {
+      name: 'Default',
+      description: { en: '', pt: '', es: '' },
+      system: 'custom',
+      config: [
+        { name: 'country', label: 'Country', type: 'TEXT', is_required: true },
+      ],
+      credentials: [],
+    },
   ],
-  credentials: [],
 };
 
 const customAgentOnlyCredentialsFixture = {
   uuid: 'custom-agent-only-credentials',
   name: 'Credentials Only Agent',
   is_official: false,
-  constants: [],
-  credentials: [{ name: 'api_key', label: 'API Key' }],
+  mcps: [
+    {
+      name: 'Default',
+      description: { en: '', pt: '', es: '' },
+      system: 'custom',
+      config: [],
+      credentials: [{ name: 'api_key', label: 'API Key' }],
+    },
+  ],
 };
 
 const createOfficialAssignmentState = () => ({
@@ -81,7 +102,7 @@ const mockMCPWithCredentials = {
   description: 'VTEX integration',
   system: 'VTEX',
   credentials: [{ name: 'token', label: 'API Token' }],
-  constants: [],
+  config: [],
 };
 
 const createCustomAssignmentState = () => ({

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
@@ -46,7 +46,6 @@ import {
   Agent,
   AgentConstantField,
   AgentCredential,
-  AgentGroup,
   AgentMCP,
 } from '@/store/types/Agents.types';
 
@@ -68,7 +67,7 @@ import CustomCredentialsStepContent from './CustomCredentialsStepContent.vue';
 const emit = defineEmits(['update:open']);
 
 const props = defineProps<{
-  agent: AgentGroup | Agent;
+  agent: Agent;
 }>();
 
 defineModel('open', {
@@ -88,8 +87,15 @@ type StepKey = (typeof Step)[keyof typeof Step];
 const stepIndex = ref<number>(1);
 const isOfficial = computed(() => Boolean(props.agent?.is_official));
 
-const officialAgent = computed(() => props.agent as AgentGroup);
-const customAgent = computed(() => props.agent as Agent);
+const officialAgent = computed(() => props.agent);
+const customAgent = computed(() => props.agent);
+
+const customAgentConstants = computed(
+  () => customAgent.value.mcps?.[0]?.config ?? [],
+);
+const customAgentCredentials = computed(
+  () => customAgent.value.mcps?.[0]?.credentials ?? [],
+);
 
 const hasSystems = computed(() => {
   if (!isOfficial.value) return false;
@@ -109,8 +115,8 @@ const stepSequence = computed<StepKey[]>(() => {
       : [Step.MCP, Step.Credentials];
   }
   const steps: StepKey[] = [];
-  if (customAgent.value.constants?.length) steps.push(Step.Constants);
-  if (customAgent.value.credentials?.length) steps.push(Step.CustomCredentials);
+  if (customAgentConstants.value.length) steps.push(Step.Constants);
+  if (customAgentCredentials.value.length) steps.push(Step.CustomCredentials);
   return steps;
 });
 
@@ -186,14 +192,14 @@ const currentStepProps = computed(() => {
     },
     [Step.Constants]: {
       agentName: customAgent.value.name,
-      constants: customAgent.value.constants ?? [],
+      constants: customAgentConstants.value,
       constantsValues: customConfig.value.constants,
       'onUpdate:constantsValues': (nextValues: ConstantsValues) => {
         customConfig.value.constants = nextValues;
       },
     },
     [Step.CustomCredentials]: {
-      credentials: customAgent.value.credentials ?? [],
+      credentials: customAgentCredentials.value,
       credentialValues: customConfig.value.credentials,
       'onUpdate:credentialValues': (nextValues: Record<string, string>) => {
         customConfig.value.credentials = nextValues;
@@ -232,7 +238,7 @@ const isNextDisabled = computed(() => {
     [Step.MCP]: () =>
       !officialConfig.value.MCP ||
       isSomeRequiredFieldMissing(
-        officialConfig.value.MCP?.constants,
+        officialConfig.value.MCP?.config,
         officialConfig.value.mcp_config,
       ),
     [Step.Credentials]: () =>
@@ -242,12 +248,12 @@ const isNextDisabled = computed(() => {
       ) || isSubmitting.value,
     [Step.Constants]: () =>
       isSomeRequiredFieldMissing(
-        customAgent.value.constants,
+        customAgentConstants.value,
         customConfig.value.constants,
       ),
     [Step.CustomCredentials]: () =>
       !areAllCredentialsFilled(
-        customAgent.value.credentials,
+        customAgentCredentials.value,
         customConfig.value.credentials,
       ) || isSubmitting.value,
   };

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/__tests__/index.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/__tests__/index.spec.js
@@ -20,7 +20,7 @@ const conciergeAgent = {
       description: { en: 'desc', pt: null, es: null },
       system: 'vtex',
       config: [],
-      credentials: [],
+      credentials: [{ name: 'token', label: 'API Token' }],
     },
   ],
   systems: ['vtex'],

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/__tests__/index.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/__tests__/index.spec.js
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
 import { nextTick } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
@@ -19,7 +19,7 @@ const conciergeAgent = {
       name: 'Default',
       description: { en: 'desc', pt: null, es: null },
       system: 'vtex',
-      constants: [],
+      config: [],
       credentials: [],
     },
   ],

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/index.vue
@@ -44,7 +44,7 @@ import { computed, ref } from 'vue';
 
 import { useI18n } from 'vue-i18n';
 
-import { Agent, AgentGroup } from '@/store/types/Agents.types';
+import { Agent } from '@/store/types/Agents.types';
 
 import AgentModalHeader from '@/components/AgentsTeam/AgentModalHeader.vue';
 import ModalAssignAgentGroupStartSetup from './Group/StartSetup/index.vue';
@@ -56,7 +56,7 @@ const { t } = useI18n();
 const emit = defineEmits(['update:open']);
 
 const props = defineProps<{
-  agent: AgentGroup | Agent;
+  agent: Agent;
 }>();
 
 const open = defineModel('open', {
@@ -70,13 +70,14 @@ const isConfiguringAgentGroup = ref<boolean>(false);
 const isAssigning = ref(false);
 
 const agentHasSetupSteps = computed(() => {
-  if (props.agent.is_official) {
-    const { mcps } = props.agent as AgentGroup;
-    return (mcps?.length ?? 0) > 0;
-  }
+  const mcps = props.agent.mcps ?? [];
+  if (mcps.length > 1) return true;
 
-  const { constants, credentials } = props.agent as Agent;
-  return (constants?.length ?? 0) > 0 || (credentials?.length ?? 0) > 0;
+  const firstMCP = mcps[0];
+  return (
+    (firstMCP?.config?.length ?? 0) > 0 ||
+    (firstMCP?.credentials?.length ?? 0) > 0
+  );
 });
 
 const footerButtonText = computed(() => {
@@ -98,17 +99,11 @@ async function assignAgent() {
   isAssigning.value = true;
 
   try {
-    if (props.agent.is_official) {
-      await agentsTeamStore.toggleAgentAssignment({
-        group: (props.agent as AgentGroup).group,
-        is_assigned: true,
-      });
-    } else {
-      await agentsTeamStore.toggleAgentAssignment({
-        uuid: (props.agent as Agent).uuid,
-        is_assigned: true,
-      });
-    }
+    await agentsTeamStore.toggleAgentAssignment({
+      uuid: props.agent.uuid,
+      group: props.agent.group,
+      is_assigned: true,
+    });
     closeAgentModal();
   } finally {
     isAssigning.value = false;

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/McpSection.vue
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/McpSection.vue
@@ -62,7 +62,7 @@ const mcpTitle = computed(() => props.mcp.name || '');
 const mcpDescription = computed(() => translateField(props.mcp.description));
 
 const mcpArguments = computed(() => {
-  const constantsEntries = props.mcp.config ?? [];
+  const constantsEntries = props.mcp.config;
   return constantsEntries
     .filter((field) => !isValueEmpty(field.value ?? null))
     .map((field) => ({

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/McpSection.vue
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/McpSection.vue
@@ -20,7 +20,7 @@
       </header>
 
       <section
-        v-if="mcpArguments.length"
+        v-if="mcpArguments?.length"
         class="agent-detail-modal__mcp-arguments"
       >
         <p
@@ -62,7 +62,7 @@ const mcpTitle = computed(() => props.mcp.name || '');
 const mcpDescription = computed(() => translateField(props.mcp.description));
 
 const mcpArguments = computed(() => {
-  const constantsEntries = props.mcp.config;
+  const constantsEntries = props.mcp.config ?? [];
   return constantsEntries
     .filter((field) => !isValueEmpty(field.value ?? null))
     .map((field) => ({

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/McpSection.vue
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/McpSection.vue
@@ -48,28 +48,26 @@ import { formatListToReadable } from '@/utils/formatters';
 import useTranslatedField from '@/composables/useTranslatedField';
 
 import type {
-  AgentAssignedMCP,
+  AgentMCP,
   AgentAssignedConstantValue,
 } from '@/store/types/Agents.types';
 
 const props = defineProps<{
-  mcp: AgentAssignedMCP;
+  mcp: AgentMCP;
 }>();
 
 const translateField = useTranslatedField();
 
 const mcpTitle = computed(() => props.mcp.name || '');
-const mcpDescription = computed(
-  () => translateField(props.mcp.description) ?? props.mcp.description,
-);
+const mcpDescription = computed(() => translateField(props.mcp.description));
 
 const mcpArguments = computed(() => {
-  const constantsEntries = props.mcp.constants || {};
-  return Object.entries(constantsEntries)
-    .filter(([_label, value]) => !isValueEmpty(value))
-    .map(([label, value]) => ({
-      label,
-      value: formatValue(value),
+  const constantsEntries = props.mcp.config;
+  return constantsEntries
+    .filter((field) => !isValueEmpty(field.value ?? null))
+    .map((field) => ({
+      label: field.label,
+      value: formatValue(field.value ?? null),
     }));
 });
 

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/SystemSection.vue
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/SystemSection.vue
@@ -15,10 +15,9 @@
 <script setup lang="ts">
 import Skill from '@/components/AgentsTeam/Skill.vue';
 import AgentDetailSection from './AgentDetailSection.vue';
-import type { AgentAssignedSystem } from '@/store/types/Agents.types';
 
 defineProps<{
-  system: AgentAssignedSystem;
+  system: { name: string; slug: string; icon?: string };
 }>();
 </script>
 

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/ViewOptions.vue
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/ViewOptions.vue
@@ -46,10 +46,10 @@
 import { ref } from 'vue';
 
 import { useAgentsTeamStore } from '@/store/AgentsTeam';
-import type { ActiveTeamAgent } from '@/store/types/Agents.types';
+import type { Agent } from '@/store/types/Agents.types';
 
 const props = defineProps<{
-  agent: ActiveTeamAgent;
+  agent: Agent;
 }>();
 
 const emit = defineEmits<{

--- a/src/components/AgentsTeam/__tests__/AssignAgentCard.spec.js
+++ b/src/components/AgentsTeam/__tests__/AssignAgentCard.spec.js
@@ -48,7 +48,7 @@ describe('AssignAgentCard.vue', () => {
         loading: false,
         agent: {
           name: 'Test Title',
-          description: 'Test Description',
+          about: { en: 'Test Description', pt: null, es: null },
           skills: [
             { name: 'Skill 1', icon: 'icon-1' },
             { name: 'Skill 2', icon: 'icon-2' },

--- a/src/composables/__tests__/useCustomAgentAssignment.spec.ts
+++ b/src/composables/__tests__/useCustomAgentAssignment.spec.ts
@@ -48,11 +48,18 @@ const buildAgent = (overrides = {}) => ({
   uuid: 'custom-uuid',
   name: 'Custom Agent',
   is_official: false,
-  credentials: [
-    { name: 'api_key', label: 'API Key', is_confidential: true },
-    { name: 'base_url', label: 'Base URL', is_confidential: false },
+  mcps: [
+    {
+      name: 'Default',
+      description: { en: '', pt: '', es: '' },
+      system: 'custom',
+      config: [],
+      credentials: [
+        { name: 'api_key', label: 'API Key', is_confidential: true },
+        { name: 'base_url', label: 'Base URL', is_confidential: false },
+      ],
+    },
   ],
-  constants: [],
   ...overrides,
 });
 
@@ -159,7 +166,19 @@ describe('useCustomAgentAssignment', () => {
     nexusaiAPI.router.agents_team.toggleAgentAssignment.mockResolvedValue({
       data: {},
     });
-    const agent = ref(buildAgent({ credentials: [] }));
+    const agent = ref(
+      buildAgent({
+        mcps: [
+          {
+            name: 'Default',
+            description: { en: '', pt: '', es: '' },
+            system: 'custom',
+            config: [],
+            credentials: [],
+          },
+        ],
+      }),
+    );
     const { submitAssignment } = useCustomAgentAssignment(agent);
 
     await submitAssignment();

--- a/src/composables/useAgent.ts
+++ b/src/composables/useAgent.ts
@@ -1,34 +1,11 @@
-import { Agent, AgentGroup, ActiveTeamAgent } from '@/store/types/Agents.types';
+import { Agent } from '@/store/types/Agents.types';
 import agentIconService from '@/utils/agentIconService';
-import useAgentSystems from './useAgentSystems';
 
 export default function useAgent() {
-  const { getSystemObject } = useAgentSystems();
-
-  function normalizeActiveAgent(agent: AgentGroup | Agent): ActiveTeamAgent {
-    const systemName =
-      'systems' in agent
-        ? (agent as AgentGroup).systems[0]
-        : agent.mcp?.system?.name;
-
+  function normalizeActiveAgent(agent: Agent): Agent {
     return {
-      uuid: (agent as Agent).uuid || '',
-      id: (agent as Agent).id || (agent as Agent).slug || '',
-      name: agent.name || '',
-      is_official: agent.is_official || false,
-      about: agent.about ?? null,
-      description: (agent as Agent).description || '',
-      group: 'group' in agent ? (agent.group as string) : undefined,
-      mcp:
-        'mcp' in agent && agent.mcp
-          ? {
-              name: agent.mcp?.name || '',
-              constants: agent.mcp?.constants || {},
-              description:
-                'description' in agent.mcp ? agent.mcp?.description : null,
-              system: getSystemObject(systemName),
-            }
-          : null,
+      ...agent,
+      id: agent.id || agent.slug || '',
       icon: agentIconService.getIconForAgent(agent),
     };
   }

--- a/src/composables/useCustomAgentAssignment.ts
+++ b/src/composables/useCustomAgentAssignment.ts
@@ -39,11 +39,12 @@ export default function useCustomAgentAssignment(agent: Ref<Agent>) {
   }
 
   function buildCredentialsPayload(): CredentialPayload[] {
-    if (!agent.value?.credentials?.length) {
+    const credentials = agent.value?.mcps?.[0]?.credentials ?? [];
+    if (!credentials.length) {
       return [];
     }
 
-    return agent.value.credentials.map((credential) => ({
+    return credentials.map((credential) => ({
       ...credential,
       value: config.value.credentials[credential.name] ?? '',
     }));

--- a/src/composables/useOfficialAgentAssignment.ts
+++ b/src/composables/useOfficialAgentAssignment.ts
@@ -1,8 +1,8 @@
 import { ref, watch, type Ref } from 'vue';
 
 import {
+  Agent,
   AgentCredential,
-  AgentGroup,
   AgentMCP,
 } from '@/store/types/Agents.types';
 
@@ -10,7 +10,6 @@ import nexusaiAPI from '@/api/nexusaiAPI';
 import { unnnicToastManager } from '@weni/unnnic-system';
 import i18n from '@/utils/plugins/i18n';
 import { useAgentsTeamStore } from '@/store/AgentsTeam';
-import useTranslatedField from './useTranslatedField';
 
 export type MCPConfigValues = Record<string, string | string[] | boolean>;
 
@@ -21,12 +20,11 @@ export type ConciergeAssignmentConfig = {
   credentials: Record<string, string>;
 };
 
-export default function useOfficialAgentAssignment(agent: Ref<AgentGroup>) {
+export default function useOfficialAgentAssignment(agent: Ref<Agent>) {
   const config = ref<ConciergeAssignmentConfig>(
     createInitialConfig() as ConciergeAssignmentConfig,
   );
   const agentsTeamStore = useAgentsTeamStore();
-  const translateField = useTranslatedField();
 
   const isSubmitting = ref(false);
   const hasVTEXSystem = agent.value?.systems?.some(
@@ -99,27 +97,26 @@ export default function useOfficialAgentAssignment(agent: Ref<AgentGroup>) {
       const { data } =
         await nexusaiAPI.router.agents_team.toggleAgentAssignment(payload);
 
-      const constantsWithLabels = Object.fromEntries(
-        Object.entries(config.value.mcp_config).map(([key, value]) => {
-          const label =
-            config.value.MCP?.constants.find((field) => field.name === key)
-              ?.label || key;
-          return [label, value];
-        }),
-      );
+      const selectedMCP = config.value.MCP;
+      const assignedConfig = (selectedMCP?.config ?? []).map((field) => ({
+        ...field,
+        value: config.value.mcp_config[field.name] ?? null,
+      }));
 
-      const normalizedAgent = {
+      const assignedMCP: AgentMCP = {
+        name: selectedMCP?.name ?? '',
+        description: selectedMCP?.description ?? { en: '', pt: '', es: '' },
+        system: config.value.system,
+        credentials: selectedMCP?.credentials ?? [],
+        config: assignedConfig,
+      };
+
+      const normalizedAgent: Agent = {
         ...agent.value,
         uuid: data.agent.uuid,
         id: data.agent.slug,
         systems: [config.value.system],
-        description:
-          translateField(agent.value.about) ?? data.agent.description,
-        mcp: {
-          name: config.value.MCP?.name || '',
-          description: config.value.MCP?.description || '',
-          constants: constantsWithLabels,
-        },
+        mcps: [assignedMCP],
       };
 
       agentsTeamStore.addAgentToTeam(normalizedAgent);

--- a/src/store/AgentsTeam.ts
+++ b/src/store/AgentsTeam.ts
@@ -10,13 +10,7 @@ import { unnnicToastManager } from '@weni/unnnic-system';
 
 import i18n from '@/utils/plugins/i18n';
 
-import {
-  Agent,
-  ActiveTeamAgent,
-  AgentGroupOrAgent,
-  AgentSystem,
-  AssignAgentsFilters,
-} from './types/Agents.types';
+import { Agent, AgentSystem, AssignAgentsFilters } from './types/Agents.types';
 import useAgent from '@/composables/useAgent';
 
 export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
@@ -58,9 +52,9 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
     };
   });
 
-  const newAgentAssigned = ref<ActiveTeamAgent | null>(null);
+  const newAgentAssigned = ref<Agent | null>(null);
 
-  function addAgentToTeam(agent: AgentGroupOrAgent) {
+  function addAgentToTeam(agent: Agent) {
     const normalizedAgent = normalizeActiveAgent(agent);
 
     activeTeam.data.agents.push(normalizedAgent);
@@ -176,7 +170,7 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
     group,
     is_assigned,
   }: {
-    uuid?: string;
+    uuid?: string | null;
     group?: string | null;
     is_assigned: boolean;
   }) {

--- a/src/store/AgentsTeam.ts
+++ b/src/store/AgentsTeam.ts
@@ -190,8 +190,7 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
         (agent) => agent.uuid === uuid,
       );
 
-      const listedAgent = foundOfficialAgent || foundMyAgent;
-      const agent = foundActiveTeamAgent || listedAgent;
+      const agent = foundActiveTeamAgent || foundOfficialAgent || foundMyAgent;
 
       if (!agent) {
         throw new Error('Agent not found');
@@ -202,7 +201,8 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
         assigned: is_assigned,
       });
 
-      if (listedAgent) listedAgent.assigned = is_assigned;
+      if (foundOfficialAgent) foundOfficialAgent.assigned = is_assigned;
+      if (foundMyAgent) foundMyAgent.assigned = is_assigned;
 
       if (is_assigned) {
         addAgentToTeam(agent);

--- a/src/store/types/Agents.types.ts
+++ b/src/store/types/Agents.types.ts
@@ -1,19 +1,20 @@
 import type { TranslatedField } from '@/composables/useTranslatedField';
 
-export type AgentCategory = 'PRODUCT_DISCOVERY_AND_RECOMMENDATIONS';
+export type AgentCategory =
+  | 'product_discovery_and_recommendations'
+  | 'orders_status_and_tracking'
+  | 'returns_exchanges_and_cancellations'
+  | 'payments_and_checkout'
+  | 'crm_and_lead_capture'
+  | 'feedback_and_surveys'
+  | 'utilities_and_monitoring'
+  | 'others';
 
 export type AgentSystem = {
   slug: string;
   name: string;
   logo: string | null;
 };
-
-export interface AgentSkill {
-  icon?: string;
-  name: string;
-  agent: string;
-  unique_name: string;
-}
 
 export interface AgentCredential {
   name: string;
@@ -28,31 +29,6 @@ export type AgentAssignedConstantValue =
   | number
   | string[]
   | null;
-
-export interface AgentAssignedSystem {
-  name: string;
-  slug: string;
-  icon: string;
-}
-
-export interface AgentAssignedMCP {
-  name: string;
-  description: TranslatedField<string>;
-  constants?: Record<string, AgentAssignedConstantValue>;
-  system?: AgentAssignedSystem;
-}
-
-export interface ActiveTeamAgent {
-  group?: string;
-  uuid: string;
-  id: string;
-  name: string;
-  is_official: boolean;
-  about: TranslatedField<string> | null;
-  description: string;
-  mcp: AgentAssignedMCP | null;
-  icon: string;
-}
 
 export type ConversationMessage = {
   direction: 'incoming' | 'outgoing';
@@ -78,6 +54,7 @@ export interface AgentConstantField {
         value: string;
       }[]
     | [];
+  value?: AgentAssignedConstantValue;
 }
 
 export interface AgentMCP {
@@ -85,43 +62,25 @@ export interface AgentMCP {
   description: TranslatedField<string>;
   system: string;
   credentials?: AgentCredential[];
-  constants: AgentConstantField[];
-}
-
-export interface AgentGroup {
-  name: string;
-  category: AgentCategory | null;
-  group: string | null;
-  uuid: string | null;
-  slug: string | null;
-  active: boolean | null;
-  about: TranslatedField<string>;
-  conversation_example?: TranslatedField<ConversationMessage[]>;
-  mcps: AgentMCP[];
-  systems: string[];
-  assigned: boolean;
-  icon: string;
-  is_official: true;
+  config: AgentConstantField[];
 }
 
 export interface Agent {
-  uuid: string;
-  id?: string;
+  group: string | null;
   name: string;
+  slug: string | null;
+  uuid: string | null;
   about: TranslatedField<string> | null;
-  description: string;
-  skills: AgentSkill[];
   assigned: boolean;
-  slug: string;
+  active: boolean | null;
   is_official: boolean;
-  credentials: AgentCredential[] | [];
-  constants?: AgentConstantField[];
+  category: AgentCategory | null;
+  systems: string[] | null;
+  mcps: AgentMCP[] | null;
+  conversation_example?: TranslatedField<ConversationMessage[]> | null;
   icon: string;
-  group?: AgentGroup | null;
-  mcp?: AgentAssignedMCP | null;
+  id?: string;
 }
-
-export type AgentGroupOrAgent = AgentGroup | Agent;
 
 type SelectOption = {
   label: string;


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To support the restructuring of endpoint return formats in the backend, standardizing a single format for official, customized, and team agents, this separation in the frontend/webapp code was no longer necessary.

### Summary of Changes
<!--- Describe your changes in detail -->
- Removed the `normalizeMCPs` function and adjusted agent mapping to directly handle MCPs and systems.
- Simplified agent assignment logic by standardizing the agent structure in various components.
- Enhanced unit tests to reflect changes in agent data handling and ensure proper functionality.