### PR TITLE
[NEXUS-5340] - feature: Categorization of instructions (drawer)

### DIFF
--- a/src/components/Instructions/InstructionsHeaderActions.vue
+++ b/src/components/Instructions/InstructionsHeaderActions.vue
@@ -12,14 +12,25 @@
     :text="$t('agents.instructions.new_instruction')"
     @click="newInstruction"
   />
+
+  <NewInstructionDrawer
+    v-model="showNewInstructionDrawer"
+    data-testid="new-instruction-drawer"
+  />
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
+
+import NewInstructionDrawer from '@/components/Instructions/NewInstructionDrawer/index.vue';
+
+const showNewInstructionDrawer = ref(false);
+
 function exportInstructions() {
   // TODO: Implement export instructions
 }
 
 function newInstruction() {
-  // TODO: Implement new instruction drawer
+  showNewInstructionDrawer.value = true;
 }
 </script>

--- a/src/components/Instructions/NewInstructionDrawer/index.vue
+++ b/src/components/Instructions/NewInstructionDrawer/index.vue
@@ -1,0 +1,54 @@
+<template>
+  <UnnnicDrawerNext
+    v-model:open="modelValue"
+    lazyMount
+  >
+    <UnnnicDrawerContent size="large">
+      <UnnnicDrawerHeader>
+        <UnnnicDrawerTitle data-testid="new-instruction-drawer-title">
+          {{ $t('agents.instructions.new_instruction_drawer.title') }}
+        </UnnnicDrawerTitle>
+      </UnnnicDrawerHeader>
+
+      <section class="new-instruction-drawer"></section>
+
+      <UnnnicDrawerFooter>
+        <UnnnicDrawerClose>
+          <UnnnicButton
+            :text="$t('agents.instructions.new_instruction_drawer.cancel')"
+            type="tertiary"
+            @click="close"
+          />
+        </UnnnicDrawerClose>
+        <UnnnicButton
+          :text="$t('agents.instructions.new_instruction_drawer.save')"
+          type="primary"
+          @click="save"
+        />
+      </UnnnicDrawerFooter>
+    </UnnnicDrawerContent>
+  </UnnnicDrawerNext>
+</template>
+
+<script setup>
+const modelValue = defineModel({
+  type: Boolean,
+  required: true,
+});
+
+function close() {
+  modelValue.value = false;
+}
+
+function save() {
+  // TODO: Implement save
+}
+</script>
+
+<style lang="scss" scoped>
+.new-instruction-drawer {
+  height: 100%;
+
+  padding: $unnnic-space-6;
+}
+</style>

--- a/src/components/Instructions/__tests__/InstructionsHeaderActions.spec.js
+++ b/src/components/Instructions/__tests__/InstructionsHeaderActions.spec.js
@@ -11,6 +11,8 @@ describe('InstructionsHeaderActions.vue', () => {
     wrapper.findComponent('[data-testid="export-instructions-button"]');
   const findNewInstructionButton = () =>
     wrapper.findComponent('[data-testid="new-instruction-button"]');
+  const findDrawer = () =>
+    wrapper.findComponent('[data-testid="new-instruction-drawer"]');
 
   const createWrapper = () => {
     wrapper = shallowMount(InstructionsHeaderActions);
@@ -57,6 +59,28 @@ describe('InstructionsHeaderActions.vue', () => {
       expect(findNewInstructionButton().props('text')).toBe(
         i18n.global.t('agents.instructions.new_instruction'),
       );
+    });
+  });
+
+  describe('NewInstructionDrawer', () => {
+    it('renders the drawer', () => {
+      createWrapper();
+
+      expect(findDrawer().exists()).toBe(true);
+    });
+
+    it('is closed by default', () => {
+      createWrapper();
+
+      expect(findDrawer().props('modelValue')).toBe(false);
+    });
+
+    it('opens when the new instruction button is clicked', async () => {
+      createWrapper();
+
+      await findNewInstructionButton().trigger('click');
+
+      expect(findDrawer().props('modelValue')).toBe(true);
     });
   });
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -345,7 +345,12 @@
       "title": "Instructions",
       "description": "Define the rules that guide how Manager responds, communicates, and makes decisions",
       "export_instructions": "Export instructions",
-      "new_instruction": "New instruction"
+      "new_instruction": "New instruction",
+      "new_instruction_drawer": {
+        "title": "New instruction",
+        "save": "Save",
+        "cancel": "Cancel"
+      }
     },
     "profile": {
       "tone_of_voice": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -345,7 +345,12 @@
       "title": "Instrucciones",
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
       "export_instructions": "Exportar instrucciones",
-      "new_instruction": "Nueva instrucción"
+      "new_instruction": "Nueva instrucción",
+      "new_instruction_drawer": {
+        "title": "Nueva instrucción",
+        "save": "Guardar",
+        "cancel": "Cancelar"
+      }
     },
     "profile": {
       "tone_of_voice": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -345,7 +345,12 @@
       "title": "Instruções",
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
       "export_instructions": "Exportar instruções",
-      "new_instruction": "Nova instrução"
+      "new_instruction": "Nova instrução",
+      "new_instruction_drawer": {
+        "title": "Nova instrução",
+        "save": "Salvar",
+        "cancel": "Cancelar"
+      }
     },
     "profile": {
       "tone_of_voice": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -344,7 +344,12 @@
       "title": "Instrucțiuni",
       "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
       "export_instructions": "Exportă instrucțiuni",
-      "new_instruction": "Instrucțiune nouă"
+      "new_instruction": "Instrucțiune nouă",
+      "new_instruction_drawer": {
+        "title": "Instrucțiune nouă",
+        "save": "Salvează",
+        "cancel": "Anulează"
+      }
     },
     "profile": {
       "tone_of_voice": {


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

This change wires it up to open a drawer where users can create a new instruction.

### Summary of Changes

- Created the `NewInstructionDrawer` component with a title, cancel, and save button, using `UnnnicDrawerNext` with lazy mounting.
- Connected the "New Instruction" button in `InstructionsHeaderActions` to toggle the drawer's visibility via a reactive `showNewInstructionDrawer` ref.
- Added i18n keys for the drawer title, save, and cancel labels across all supported locales (en, es, pt_br, ro).
- Added unit tests covering that the drawer renders, is closed by default, and opens when the "New Instruction" button is clicked.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/813e1d34-c654-4014-86b0-2b0cf67d6f2b.png)

