### PR TITLE
[NEXUS-5339] - feat: Categorization of instructions (header)

### DIFF
--- a/src/components/Instructions/InstructionsHeaderActions.vue
+++ b/src/components/Instructions/InstructionsHeaderActions.vue
@@ -1,0 +1,25 @@
+<template>
+  <UnnnicButton
+    data-testid="export-instructions-button"
+    type="secondary"
+    :text="$t('agents.instructions.export_instructions')"
+    @click="exportInstructions"
+  />
+
+  <UnnnicButton
+    data-testid="new-instruction-button"
+    type="primary"
+    :text="$t('agents.instructions.new_instruction')"
+    @click="newInstruction"
+  />
+</template>
+
+<script setup lang="ts">
+function exportInstructions() {
+  // TODO: Implement export instructions
+}
+
+function newInstruction() {
+  // TODO: Implement new instruction drawer
+}
+</script>

--- a/src/components/Instructions/__tests__/InstructionsHeaderActions.spec.js
+++ b/src/components/Instructions/__tests__/InstructionsHeaderActions.spec.js
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { shallowMount } from '@vue/test-utils';
+
+import InstructionsHeaderActions from '../InstructionsHeaderActions.vue';
+import i18n from '@/utils/plugins/i18n';
+
+describe('InstructionsHeaderActions.vue', () => {
+  let wrapper;
+
+  const findExportButton = () =>
+    wrapper.findComponent('[data-testid="export-instructions-button"]');
+  const findNewInstructionButton = () =>
+    wrapper.findComponent('[data-testid="new-instruction-button"]');
+
+  const createWrapper = () => {
+    wrapper = shallowMount(InstructionsHeaderActions);
+  };
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('renders both action buttons', () => {
+    createWrapper();
+
+    expect(findExportButton().exists()).toBe(true);
+    expect(findNewInstructionButton().exists()).toBe(true);
+  });
+
+  describe('export instructions button', () => {
+    it('has type secondary', () => {
+      createWrapper();
+
+      expect(findExportButton().props('type')).toBe('secondary');
+    });
+
+    it('has the correct translated text', () => {
+      createWrapper();
+
+      expect(findExportButton().props('text')).toBe(
+        i18n.global.t('agents.instructions.export_instructions'),
+      );
+    });
+  });
+
+  describe('new instruction button', () => {
+    it('has type primary', () => {
+      createWrapper();
+
+      expect(findNewInstructionButton().props('type')).toBe('primary');
+    });
+
+    it('has the correct translated text', () => {
+      createWrapper();
+
+      expect(findNewInstructionButton().props('text')).toBe(
+        i18n.global.t('agents.instructions.new_instruction'),
+      );
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -343,7 +343,9 @@
     },
     "instructions": {
       "title": "Instructions",
-      "description": "Write quick rules to shape agent behavior"
+      "description": "Define the rules that guide how Manager responds, communicates, and makes decisions",
+      "export_instructions": "Export instructions",
+      "new_instruction": "New instruction"
     },
     "profile": {
       "tone_of_voice": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -343,7 +343,9 @@
     },
     "instructions": {
       "title": "Instrucciones",
-      "description": "Escribe reglas rápidas para configurar el comportamiento del agente"
+      "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
+      "export_instructions": "Exportar instrucciones",
+      "new_instruction": "Nueva instrucción"
     },
     "profile": {
       "tone_of_voice": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -343,7 +343,9 @@
     },
     "instructions": {
       "title": "Instruções",
-      "description": "Escreva regras rápidas para moldar o comportamento do agente"
+      "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
+      "export_instructions": "Exportar instruções",
+      "new_instruction": "Nova instrução"
     },
     "profile": {
       "tone_of_voice": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -342,7 +342,9 @@
     },
     "instructions": {
       "title": "Instrucțiuni",
-      "description": "Scrie reguli rapide pentru a modela comportamentul agentului"
+      "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
+      "export_instructions": "Exportă instrucțiuni",
+      "new_instruction": "Instrucțiune nouă"
     },
     "profile": {
       "tone_of_voice": {

--- a/src/store/FeatureFlags.js
+++ b/src/store/FeatureFlags.js
@@ -46,6 +46,9 @@ export const useFeatureFlagsStore = defineStore('FeatureFlags', () => {
     supervisorExport: isProjectEnabledForFlag('FF_SUPERVISOR_EXPORT'),
     settingsAgentVoice: isFeatureFlagEnabled('settings_agent_voice'),
     conversationsImprovements: isFeatureFlagEnabled('improvements'),
+    categorizationOfInstructions: isFeatureFlagEnabled(
+      'categorization_of_instructions',
+    ),
   }));
 
   return {

--- a/src/views/AgentsTeam/index.vue
+++ b/src/views/AgentsTeam/index.vue
@@ -25,10 +25,13 @@ import { useRoute } from 'vue-router';
 
 import i18n from '@/utils/plugins/i18n';
 
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 import HomeHeaderActions from '@/components/AgentsTeam/HomeHeaderActions.vue';
+import InstructionsHeaderActions from '@/components/Instructions/InstructionsHeaderActions.vue';
 
 const route = useRoute();
 const { t } = i18n.global;
+const featureFlagsStore = useFeatureFlagsStore();
 
 const headerTitle = computed(() => {
   const titles: Record<string, string> = {
@@ -54,6 +57,9 @@ const headerActions = computed(() => {
   const actionsMap: Record<string, Component | null> = {
     'agents-team': HomeHeaderActions,
     'agents-assign': null,
+    instructions: featureFlagsStore.flags.categorizationOfInstructions
+      ? InstructionsHeaderActions
+      : null,
   };
 
   return actionsMap[route.name as string] || null;

--- a/src/views/__tests__/AgentsTeam/AgentsTeam.spec.js
+++ b/src/views/__tests__/AgentsTeam/AgentsTeam.spec.js
@@ -3,6 +3,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import AgentsTeamView from '@/views/AgentsTeam/index.vue';
 import HomeHeaderActions from '@/components/AgentsTeam/HomeHeaderActions.vue';
+import InstructionsHeaderActions from '@/components/Instructions/InstructionsHeaderActions.vue';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 import i18n from '@/utils/plugins/i18n';
 
 const mockRoute = {
@@ -18,6 +20,10 @@ vi.mock('vue-router', async () => {
   };
 });
 
+vi.mock('@/store/FeatureFlags', () => ({
+  useFeatureFlagsStore: vi.fn(),
+}));
+
 describe('AgentsTeam view', () => {
   let wrapper;
   let tSpy;
@@ -29,7 +35,12 @@ describe('AgentsTeam view', () => {
     actions: wrapper.vm.headerActions?.value ?? wrapper.vm.headerActions,
   });
 
-  const mountView = () => shallowMount(AgentsTeamView);
+  const createWrapper = ({ categorizationOfInstructions = false } = {}) => {
+    useFeatureFlagsStore.mockReturnValue({
+      flags: { categorizationOfInstructions },
+    });
+    wrapper = shallowMount(AgentsTeamView);
+  };
 
   beforeEach(() => {
     mockRoute.name = 'agents-team';
@@ -44,7 +55,7 @@ describe('AgentsTeam view', () => {
   });
 
   it('renders default header content for agents-team route', () => {
-    wrapper = mountView();
+    createWrapper();
 
     expect(wrapper.find('[data-testid="agents-header"]').exists()).toBe(true);
 
@@ -58,7 +69,7 @@ describe('AgentsTeam view', () => {
   it('updates header copy for assign route', () => {
     mockRoute.name = 'agents-assign';
 
-    wrapper = mountView();
+    createWrapper();
 
     const headerState = getHeaderState();
 
@@ -70,7 +81,7 @@ describe('AgentsTeam view', () => {
   it('injects header actions when they are available', () => {
     mockRoute.name = 'agents-team';
 
-    wrapper = mountView();
+    createWrapper();
 
     const headerState = getHeaderState();
 
@@ -78,8 +89,35 @@ describe('AgentsTeam view', () => {
   });
 
   it('always renders the nested router view outlet', () => {
-    wrapper = mountView();
+    createWrapper();
 
     expect(wrapper.find('[data-testid="router-view"]').exists()).toBe(true);
+  });
+
+  describe('instructions route', () => {
+    beforeEach(() => {
+      mockRoute.name = 'instructions';
+    });
+
+    it('sets the correct title and description', () => {
+      createWrapper();
+
+      const headerState = getHeaderState();
+
+      expect(headerState.title).toBe('agents.instructions.title');
+      expect(headerState.description).toBe('agents.instructions.description');
+    });
+
+    it('shows InstructionsHeaderActions when categorizationOfInstructions flag is on', () => {
+      createWrapper({ categorizationOfInstructions: true });
+
+      expect(getHeaderState().actions).toBe(InstructionsHeaderActions);
+    });
+
+    it('shows no header actions when categorizationOfInstructions flag is off', () => {
+      createWrapper({ categorizationOfInstructions: false });
+
+      expect(getHeaderState().actions).toBe(null);
+    });
   });
 });


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The instructions page lacked header action buttons for creating and exporting instructions. These actions need to be gated behind a feature flag (`categorization_of_instructions`) since they are part of the instruction categorization feature that is still being rolled out.

### Summary of Changes

- **`FeatureFlags`** **store** — Added `categorizationOfInstructions` flag driven by the Growthbook `categorization_of_instructions` experiment.
- **`InstructionsHeaderActions.vue`** — New component with two header action buttons: "Export instructions" (secondary) and "New instruction" (primary).
- **`AgentsTeam/index.vue`** — Wired `InstructionsHeaderActions` into the `headerActions` computed for the `instructions` route, conditionally rendered based on the `categorizationOfInstructions` flag.
- **Locales (`en`,** **`pt_br`,** **`es`,** **`ro`)** — Added `export_instructions` and `new_instruction` keys; updated the `instructions.description` copy to better describe how the Manager responds, communicates, and makes decisions.
- **Tests** — Added `InstructionsHeaderActions.spec.js` and extended `AgentsTeam.spec.js` to cover flag-on/off behavior for the instructions route.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/121b89ea-a8e8-48df-8da9-7c365603cab2.png)

