### PR TITLE
refactor: Simplify agent name handling in Preview components

### DIFF
--- a/src/components/Preview/PreviewLogs.vue
+++ b/src/components/Preview/PreviewLogs.vue
@@ -95,7 +95,6 @@
 <script setup>
 import { ref, onMounted, nextTick, computed, watch } from 'vue';
 
-import { useAgentsTeamStore } from '@/store/AgentsTeam';
 import PreviewLogsDetailsModal from './PreviewLogsDetailsModal.vue';
 
 const emit = defineEmits(['scroll-to-bottom']);
@@ -112,16 +111,7 @@ const props = defineProps({
       return ['left', 'right'].includes(value);
     },
   },
-  agents: {
-    type: Object,
-    default: () => ({
-      agents: [],
-      manager: {},
-    }),
-  },
 });
-
-const agentsTeamStore = useAgentsTeamStore();
 
 const showDetailsModal = ref(false);
 const selectedLog = ref({
@@ -130,41 +120,18 @@ const selectedLog = ref({
 });
 
 const processedLogs = computed(() => {
-  const teamData = props.agents.agents?.length
-    ? props.agents
-    : agentsTeamStore.activeTeam?.data;
+  return props.logs.reduce((logsByAgent, log) => {
+    const agentName = log.config?.agentName ?? '';
+    if (!agentName) return logsByAgent;
 
-  const teamAgents = teamData?.agents || [];
-  const galleryAgents = agentsTeamStore.allAgents?.agents || [];
-  const manager = teamData?.manager || agentsTeamStore.allAgents?.manager;
+    const agentLabel = agentName === 'manager' ? 'Manager' : agentName;
+    const lastEntry = logsByAgent.at(-1);
 
-  if (!manager && !teamAgents.length && !galleryAgents.length) return [];
-
-  const logs = props.logs;
-
-  return logs.reduce((logsByAgent, log) => {
-    const { agentName = '' } = log.config || {};
-
-    const foundAgent =
-      teamAgents.find((a) => a.id === agentName) ||
-      galleryAgents.find((a) => a.id === agentName);
-
-    if (!foundAgent && !agentName) return logsByAgent;
-
-    const agentId = foundAgent?.id || agentName;
-    const agentLabel =
-      foundAgent?.name || (agentName === 'manager' ? 'Manager' : agentName);
-
-    const lastLog = logsByAgent.at(-1);
-    if (lastLog?.id !== agentId) {
-      logsByAgent.push({
-        id: agentId,
-        agent: agentLabel,
-        steps: [],
-      });
+    if (lastEntry?.agent !== agentLabel) {
+      logsByAgent.push({ agent: agentLabel, steps: [] });
     }
 
-    logsByAgent.at(-1)?.steps.push({
+    logsByAgent.at(-1).steps.push({
       title: getLogSummary(log) || 'Unknown',
       log,
     });

--- a/src/components/Preview/PreviewLogsSection.vue
+++ b/src/components/Preview/PreviewLogsSection.vue
@@ -23,7 +23,6 @@
       v-else
       data-testid="preview-logs"
       :logs="filteredLogs"
-      :agents="agentsTeamStore.activeTeam.data"
       @scroll-to-bottom="$emit('scroll-to-bottom')"
     />
   </section>
@@ -35,9 +34,6 @@ import { ref, onMounted, watch, computed } from 'vue';
 import PreviewLogs from '@/components/Preview/PreviewLogs.vue';
 import PreviewLogsFilters from '@/components/Preview/PreviewLogsFilters.vue';
 import { usePreviewStore } from '@/store/Preview';
-import { useAgentsTeamStore } from '@/store/AgentsTeam';
-
-const agentsTeamStore = useAgentsTeamStore();
 
 const previewStore = usePreviewStore();
 const logs = computed(() => previewStore.collaboratorsLogs);

--- a/src/components/Preview/PreviewVisualFlow.vue
+++ b/src/components/Preview/PreviewVisualFlow.vue
@@ -24,7 +24,7 @@
       :height="visualFlowHeight"
       :startY="managerRef?.$el.getBoundingClientRect().height"
       :coloredLineIndex="
-        teamAgents?.findIndex((agent) => agent.id === activeAgent?.id)
+        teamAgents?.findIndex((agent) => agent.name === activeAgent?.name)
       "
     />
 
@@ -98,7 +98,7 @@ const branchPositions = computed(() => {
 });
 
 function isActiveAgent(agent) {
-  return agent?.id === activeAgent.value?.id;
+  return agent?.name === activeAgent.value?.name;
 }
 
 const visualFlowHeight = ref(0);

--- a/src/components/Preview/__tests__/PreviewLogs.spec.js
+++ b/src/components/Preview/__tests__/PreviewLogs.spec.js
@@ -5,17 +5,6 @@ import { nextTick } from 'vue';
 
 import PreviewLogs from '../PreviewLogs.vue';
 
-import { usePreviewStore } from '@/store/Preview';
-import { useAgentsTeamStore } from '@/store/AgentsTeam';
-
-const mockAllAgents = {
-  agents: [
-    { id: 'agent-1', name: 'Test Agent 1' },
-    { id: 'agent-2', name: 'Test Agent 2' },
-  ],
-  manager: { id: 'manager', name: 'Manager' },
-};
-
 const mockLogs = [
   {
     type: 'trace_update',
@@ -23,7 +12,7 @@ const mockLogs = [
       trace: {},
     },
     config: {
-      agentName: 'agent-1',
+      agentName: 'Test Agent 1',
       icon: 'icon-1',
       summary: 'First trace summary',
     },
@@ -32,7 +21,7 @@ const mockLogs = [
     type: 'trace_update',
     data: null,
     config: {
-      agentName: 'agent-1',
+      agentName: 'Test Agent 1',
       icon: 'icon-2',
       summary: 'Second trace summary',
     },
@@ -48,13 +37,7 @@ const mockLogs = [
 ];
 
 const createWrapper = (props = {}) => {
-  const pinia = createTestingPinia({
-    initialState: {
-      preview: {
-        logs: [...mockLogs],
-      },
-    },
-  });
+  const pinia = createTestingPinia();
 
   return mount(PreviewLogs, {
     props: {
@@ -75,8 +58,6 @@ const createWrapper = (props = {}) => {
 
 describe('PreviewLogs.vue', () => {
   let wrapper;
-  let previewStore;
-  let agentsTeamStore;
 
   const previewLogs = () => wrapper.find('[data-testid="preview-logs"]');
   const emptyMessage = () => wrapper.find('[data-testid="preview-logs-empty"]');
@@ -104,9 +85,6 @@ describe('PreviewLogs.vue', () => {
     }));
 
     wrapper = createWrapper();
-    previewStore = usePreviewStore();
-    agentsTeamStore = useAgentsTeamStore();
-    agentsTeamStore.allAgents = mockAllAgents;
   });
 
   afterEach(() => {
@@ -164,31 +142,6 @@ describe('PreviewLogs.vue', () => {
       await wrapper.setProps({ logsSide: 'right' });
       expect(previewLogs().classes()).toContain('preview-logs--right');
     });
-
-    it('uses provided agents prop when available', async () => {
-      const customAgents = {
-        agents: [{ id: 'custom-agent', name: 'Custom Agent' }],
-        manager: { id: 'custom-manager', name: 'Custom Manager' },
-      };
-
-      const customLogs = [
-        {
-          type: 'trace_update',
-          data: null,
-          config: {
-            agentName: 'custom-agent',
-            summary: 'Custom agent trace',
-          },
-        },
-      ];
-
-      await wrapper.setProps({
-        agents: customAgents,
-        logs: customLogs,
-      });
-
-      expect(logAgentNames().at(0).text()).toBe('Custom Agent');
-    });
   });
 
   describe('Logs processing', () => {
@@ -208,14 +161,14 @@ describe('PreviewLogs.vue', () => {
       expect(wrapper.vm.processedLogs).toEqual([]);
     });
 
-    it('handles missing agent correctly', async () => {
+    it('uses agentName directly as label when backend sends a display name', async () => {
       const logsWithUnknownAgent = [
         {
           type: 'trace_update',
           summary: 'Unknown agent trace',
           data: null,
           config: {
-            agentName: 'unknown-agent',
+            agentName: 'Custom Display Name',
           },
         },
       ];
@@ -223,7 +176,7 @@ describe('PreviewLogs.vue', () => {
       await wrapper.setProps({ logs: logsWithUnknownAgent });
 
       expect(wrapper.vm.processedLogs.length).toBe(1);
-      expect(wrapper.vm.processedLogs[0].agent).toBe('unknown-agent');
+      expect(wrapper.vm.processedLogs[0].agent).toBe('Custom Display Name');
     });
 
     it('groups consecutive logs from the same agent', async () => {
@@ -232,7 +185,7 @@ describe('PreviewLogs.vue', () => {
           type: 'trace_update',
           data: null,
           config: {
-            agentName: 'agent-1',
+            agentName: 'Concierge',
             summary: 'First step',
           },
         },
@@ -240,7 +193,7 @@ describe('PreviewLogs.vue', () => {
           type: 'trace_update',
           data: null,
           config: {
-            agentName: 'agent-1',
+            agentName: 'Concierge',
             summary: 'Second step',
           },
         },
@@ -248,7 +201,7 @@ describe('PreviewLogs.vue', () => {
           type: 'trace_update',
           data: null,
           config: {
-            agentName: 'agent-2',
+            agentName: 'Reservations',
             summary: 'Third step',
           },
         },
@@ -429,14 +382,14 @@ describe('PreviewLogs.vue', () => {
         {
           data: null,
           config: {
-            agentName: 'agent-1',
+            agentName: 'Concierge',
             summary: 'Step without icon',
           },
         },
         {
           data: null,
           config: {
-            agentName: 'agent-1',
+            agentName: 'Concierge',
             summary: 'Second step without icon',
           },
         },
@@ -452,14 +405,14 @@ describe('PreviewLogs.vue', () => {
         {
           data: { trace: { someTrace: 'data' } },
           config: {
-            agentName: 'agent-1',
+            agentName: 'Concierge',
             summary: 'Step with data',
           },
         },
         {
           data: null,
           config: {
-            agentName: 'agent-1',
+            agentName: 'Concierge',
             summary: 'Step without data',
           },
         },
@@ -485,23 +438,6 @@ describe('PreviewLogs.vue', () => {
       await wrapper.setProps({ logs: logsWithMissingAgentName });
 
       expect(wrapper.vm.processedLogs.length).toBe(0);
-    });
-
-    it('uses agentName as fallback label when agent is not found', async () => {
-      const logsWithNonExistentAgent = [
-        {
-          data: null,
-          config: {
-            agentName: 'non-existent-agent',
-            summary: 'Log from non-existent agent',
-          },
-        },
-      ];
-
-      await wrapper.setProps({ logs: logsWithNonExistentAgent });
-
-      expect(wrapper.vm.processedLogs.length).toBe(1);
-      expect(wrapper.vm.processedLogs[0].agent).toBe('non-existent-agent');
     });
   });
 });

--- a/src/components/Preview/__tests__/PreviewVisualFlow.spec.js
+++ b/src/components/Preview/__tests__/PreviewVisualFlow.spec.js
@@ -38,7 +38,7 @@ describe('PreviewVisualFlow.vue', () => {
         },
         preview: {
           activeAgent: {
-            id: 1,
+            name: 'Agent 1',
             currentTask: 'Current Task',
           },
         },
@@ -156,7 +156,7 @@ describe('PreviewVisualFlow.vue', () => {
     it('should update branch positions when active agent changes', async () => {
       const previewStore = usePreviewStore();
       const newActiveAgent = {
-        id: 2,
+        name: 'Agent 2',
         currentTask: 'New Task',
       };
 

--- a/src/components/Preview/__tests__/__snapshots__/PreviewLogs.spec.js.snap
+++ b/src/components/Preview/__tests__/__snapshots__/PreviewLogs.spec.js.snap
@@ -4,7 +4,7 @@ exports[`PreviewLogs.vue > Component rendering > matches snapshot 1`] = `
 "<section data-v-b04d9899="" data-testid="preview-logs" class="preview-logs preview-logs--left">
   <!--v-if-->
   <ol data-v-b04d9899="" class="preview-logs__logs preview-logs__logs--left">
-    <li data-v-b04d9899="" class="logs__log logs__log--left logs-enter-from logs-enter-active" data-testid="preview-logs-log">
+    <li data-v-b04d9899="" class="logs__log logs__log--left" data-testid="preview-logs-log">
       <p data-v-b04d9899="" class="log__agent-name log__agent-name--left" data-testid="preview-logs-log-agent-name">Test Agent 1</p>
       <ol data-v-b04d9899="" class="log__steps">
         <li data-v-b04d9899="" class="steps__step steps__step--left" data-testid="preview-logs-log-step">
@@ -18,7 +18,7 @@ exports[`PreviewLogs.vue > Component rendering > matches snapshot 1`] = `
         </li>
       </ol>
     </li>
-    <li data-v-b04d9899="" class="logs__log logs__log--left logs-enter-from logs-enter-active" data-testid="preview-logs-log">
+    <li data-v-b04d9899="" class="logs__log logs__log--left" data-testid="preview-logs-log">
       <p data-v-b04d9899="" class="log__agent-name log__agent-name--left" data-testid="preview-logs-log-agent-name">Manager</p>
       <ol data-v-b04d9899="" class="log__steps">
         <li data-v-b04d9899="" class="steps__step steps__step--left" data-testid="preview-logs-log-step">

--- a/src/store/Preview.js
+++ b/src/store/Preview.js
@@ -4,7 +4,6 @@ import { computed, ref } from 'vue';
 
 import WS from '@/websocket/setup';
 
-import { useAgentsTeamStore } from './AgentsTeam';
 import { processLog } from '@/utils/previewLogs';
 import { useProjectStore } from './Project';
 import { useUserStore } from './User';
@@ -12,43 +11,21 @@ import { useUserStore } from './User';
 export const usePreviewStore = defineStore('preview', () => {
   const ws = ref(null);
   const logs = ref([]);
-  const collaboratorInvoked = ref('');
   const collaboratorsLogs = computed(() =>
     logs.value.filter((log) => log.type === 'trace_update'),
   );
   const activeAgent = computed(() => {
-    const agentsTeamStore = useAgentsTeamStore();
-    const { manager, agents } = agentsTeamStore.activeTeam.data;
     const lastLog = logs.value.at(-1);
-
-    const lastLogAgentId = lastLog?.config?.agentName;
-
-    const agent =
-      lastLogAgentId === 'manager'
-        ? manager
-        : agents?.find(
-            (agent) =>
-              agent?.id && lastLogAgentId && agent?.id === lastLogAgentId,
-          );
+    const rawAgentName = lastLog?.config?.agentName;
 
     return {
-      ...agent,
+      name: rawAgentName === 'manager' ? 'Manager' : rawAgentName,
       currentTask: lastLog?.config?.summary,
     };
   });
 
   function addLog(log) {
-    if (log.type === 'trace_update') {
-      const processedLog = processLog({
-        log,
-        currentAgent: collaboratorInvoked.value,
-      });
-
-      collaboratorInvoked.value = processedLog.config.currentAgent;
-      logs.value.push(processedLog);
-    } else {
-      logs.value.push(log);
-    }
+    logs.value.push(log.type === 'trace_update' ? processLog({ log }) : log);
   }
 
   function clearLogs() {
@@ -89,6 +66,5 @@ export const usePreviewStore = defineStore('preview', () => {
     collaboratorsLogs,
     logs,
     addLog,
-    collaboratorInvoked,
   };
 });

--- a/src/store/__tests__/Preview.unit.spec.js
+++ b/src/store/__tests__/Preview.unit.spec.js
@@ -2,16 +2,12 @@ import { setActivePinia, createPinia } from 'pinia';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import { usePreviewStore } from '@/store/Preview';
-import { useAgentsTeamStore } from '@/store/AgentsTeam';
 import { useUserStore } from '@/store/User';
 import { useProjectStore } from '@/store/Project';
 import WS from '@/websocket/setup';
 import { processLog } from '@/utils/previewLogs';
 
 vi.mock('@/websocket/setup');
-vi.mock('@/store/AgentsTeam', () => ({
-  useAgentsTeamStore: vi.fn(),
-}));
 vi.mock('@/store/User', () => ({
   useUserStore: vi.fn(),
 }));
@@ -21,25 +17,12 @@ vi.mock('@/store/Project', () => ({
 
 describe('PreviewStore', () => {
   let store;
-  let mockAgentsTeamStore;
   let mockUserStore;
   let mockProjectStore;
   let mockWsInstance;
 
   beforeEach(() => {
     setActivePinia(createPinia());
-
-    mockAgentsTeamStore = {
-      activeTeam: {
-        data: {
-          agents: [
-            { id: 'agent-1', name: 'Agent 1' },
-            { id: 'agent-2', name: 'Agent 2' },
-          ],
-          manager: { id: 'manager', name: 'Manager' },
-        },
-      },
-    };
 
     mockUserStore = {
       user: {
@@ -57,7 +40,6 @@ describe('PreviewStore', () => {
     };
 
     WS.mockImplementation(() => mockWsInstance);
-    useAgentsTeamStore.mockReturnValue(mockAgentsTeamStore);
     useUserStore.mockReturnValue(mockUserStore);
     useProjectStore.mockReturnValue(mockProjectStore);
     store = usePreviewStore();
@@ -86,13 +68,13 @@ describe('PreviewStore', () => {
       expect(store.collaboratorsLogs).toEqual([store.logs[0], store.logs[2]]);
     });
 
-    it('should return the active agent based on the last trace', () => {
+    it('should expose the active agent name and current task from the last trace', () => {
       store.logs = [
         {
           type: 'trace_update',
           data: null,
           config: {
-            agentName: 'agent-1',
+            agentName: 'Concierge',
             summary: 'Task 1',
           },
         },
@@ -100,55 +82,67 @@ describe('PreviewStore', () => {
           type: 'trace_update',
           data: null,
           config: {
-            agentName: 'agent-2',
+            agentName: 'Reservations',
             summary: 'Task 2',
           },
         },
       ];
 
       expect(store.activeAgent).toEqual({
-        ...mockAgentsTeamStore.activeTeam.data.agents[1],
+        name: 'Reservations',
         currentTask: 'Task 2',
       });
     });
 
-    it('should return only the task info when agent not found', () => {
+    it('should normalize "manager" agentName to "Manager"', () => {
       store.logs = [
         {
           type: 'trace_update',
           data: null,
           config: {
-            agentName: 'unknown-agent',
-            summary: 'Task X',
+            agentName: 'manager',
+            summary: 'Thinking',
           },
         },
       ];
+
       expect(store.activeAgent).toEqual({
-        currentTask: 'Task X',
+        name: 'Manager',
+        currentTask: 'Thinking',
+      });
+    });
+
+    it('should return undefined name and currentTask when there are no logs', () => {
+      expect(store.activeAgent).toEqual({
+        name: undefined,
+        currentTask: undefined,
       });
     });
   });
 
   describe('Actions', () => {
-    it('should add a log', () => {
+    it('should add a trace_update log going through processLog', () => {
       const log = {
         type: 'trace_update',
         trace: {
           trace: {
             orchestrationTrace: {
-              invocationInput: {
-                agentCollaboratorInvocationInput: {
-                  agentCollaboratorName: 'agent-1',
-                },
-              },
+              rationale: { text: 'Thinking' },
             },
           },
+          config: { agentName: 'manager' },
         },
       };
       store.addLog(log);
-      const processedLog = processLog({ log, currentAgent: 'agent-1' });
 
-      expect(store.logs).toEqual([processedLog]);
+      expect(store.logs).toEqual([processLog({ log })]);
+    });
+
+    it('should add non-trace_update logs as-is', () => {
+      const log = { type: 'message', text: 'hi' };
+      store.addLog(log);
+
+      expect(store.logs).toEqual([log]);
     });
 
     it('should clear logs', () => {

--- a/src/utils/__tests__/previewLogs.spec.js
+++ b/src/utils/__tests__/previewLogs.spec.js
@@ -29,29 +29,31 @@ describe('previewLogs.js', () => {
       },
     });
 
-    const t = (params) => i18n.global.t(params);
-
     describe('Basic functionality', () => {
-      it('should process a basic log with orchestration trace', () => {
-        const mockLog = createMockLog();
-        const currentAgent = 'test-agent';
+      it('should preserve type, trace data and forward backend config (agentName)', () => {
+        const mockLog = {
+          type: 'trace_update',
+          trace: {
+            trace: createMockTrace(),
+            config: { agentName: 'manager' },
+          },
+        };
 
-        const result = processLog({ log: mockLog, currentAgent });
+        const result = processLog({ log: mockLog });
 
         expect(result).toEqual({
           type: 'trace_update',
-          data: { trace: createMockTrace() },
+          data: { trace: createMockTrace(), config: { agentName: 'manager' } },
           config: {
+            agentName: 'manager',
             summary: '',
             category: '',
             icon: '',
-            currentAgent: 'test-agent',
-            agentName: 'test-agent',
           },
         });
       });
 
-      it('should handle log with nested trace structure', () => {
+      it('should handle log with nested trace structure and final response', () => {
         const mockLog = {
           type: 'trace_update',
           trace: {
@@ -63,7 +65,7 @@ describe('previewLogs.js', () => {
           },
         };
 
-        const result = processLog({ log: mockLog, currentAgent: '' });
+        const result = processLog({ log: mockLog });
 
         expect(result.type).toBe('trace_update');
         expect(result.config.summary).toBe('Sending final response');
@@ -81,7 +83,7 @@ describe('previewLogs.js', () => {
           }),
         };
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe(
           i18n.global.t('agent_builder.traces.search_result_received'),
@@ -99,7 +101,7 @@ describe('previewLogs.js', () => {
           },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe(
           i18n.global.t('agent_builder.traces.searching_knowledge_base'),
@@ -115,7 +117,7 @@ describe('previewLogs.js', () => {
           },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe(
           i18n.global.t('agent_builder.traces.search_result_received'),
@@ -131,7 +133,7 @@ describe('previewLogs.js', () => {
           modelInvocationInput: { prompt: 'test prompt' },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe(
           i18n.global.t('agent_builder.traces.invoking_model'),
@@ -146,7 +148,7 @@ describe('previewLogs.js', () => {
           modelInvocationOutput: { response: 'test response' },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe('Model response received');
         expect(result.config.icon).toBe('workspaces');
@@ -165,15 +167,13 @@ describe('previewLogs.js', () => {
           },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe(
           i18n.global.t('agent_builder.traces.delegating_to_agent'),
         );
         expect(result.config.icon).toBe('login');
         expect(result.config.category).toBe('delegating_to_agent');
-        expect(result.config.currentAgent).toBe('collaborator-agent');
-        expect(result.config.agentName).toBe('collaborator-agent');
       });
 
       it('should process agent collaborator invocation output', () => {
@@ -185,15 +185,13 @@ describe('previewLogs.js', () => {
           },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe(
           i18n.global.t('agent_builder.traces.forwarding_to_manager'),
         );
         expect(result.config.icon).toBe('logout');
         expect(result.config.category).toBe('forwarding_to_manager');
-        expect(result.config.currentAgent).toBe('');
-        expect(result.config.agentName).toBe('output-agent');
       });
     });
 
@@ -207,7 +205,7 @@ describe('previewLogs.js', () => {
           },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe('Executing tool searchTool');
         expect(result.config.icon).toBe('build');
@@ -221,7 +219,7 @@ describe('previewLogs.js', () => {
           },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe('Executing tool ');
         expect(result.config.icon).toBe('build');
@@ -235,7 +233,7 @@ describe('previewLogs.js', () => {
           },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe(
           i18n.global.t('agent_builder.traces.tool_result_received'),
@@ -246,35 +244,62 @@ describe('previewLogs.js', () => {
     });
 
     describe('Final response traces', () => {
-      it('should process final response without agent name', () => {
+      it('should process final response without agent name as final response', () => {
         const mockLog = createMockLog({
           observation: {
             finalResponse: { text: 'Final response' },
           },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: '' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe('Sending final response');
         expect(result.config.icon).toBe('question_answer');
         expect(result.config.category).toBe('sending_final_response');
       });
 
-      it('should process final response with agent name in config', () => {
-        const mockLog = createMockLog({
-          observation: {
-            finalResponse: { text: 'Final response' },
+      it('should process final response with collaborator agent name as response for manager', () => {
+        const mockLog = {
+          type: 'trace_update',
+          trace: {
+            trace: createMockTrace({
+              observation: {
+                finalResponse: { text: 'Final response' },
+              },
+            }),
+            config: { agentName: 'collaborator' },
           },
-        });
+        };
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe(
           i18n.global.t('agent_builder.traces.sending_response_for_manager'),
         );
         expect(result.config.icon).toBe('chat_bubble');
         expect(result.config.category).toBe('sending_response_for_manager');
-        expect(result.config.agentName).toBe('agent');
+        expect(result.config.agentName).toBe('collaborator');
+      });
+
+      it('should process final response with agentName "manager" as final response', () => {
+        const mockLog = {
+          type: 'trace_update',
+          trace: {
+            trace: createMockTrace({
+              observation: {
+                finalResponse: { text: 'Final response' },
+              },
+            }),
+            config: { agentName: 'manager' },
+          },
+        };
+
+        const result = processLog({ log: mockLog });
+
+        expect(result.config.summary).toBe('Sending final response');
+        expect(result.config.icon).toBe('question_answer');
+        expect(result.config.category).toBe('sending_final_response');
+        expect(result.config.agentName).toBe('manager');
       });
     });
 
@@ -284,7 +309,7 @@ describe('previewLogs.js', () => {
           rationale: { text: 'Thinking process' },
         });
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe('Thinking');
         expect(result.config.icon).toBe('lightbulb');
@@ -303,7 +328,7 @@ describe('previewLogs.js', () => {
           },
         };
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe(
           i18n.global.t('agent_builder.traces.applying_safety_rules'),
@@ -324,7 +349,7 @@ describe('previewLogs.js', () => {
           },
         };
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result.config.summary).toBe('Processing message');
         expect(result.config.icon).toBe('autorenew');
@@ -336,7 +361,7 @@ describe('previewLogs.js', () => {
       it('should capture Sentry exception when no matching trace rules found', () => {
         const mockLog = createMockLog();
 
-        processLog({ log: mockLog, currentAgent: 'agent' });
+        processLog({ log: mockLog });
 
         expect(Sentry.captureException).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -352,7 +377,7 @@ describe('previewLogs.js', () => {
           trace: {},
         };
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result).toEqual({
           type: 'trace_update',
@@ -361,8 +386,6 @@ describe('previewLogs.js', () => {
             summary: '',
             category: '',
             icon: '',
-            currentAgent: 'agent',
-            agentName: 'agent',
           },
         });
       });
@@ -373,7 +396,7 @@ describe('previewLogs.js', () => {
           trace: null,
         };
 
-        const result = processLog({ log: mockLog, currentAgent: 'agent' });
+        const result = processLog({ log: mockLog });
 
         expect(result).toEqual({
           type: 'trace_update',
@@ -382,60 +405,36 @@ describe('previewLogs.js', () => {
             summary: '',
             category: '',
             icon: '',
-            currentAgent: 'agent',
-            agentName: 'agent',
           },
         });
       });
     });
 
-    describe('Agent name handling', () => {
-      it('should prioritize invocation input agent name over current agent', () => {
-        const mockLog = createMockLog({
-          invocationInput: {
-            agentCollaboratorInvocationInput: {
-              agentCollaboratorName: 'priority-agent',
-            },
+    describe('Agent name passthrough', () => {
+      it('passes through agentName from backend config', () => {
+        const mockLog = {
+          type: 'trace_update',
+          trace: {
+            trace: createMockTrace({
+              rationale: { text: 'Thinking' },
+            }),
+            config: { agentName: 'Concierge' },
           },
-        });
+        };
 
-        const result = processLog({
-          log: mockLog,
-          currentAgent: 'current-agent',
-        });
+        const result = processLog({ log: mockLog });
 
-        expect(result.config.currentAgent).toBe('priority-agent');
-        expect(result.config.agentName).toBe('priority-agent');
+        expect(result.config.agentName).toBe('Concierge');
       });
 
-      it('should reset current agent when output agent is present', () => {
+      it('leaves config.agentName undefined when backend did not send it', () => {
         const mockLog = createMockLog({
-          observation: {
-            agentCollaboratorInvocationOutput: {
-              agentCollaboratorName: 'output-agent',
-            },
-          },
+          rationale: { text: 'Thinking' },
         });
 
-        const result = processLog({
-          log: mockLog,
-          currentAgent: 'current-agent',
-        });
+        const result = processLog({ log: mockLog });
 
-        expect(result.config.currentAgent).toBe('');
-        expect(result.config.agentName).toBe('output-agent');
-      });
-
-      it('should fallback to current agent when no trace agent names', () => {
-        const mockLog = createMockLog();
-
-        const result = processLog({
-          log: mockLog,
-          currentAgent: 'fallback-agent',
-        });
-
-        expect(result.config.currentAgent).toBe('fallback-agent');
-        expect(result.config.agentName).toBe('fallback-agent');
+        expect(result.config.agentName).toBeUndefined();
       });
     });
   });

--- a/src/utils/previewLogs.js
+++ b/src/utils/previewLogs.js
@@ -2,15 +2,14 @@ import i18n from './plugins/i18n';
 import * as Sentry from '@sentry/browser';
 
 /**
- * Processes a trace object and updates it with additional configuration and collaborator information.
+ * Processes a trace object and enriches it with the resolved summary/icon/category.
  *
- * @param {Object} trace - The original trace object to process
- * @param {string} currentAgent - The name of the collaborator that was invoked
+ * @param {Object} params
+ * @param {Object} params.log - The original log message received from the backend
  *
  * @example
  * const result = processLog({
- *   trace: { trace: { trace: { orchestrationTrace: { ... } } } },
- *   currentAgent: 'string'
+ *   log: { trace: { trace: { orchestrationTrace: { ... } }, config: { agentName: 'manager' } } },
  * });
  *
  * @returns
@@ -23,33 +22,19 @@ import * as Sentry from '@sentry/browser';
  *   config: {
  *     summary: 'string',
  *     icon: 'string',
- *     currentAgent: 'string'
+ *     category: 'string',
+ *     agentName: 'string'
  *   }
  * }
  */
-export function processLog({ log, currentAgent }) {
+export function processLog({ log }) {
   const trace = log?.trace?.trace || log?.trace || {};
 
   const {
-    orchestrationTrace: {
-      invocationInput: { agentCollaboratorInvocationInput } = {},
-      observation: { agentCollaboratorInvocationOutput } = {},
-      modelInvocationInput,
-      modelInvocationOutput,
-    } = {},
+    orchestrationTrace: { modelInvocationInput, modelInvocationOutput } = {},
   } = trace;
 
   const configData = log?.trace?.config || {};
-
-  let updatedCollaborator = currentAgent;
-  if (!configData.agentName) {
-    updatedCollaborator = addAgentToConfig({
-      currentAgent,
-      input: agentCollaboratorInvocationInput,
-      output: agentCollaboratorInvocationOutput,
-      config: configData,
-    });
-  }
 
   const traceConfig = getLogConfig({ trace, config: configData });
 
@@ -64,7 +49,6 @@ export function processLog({ log, currentAgent }) {
     config: {
       ...configData,
       ...traceConfig,
-      currentAgent: updatedCollaborator,
     },
   };
 }
@@ -225,30 +209,4 @@ function getLogConfig({ trace, config }) {
     category,
     icon,
   };
-}
-
-/**
- * This function is necessary to maintain agent sequencing according to the invoke,
- * since the agent only sends its ID in the input and output, and not in all of its traces
- * @param {Object} config - The config object to update
- * @param {string} currentAgent - The name of the collaborator that was invoked
- * @param {Object} input - The input object
- * @param {Object} output - The output object
- */
-function addAgentToConfig({ currentAgent, input, output, config }) {
-  const traceInvokingAgent = input?.agentCollaboratorName;
-  const traceOutputAgent = output?.agentCollaboratorName;
-
-  let updatedCollaborator = currentAgent;
-  if (traceInvokingAgent) updatedCollaborator = traceInvokingAgent;
-  else if (traceOutputAgent) updatedCollaborator = '';
-
-  const agentName =
-    traceInvokingAgent || traceOutputAgent || updatedCollaborator;
-
-  if (agentName) {
-    config.agentName = agentName;
-  }
-
-  return updatedCollaborator;
 }


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Summary of Changes
<!--- Describe your changes in detail -->
- Removed the dependency on `useAgentsTeamStore` in `PreviewLogs` and `PreviewLogsSection` components to simplify agent data management.
- Updated log processing to use agentName directly.
- Simplified processLog utility.
- Adjusted tests accordingly.