### PR TITLE
[CFE-955] - feat: Add ICU MessageFormat support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "dompurify": "^3.1.7",
         "dotenv": "^16.4.7",
         "html-rspack-plugin": "^6.0.2",
+        "intl-messageformat": "^11.2.7",
         "jsdom": "^27.0.0",
         "lodash": "^4.17.21",
         "marked": "^14.1.2",
@@ -1376,6 +1377,27 @@
           "optional": true
         }
       }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.5.tgz",
+      "integrity": "sha512-KLi3fan6WnCHmigd9pmEEN8Hid0v4wiFBW576M/d07KMWYecf1CvyMI3n34vCmHT4AoVqG2n702kiHbXjzZX2A==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.10",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.10.tgz",
+      "integrity": "sha512-XeJihYLy1lCe19xfK1KWKG/betBOK2rB0luL8lSkjfvJj0zP+LTJvkC+RKd0jsFI8mWxN71LrarHSrEXE8xxOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.9"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.9.tgz",
+      "integrity": "sha512-rsxswgHMfU1zUgB2byc08fesf83wLGjFnzLCEtuf00mx2doiqc6pYrf67raI37XqdRcGUviQepk2UKGqpng74Q==",
+      "license": "MIT"
     },
     "node_modules/@growthbook/growthbook": {
       "version": "1.6.1",
@@ -7556,6 +7578,16 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.7.tgz",
+      "integrity": "sha512-+q6Ktg119nULZEpZ8YTuGOst9MyEzFtjD63FTGBlN1mLz0Z/MOUYDIvnpVKwq17eezIEh+cfJIebfJoCetpiNw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.5",
+        "@formatjs/icu-messageformat-parser": "3.5.10"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "dompurify": "^3.1.7",
     "dotenv": "^16.4.7",
     "html-rspack-plugin": "^6.0.2",
+    "intl-messageformat": "^11.2.7",
     "jsdom": "^27.0.0",
     "lodash": "^4.17.21",
     "marked": "^14.1.2",

--- a/src/api/nexus/Instructions.js
+++ b/src/api/nexus/Instructions.js
@@ -67,7 +67,7 @@ export const Instructions = {
       es: 'Spanish',
       ro: 'Romanian',
     };
-    const language = languageMap[i18n.global.locale] || 'English';
+    const language = languageMap[i18n.global.locale.value] || 'English';
 
     const response = await request.$http.post(
       `api/${projectUuid}/instructions-classification/`,

--- a/src/api/nexusaiAPI.js
+++ b/src/api/nexusaiAPI.js
@@ -244,7 +244,7 @@ export default {
           text,
           attachments,
           contact_urn,
-          language: i18n.global.locale,
+          language: i18n.global.locale.value,
           manager_agent_uuid: manager_uuid,
         });
       },

--- a/src/components/AgentsTeam/AssignAgents/AssignAgentsHeader.vue
+++ b/src/components/AgentsTeam/AssignAgents/AssignAgentsHeader.vue
@@ -54,15 +54,9 @@ const headerTitle = computed(() => {
 });
 
 const availableAgentsText = computed(() =>
-  t(
-    'agents.assign_agents.header.agents_available',
-    availableAgentsCount.value,
-    {
-      named: {
-        count: availableAgentsCount.value,
-      },
-    },
-  ),
+  t('agents.assign_agents.header.agents_available', {
+    count: availableAgentsCount.value,
+  }),
 );
 </script>
 

--- a/src/components/AgentsTeam/AssignAgents/__tests__/AssignAgentsHeader.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/__tests__/AssignAgentsHeader.spec.js
@@ -86,15 +86,9 @@ describe('AssignAgentsHeader', () => {
     expect(
       wrapper.find('[data-testid="assign-agents-header-subtitle"]').text(),
     ).toBe(
-      i18n.global.t(
-        'agents.assign_agents.header.agents_available',
-        availableAgents.length,
-        {
-          named: {
-            count: availableAgents.length,
-          },
-        },
-      ),
+      i18n.global.t('agents.assign_agents.header.agents_available', {
+        count: availableAgents.length,
+      }),
     );
   });
 
@@ -112,8 +106,8 @@ describe('AssignAgentsHeader', () => {
     expect(
       wrapper.find('[data-testid="assign-agents-header-subtitle"]').text(),
     ).toBe(
-      i18n.global.t('agents.assign_agents.header.agents_available', 2, {
-        named: { count: 2 },
+      i18n.global.t('agents.assign_agents.header.agents_available', {
+        count: 2,
       }),
     );
   });

--- a/src/components/Preview/Menu/Catalog/CatalogProduct.vue
+++ b/src/components/Preview/Menu/Catalog/CatalogProduct.vue
@@ -100,7 +100,7 @@ const titleText = computed(() => {
     return props.product.product;
   }
 
-  return `${props.product.product} (${props.quantity} ${i18n.global.t('router.preview.catalog.items', props.quantity)})`;
+  return `${props.product.product} (${props.quantity} ${i18n.global.t('router.preview.catalog.items', { count: props.quantity })})`;
 });
 
 function updateQuantity(quantity) {

--- a/src/components/Preview/Menu/Catalog/__tests__/index.spec.js
+++ b/src/components/Preview/Menu/Catalog/__tests__/index.spec.js
@@ -231,11 +231,9 @@ describe('Catalog', () => {
       await wrapper.vm.$nextTick();
 
       expect(wrapper.vm.cartButtonText).toBe(
-        i18n.global.t(
-          'router.preview.catalog.view_cart',
-          mockMessage.catalog_message.products.length,
-          { quantity: mockMessage.catalog_message.products.length },
-        ),
+        i18n.global.t('router.preview.catalog.view_cart', {
+          count: mockMessage.catalog_message.products.length,
+        }),
       );
     });
   });

--- a/src/components/Preview/Menu/Catalog/index.vue
+++ b/src/components/Preview/Menu/Catalog/index.vue
@@ -86,13 +86,9 @@ const cartButtonText = computed(() => {
     return i18n.global.t('router.preview.catalog.add_to_cart');
   }
 
-  return i18n.global.t(
-    'router.preview.catalog.view_cart',
-    cartItemsQuantity.value,
-    {
-      quantity: cartItemsQuantity.value,
-    },
-  );
+  return i18n.global.t('router.preview.catalog.view_cart', {
+    count: cartItemsQuantity.value,
+  });
 });
 
 const cartItems = ref([]);

--- a/src/components/QuickTest/MessageDisplay/MessageCatalogOrder.vue
+++ b/src/components/QuickTest/MessageDisplay/MessageCatalogOrder.vue
@@ -87,7 +87,7 @@ const emit = defineEmits(['view-details', 'close-order-details']);
 const isOrderDetailsOpen = ref(false);
 
 const itemsText = computed(() => {
-  return `${props.order.productsQuantity} ${i18n.global.t('router.preview.catalog.items', props.order.productsQuantity)}`;
+  return `${props.order.productsQuantity} ${i18n.global.t('router.preview.catalog.items', { count: props.order.productsQuantity })}`;
 });
 
 const subtotalText = computed(() => {

--- a/src/components/Tunings/ProjectDetailsModal/index.vue
+++ b/src/components/Tunings/ProjectDetailsModal/index.vue
@@ -64,7 +64,7 @@ const charactersUsage = computed(() => {
   const count = projectDetails.value.charactersCount;
   const maxCount = 20000;
 
-  const numberFormatter = new Intl.NumberFormat(i18n.global.locale);
+  const numberFormatter = new Intl.NumberFormat(i18n.global.locale.value);
   const formattedCount = numberFormatter.format(count);
   const formattedMaxCount = numberFormatter.format(maxCount);
 

--- a/src/components/Tunings/SettingsAgentsTeam/ManagerSelector/UpgradeDisclaimer.vue
+++ b/src/components/Tunings/SettingsAgentsTeam/ManagerSelector/UpgradeDisclaimer.vue
@@ -43,7 +43,7 @@ const formattedLegacyDeprecation = computed(() => {
     return '';
   }
 
-  const normalizedLocale = i18n.global.locale?.toLowerCase() || 'en';
+  const normalizedLocale = i18n.global.locale.value?.toLowerCase() || 'en';
   const localeConfig = localeFormats[normalizedLocale] || localeFormats.en;
 
   return format(legacyDeprecationDate.value, localeConfig.pattern, {

--- a/src/components/Tunings/SettingsAgentsTeam/ManagerSelector/__tests__/UpgradeDisclaimer.spec.js
+++ b/src/components/Tunings/SettingsAgentsTeam/ManagerSelector/__tests__/UpgradeDisclaimer.spec.js
@@ -76,7 +76,7 @@ describe('UpgradeDisclaimer.vue', () => {
     const disclaimer = wrapper.findComponent(
       '[data-testid="upgrade-disclaimer"]',
     );
-    const normalizedLocale = i18n.global.locale?.toLowerCase() || 'en';
+    const normalizedLocale = i18n.global.locale.value?.toLowerCase() || 'en';
     const localeConfig = localeFormats[normalizedLocale] || localeFormats.en;
     const expectedDate = format(
       new Date(managerOptionsMock.managers.legacy.deprecation),

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -83,7 +83,7 @@
       },
       "filters": {
         "filter_conversations": "Filter conversations",
-        "count_applied_filters": "(1 filter applied) | ({count} filters applied)",
+        "count_applied_filters": "{count, plural, one {(1 filter applied)} other {({count} filters applied)}}",
         "filter_conversations_drawer": "Filter conversations",
         "apply_filters": "Apply filters",
         "clear_filters": "Clear filters",
@@ -325,7 +325,7 @@
         "all_systems": "All systems",
         "all_custom_agents": "All custom agents",
         "system_title": "{system} agents",
-        "agents_available": "No agents available | {count} agent available | {count} agents available"
+        "agents_available": "{count, plural, =0 {No agents available} one {{count} agent available} other {{count} agents available}}"
       },
       "sidebar": {
         "official_title": "Official agents",
@@ -382,7 +382,7 @@
         "system_selection": {
           "title": "System selection",
           "description": "Select the data source system",
-          "mcp_count": "{count} MCP available | {count} MCPs available"
+          "mcp_count": "{count, plural, one {{count} MCP available} other {{count} MCPs available}}"
         },
         "mcp_selection": {
           "title": "MCP selection",
@@ -599,7 +599,7 @@
       "standby": "Standby mode",
       "catalog": {
         "title": "Product catalog",
-        "view_cart": "View cart ({quantity} item) | View cart ({quantity} items)",
+        "view_cart": "{count, plural, one {View cart ({count} item)} other {View cart ({count} items)}}",
         "add_to_cart": "Add to cart",
         "subtotal": "Subtotal",
         "place_order": "Checkout",
@@ -607,7 +607,7 @@
         "order_summary": "Order summary",
         "order_details": "Order details",
         "view_order_details": "View order details",
-        "items": "item | items",
+        "items": "{count, plural, one {item} other {items}}",
         "remove": "Remove"
       }
     }
@@ -790,10 +790,10 @@
     }
   },
   "time": {
-    "time_ago_minutes": "{count} minute ago | {count} minutes ago",
-    "time_ago_hours": "{count} hour ago | {count} hours ago",
-    "time_ago_days": "{count} day ago | {count} days ago",
-    "time_ago_months": "{count} month ago | {count} months ago"
+    "time_ago_minutes": "{count, plural, one {{count} minute ago} other {{count} minutes ago}}",
+    "time_ago_hours": "{count, plural, one {{count} hour ago} other {{count} hours ago}}",
+    "time_ago_days": "{count, plural, one {{count} day ago} other {{count} days ago}}",
+    "time_ago_months": "{count, plural, one {{count} month ago} other {{count} months ago}}"
   },
   "audio_recorder": {
     "discard_button": "Discard"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -83,7 +83,7 @@
       },
       "filters": {
         "filter_conversations": "Filtrar conversaciones",
-        "count_applied_filters": "(1 filtro aplicado) | ({count} filtros aplicados)",
+        "count_applied_filters": "{count, plural, one {(1 filtro aplicado)} other {({count} filtros aplicados)}}",
         "filter_conversations_drawer": "Filtrar conversaciones",
         "apply_filters": "Aplicar filtros",
         "clear_filters": "Limpiar filtros",
@@ -325,7 +325,7 @@
         "all_systems": "Todos los sistemas",
         "all_custom_agents": "Todos los agentes personalizados",
         "system_title": "Agentes {system}",
-        "agents_available": "No hay agentes disponibles | {count} agente disponible | {count} agentes disponibles"
+        "agents_available": "{count, plural, =0 {No hay agentes disponibles} one {{count} agente disponible} other {{count} agentes disponibles}}"
       },
       "sidebar": {
         "official_title": "Agentes oficiales",
@@ -382,7 +382,7 @@
         "system_selection": {
           "title": "Selección de sistema",
           "description": "Seleccione el sistema de origen de los datos",
-          "mcp_count": "{count} MCP disponible | {count} MCPs disponibles"
+          "mcp_count": "{count, plural, one {{count} MCP disponible} other {{count} MCPs disponibles}}"
         },
         "mcp_selection": {
           "title": "Selección de MCP",
@@ -599,7 +599,7 @@
       "standby": "Modo de espera",
       "catalog": {
         "title": "Catálogo de productos",
-        "view_cart": "Ver carrito ({quantity} ítem) | Ver carrito ({quantity} ítems)",
+        "view_cart": "{count, plural, one {Ver carrito ({count} ítem)} other {Ver carrito ({count} ítems)}}",
         "add_to_cart": "Agregar al carrito",
         "subtotal": "Subtotal",
         "place_order": "Finalizar compra",
@@ -607,7 +607,7 @@
         "order_summary": "Resumen del pedido",
         "order_details": "Detalles del pedido",
         "view_order_details": "Ver detalles del pedido",
-        "items": "ítem | ítems",
+        "items": "{count, plural, one {ítem} other {ítems}}",
         "remove": "Remover"
       }
     }
@@ -790,10 +790,10 @@
     }
   },
   "time": {
-    "time_ago_minutes": "Hace {count} minuto | Hace {count} minutos",
-    "time_ago_hours": "Hace {count} hora | Hace {count} horas",
-    "time_ago_days": "Hace {count} día | Hace {count} días",
-    "time_ago_months": "Hace {count} mes | Hace {count} meses"
+    "time_ago_minutes": "{count, plural, one {Hace {count} minuto} other {Hace {count} minutos}}",
+    "time_ago_hours": "{count, plural, one {Hace {count} hora} other {Hace {count} horas}}",
+    "time_ago_days": "{count, plural, one {Hace {count} día} other {Hace {count} días}}",
+    "time_ago_months": "{count, plural, one {Hace {count} mes} other {Hace {count} meses}}"
   },
   "audio_recorder": {
     "discard_button": "Descartar"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -83,7 +83,7 @@
       },
       "filters": {
         "filter_conversations": "Filtrar conversas",
-        "count_applied_filters": "(1 filtro aplicado) | ({count} filtros aplicados)",
+        "count_applied_filters": "{count, plural, one {(1 filtro aplicado)} other {({count} filtros aplicados)}}",
         "filter_conversations_drawer": "Filtrar conversas",
         "apply_filters": "Aplicar filtros",
         "clear_filters": "Limpar filtros",
@@ -325,7 +325,7 @@
         "all_systems": "Todos os sistemas",
         "all_custom_agents": "Todos os agentes personalizados",
         "system_title": "Agentes {system}",
-        "agents_available": "Nenhum agente disponível | {count} agente disponível | {count} agentes disponíveis"
+        "agents_available": "{count, plural, =0 {Nenhum agente disponível} one {{count} agente disponível} other {{count} agentes disponíveis}}"
       },
       "sidebar": {
         "official_title": "Agentes oficiais",
@@ -382,7 +382,7 @@
         "system_selection": {
           "title": "Seleção de sistema",
           "description": "Selecione o sistema de origem dos dados",
-          "mcp_count": "{count} MCP disponível | {count} MCPs disponíveis"
+          "mcp_count": "{count, plural, one {{count} MCP disponível} other {{count} MCPs disponíveis}}"
         },
         "mcp_selection": {
           "title": "Seleção de MCP",
@@ -599,7 +599,7 @@
       "standby": "Modo de espera",
       "catalog": {
         "title": "Catálogo de produtos",
-        "view_cart": "Ver carrinho ({quantity} item) | Ver carrinho ({quantity} itens)",
+        "view_cart": "{count, plural, one {Ver carrinho ({count} item)} other {Ver carrinho ({count} itens)}}",
         "add_to_cart": "Adicionar ao carrinho",
         "subtotal": "Subtotal",
         "place_order": "Finalizar compra",
@@ -607,7 +607,7 @@
         "order_summary": "Resumo do pedido",
         "order_details": "Detalhes do pedido",
         "view_order_details": "Ver detalhes do pedido",
-        "items": "item | itens",
+        "items": "{count, plural, one {item} other {itens}}",
         "remove": "Remover"
       }
     }
@@ -790,10 +790,10 @@
     }
   },
   "time": {
-    "time_ago_minutes": "Há {count} minuto | Há {count} minutos",
-    "time_ago_hours": "Há {count} hora | Há {count} horas",
-    "time_ago_days": "Há {count} dia | Há {count} dias",
-    "time_ago_months": "Há {count} mês | Há {count} meses"
+    "time_ago_minutes": "{count, plural, one {Há {count} minuto} other {Há {count} minutos}}",
+    "time_ago_hours": "{count, plural, one {Há {count} hora} other {Há {count} horas}}",
+    "time_ago_days": "{count, plural, one {Há {count} dia} other {Há {count} dias}}",
+    "time_ago_months": "{count, plural, one {Há {count} mês} other {Há {count} meses}}"
   },
   "audio_recorder": {
     "discard_button": "Descartar"

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -83,7 +83,7 @@
       },
       "filters": {
         "filter_conversations": "Filtrează conversațiile",
-        "count_applied_filters": "(1 filtru aplicat) | ({count} filtre aplicate)",
+        "count_applied_filters": "{count, plural, one {(1 filtru aplicat)} few {({count} filtre aplicate)} other {({count} de filtre aplicate)}}",
         "filter_conversations_drawer": "Filtrează conversațiile",
         "apply_filters": "Aplicare filtre",
         "clear_filters": "Elimină filtrele",
@@ -324,7 +324,7 @@
         "all_systems": "Toate sistemele",
         "all_custom_agents": "Toți agenții personalizați",
         "system_title": "Agenți {system}",
-        "agents_available": "Niciun agent disponibil | {count} agent disponibil | {count} agenți disponibili"
+        "agents_available": "{count, plural, =0 {Niciun agent disponibil} one {{count} agent disponibil} few {{count} agenți disponibili} other {{count} de agenți disponibili}}"
       },
       "sidebar": {
         "official_title": "Agenți oficiali",
@@ -381,7 +381,7 @@
         "system_selection": {
           "title": "Selectare sistem",
           "description": "Selectează sistemul sursă de date",
-          "mcp_count": "{count} MCP disponibil | {count} MCP-uri disponibile"
+          "mcp_count": "{count, plural, one {{count} MCP disponibil} few {{count} MCP-uri disponibile} other {{count} de MCP-uri disponibile}}"
         },
         "mcp_selection": {
           "title": "Selectare MCP",
@@ -591,7 +591,7 @@
       "standby": "Mod standby",
       "catalog": {
         "title": "Catalog de produse",
-        "view_cart": "Vizualizează coșul ({quantity} articol) | Vizualizează coșul ({quantity} articole)",
+        "view_cart": "{count, plural, one {Vizualizează coșul ({count} articol)} few {Vizualizează coșul ({count} articole)} other {Vizualizează coșul ({count} de articole)}}",
         "add_to_cart": "Adaugă în coș",
         "subtotal": "Subtotal",
         "place_order": "Finalizează comanda",
@@ -599,7 +599,7 @@
         "order_summary": "Sumar comandă",
         "order_details": "Detalii comandă",
         "view_order_details": "Vizualizează detaliile comenzii",
-        "items": "articol | articole",
+        "items": "{count, plural, one {articol} few {articole} other {de articole}}",
         "remove": "Eliminare"
       }
     }
@@ -782,10 +782,10 @@
     }
   },
   "time": {
-    "time_ago_minutes": "Acum {count} minut | Acum {count} minute",
-    "time_ago_hours": "Acum {count} oră | Acum {count} ore",
-    "time_ago_days": "Acum {count} zi | Acum {count} zile",
-    "time_ago_months": "Acum {count} lună | Acum {count} luni"
+    "time_ago_minutes": "{count, plural, one {Acum {count} minut} few {Acum {count} minute} other {Acum {count} de minute}}",
+    "time_ago_hours": "{count, plural, one {Acum {count} oră} few {Acum {count} ore} other {Acum {count} de ore}}",
+    "time_ago_days": "{count, plural, one {Acum {count} zi} few {Acum {count} zile} other {Acum {count} de zile}}",
+    "time_ago_months": "{count, plural, one {Acum {count} lună} few {Acum {count} luni} other {Acum {count} de luni}}"
   },
   "audio_recorder": {
     "discard_button": "Renunță"

--- a/src/utils/language.js
+++ b/src/utils/language.js
@@ -4,7 +4,7 @@ export function setupLanguageListener() {
   return new Promise((resolve) => {
     window.addEventListener('message', (event) => {
       if (event.data.event === 'setLanguage') {
-        i18n.global.locale = event.data.language;
+        i18n.global.locale.value = event.data.language;
         resolve();
       }
     });

--- a/src/utils/plugins/i18n.ts
+++ b/src/utils/plugins/i18n.ts
@@ -4,6 +4,7 @@ import en from '@/locales/en.json';
 import ptbr from '@/locales/pt_br.json';
 import es from '@/locales/es.json';
 import ro from '@/locales/ro.json';
+import { icuMessageCompiler } from '@/utils/plugins/icuMessageCompiler';
 
 const languages = {
   en,
@@ -15,10 +16,17 @@ const languages = {
 const messages = Object.assign(languages);
 
 const i18n = createI18n({
+  legacy: false,
   locale: 'en',
   fallbackLocale: 'en',
   messages,
+  messageCompiler: icuMessageCompiler,
+  globalInjection: true,
   warnHtmlInMessage: 'off',
+  silentTranslationWarn: true,
+  silentFallbackWarn: true,
+  missingWarn: false,
+  fallbackWarn: false,
 });
 
 export default i18n;

--- a/src/utils/plugins/icuMessageCompiler.ts
+++ b/src/utils/plugins/icuMessageCompiler.ts
@@ -1,0 +1,146 @@
+import IntlMessageFormat from 'intl-messageformat';
+import type { CompileError, MessageCompiler, MessageContext } from 'vue-i18n';
+
+type NamedValues = Record<string, unknown>;
+
+/**
+ * `interpolate` and `normalize` exist on the runtime message context but are
+ * excluded from the public type. They are required so a single message function
+ * works both for `t()` (text) and the `<i18n-t>` component (vnode).
+ */
+type RuntimeMessageContext = MessageContext & {
+  interpolate: (_value: unknown) => unknown;
+  normalize: (_values: unknown[]) => unknown;
+};
+
+/**
+ * Matches real ICU blocks only: {var, plural|selectordinal, <branch> { … }
+ * or {var, select, <key> { … }. Avoids false positives like
+ * "{user, select another option}" or "{item, plural forms available}".
+ */
+const ICU_PLURAL_OR_SELECTORDINAL_PATTERN =
+  /\{([a-zA-Z][\w]*),\s*(?:plural|selectordinal)\s*,\s*(?:(?:=\d+)|zero|one|two|few|many|other)\s*\{/i;
+
+const ICU_SELECT_PATTERN = /\{([a-zA-Z][\w]*),\s*select\s*,\s*[\w#.-]+\s*\{/i;
+
+export function shouldUseIntlMessageFormat(message: string): boolean {
+  return (
+    ICU_PLURAL_OR_SELECTORDINAL_PATTERN.test(message) ||
+    ICU_SELECT_PATTERN.test(message)
+  );
+}
+
+/** Tag names in ICU XML markup (<b>, <i>, <br/>) need function handlers in .format(). */
+const ICU_XML_TAG_PATTERN = /<\/?([a-zA-Z][a-zA-Z0-9]*)\b/g;
+
+const NAMED_PLACEHOLDER_PATTERN = /\{(\w+)\}/g;
+
+/**
+ * Builds the message parts for plain (non-ICU) strings, resolving `{name}`
+ * placeholders through the message context. Unprovided placeholders are kept
+ * literally to preserve the previous behavior. Returning context-resolved parts
+ * lets `ctx.normalize` produce a string for `t()` and vnodes for `<i18n-t>`.
+ */
+function buildPlainMessageParts(
+  message: string,
+  ctx: RuntimeMessageContext,
+): unknown[] {
+  const values = (ctx.values || {}) as NamedValues;
+  const parts: unknown[] = [];
+  let lastIndex = 0;
+  let match;
+
+  NAMED_PLACEHOLDER_PATTERN.lastIndex = 0;
+  while ((match = NAMED_PLACEHOLDER_PATTERN.exec(message)) !== null) {
+    const [token, name] = match;
+
+    if (match.index > lastIndex) {
+      parts.push(message.slice(lastIndex, match.index));
+    }
+
+    if (Object.prototype.hasOwnProperty.call(values, name)) {
+      parts.push(ctx.interpolate(ctx.named(name)));
+    } else {
+      parts.push(token);
+    }
+
+    lastIndex = NAMED_PLACEHOLDER_PATTERN.lastIndex;
+  }
+
+  if (lastIndex < message.length) {
+    parts.push(message.slice(lastIndex));
+  }
+
+  return parts;
+}
+
+function createDefaultTagHandler(tagName: string) {
+  if (tagName === 'br') {
+    return (chunks: string[]) => chunks.join('') + '<br/>';
+  }
+
+  return (chunks: string[]) => {
+    const content = chunks.join('');
+    return `<${tagName}>${content}</${tagName}>`;
+  };
+}
+
+/**
+ * Merges $t params with default ICU tag handlers so plural + HTML works without
+ * passing b/i/br manually on every call.
+ */
+function buildIntlFormatValues(
+  message: string,
+  values: NamedValues = {},
+): NamedValues {
+  const formatValues: NamedValues = { ...(values || {}) };
+  let match;
+
+  while ((match = ICU_XML_TAG_PATTERN.exec(message)) !== null) {
+    const tagName = match[1];
+    const existing = formatValues[tagName];
+
+    if (typeof existing === 'function') {
+      continue;
+    }
+
+    formatValues[tagName] = createDefaultTagHandler(tagName);
+  }
+
+  ICU_XML_TAG_PATTERN.lastIndex = 0;
+  return formatValues;
+}
+
+/**
+ * Vue I18n custom messageCompiler: ICU plural/select via IntlMessageFormat;
+ * plain strings (HTML, simple {name}) use named interpolation only.
+ * Both branches return through `ctx.normalize` so the same compiled function
+ * supports `t()` (string output) and `<i18n-t>` (vnode array output).
+ */
+export const icuMessageCompiler: MessageCompiler = (
+  message,
+  { locale, key, onError },
+) => {
+  if (typeof message === 'string') {
+    if (shouldUseIntlMessageFormat(message)) {
+      const formatter = new IntlMessageFormat(message, locale);
+      return (context) => {
+        const ctx = context as RuntimeMessageContext;
+        const formatted = formatter.format(
+          buildIntlFormatValues(message, ctx.values as NamedValues),
+        );
+        const parts = Array.isArray(formatted) ? formatted : [formatted];
+        return ctx.normalize(parts) as string;
+      };
+    }
+
+    return (context) => {
+      const ctx = context as RuntimeMessageContext;
+      return ctx.normalize(buildPlainMessageParts(message, ctx)) as string;
+    };
+  }
+
+  const astError = new Error('not support for AST') as unknown as CompileError;
+  onError?.(astError);
+  return () => key;
+};

--- a/src/views/Supervisor/SupervisorFilters/index.vue
+++ b/src/views/Supervisor/SupervisorFilters/index.vue
@@ -77,7 +77,6 @@ const filterButtonText = computed(() => {
   const text = t('agent_builder.supervisor.filters.filter_conversations');
   const countText = t(
     'agent_builder.supervisor.filters.count_applied_filters',
-    count,
     {
       count,
     },


### PR DESCRIPTION
## Description
### Type of Change
<!-- Remove the space between "[" and "]", enter an x in the category(ies) that fits the pull request and do not exclude the others -->
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
VTEX localization delivers plural strings in ICU format, but this webapp used vue-i18n's pipe syntax. That mismatch broke plural rendering in production when new translations were merged.

### Summary of Changes

- Added ICU support via `intl-messageformat` and a custom `messageCompiler`
- Switched vue-i18n to composition mode (`legacy: false`)
- Converted all 9 pipe-pluralized messages to ICU format in `en.json`, `pt_br.json`, `es.json`, and `ro.json`.
  - Romanian plural messages now use `one` / `few` / `other` (and `=0` where applicable) instead of the simplified two-form pipe syntax.
- Updated plural call sites and tests to use named values (`{ count }`, `{ quantity }`)
- Fixed `i18n.global.locale` usages for composition mode (`.value`)