### PR TITLE
[NEXUS-5363] - fix: Adjust assign agent modal when agent not have MCP

### DIFF
--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/MCPs.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/MCPs.vue
@@ -1,5 +1,6 @@
 <template>
   <section
+    v-if="mcps.length"
     class="start-setup-mcps"
     data-testid="start-setup-mcps"
   >
@@ -10,10 +11,7 @@
       {{ $t('agents.assign_agents.setup.mcps_available.title') }}
     </p>
 
-    <ul
-      v-if="mcps.length"
-      class="start-setup-mcps__list"
-    >
+    <ul class="start-setup-mcps__list">
       <li
         v-for="(mcp, index) in mcps"
         :key="mcp.name"

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/__tests__/MCPs.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/__tests__/MCPs.spec.js
@@ -130,7 +130,7 @@ describe('StartSetup MCPs', () => {
     await wrapper.setProps({ mcps: [] });
 
     expect(wrapper.find('[data-testid="start-setup-mcps"]').exists()).toBe(
-      true,
+      false,
     );
     expect(
       wrapper.find('[data-testid="start-setup-mcps-item-title"]').exists(),

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/index.vue
@@ -49,7 +49,9 @@ const conversationExample = computed(
   () => translateField(props.agent.conversation_example) ?? [],
 );
 
-const agentMCPs = computed(() => props.agent.mcps ?? []);
+const agentMCPs = computed(
+  () => props.agent.mcps?.filter((mcp) => mcp.name) ?? [],
+);
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/index.vue
@@ -96,7 +96,8 @@ const hasSystems = computed(() => {
 const hasMCPs =
   isOfficial.value &&
   Array.isArray(props.agent.mcps) &&
-  props.agent.mcps.length > 0;
+  props.agent.mcps.length > 0 &&
+  props.agent.mcps[0]?.name;
 
 const stepSequence = computed<StepKey[]>(() => {
   if (hasMCPs) {

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/index.vue
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/index.vue
@@ -66,7 +66,9 @@ const translateField = useTranslatedField();
 
 const aboutDescription = computed(() => translateField(props.agent.about));
 
-const assignedMCP = computed(() => props.agent.mcps?.[0] ?? null);
+const assignedMCP = computed(
+  () => props.agent.mcps?.filter((mcp) => mcp.name)?.[0] ?? null,
+);
 
 const assignedSystemSlug = computed(() => assignedMCP.value?.system ?? null);
 


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Summary of Changes
- Updated logic to ensure MCPs have a valid name before being rendered