### PR TITLE
[NEXUS-5340] - feat: Add form component with validate button to NewInstructionDrawer

### DIFF
--- a/src/components/Instructions/NewInstructionDrawer/Form.vue
+++ b/src/components/Instructions/NewInstructionDrawer/Form.vue
@@ -1,0 +1,85 @@
+<template>
+  <form
+    class="new-instruction-drawer__form"
+    data-testid="new-instruction-drawer-form"
+    @submit.prevent="validate"
+  >
+    <textarea
+      id="new-instruction-drawer-textarea"
+      ref="textareaRef"
+      v-model="instructionsStore.newInstruction.text"
+      class="new-instruction-drawer__textarea"
+      data-testid="new-instruction-drawer-textarea"
+    />
+
+    <UnnnicButton
+      data-testid="new-instruction-drawer-validate-button"
+      type="secondary"
+      :text="$t('agents.instructions.new_instruction_drawer.validate')"
+      :disabled="validateButtonDisabled"
+    />
+  </form>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue';
+
+import { useInstructionsStore } from '@/store/Instructions';
+
+const instructionsStore = useInstructionsStore();
+
+const textareaRef = ref<HTMLTextAreaElement | null>(null);
+
+const validateButtonDisabled = computed(() => {
+  const instructionSuggestionStatus =
+    instructionsStore.instructionSuggestedByAI.status;
+  const newInstructionText = instructionsStore.newInstruction.text.trim();
+  return (
+    !newInstructionText ||
+    instructionSuggestionStatus === 'complete' ||
+    instructionSuggestionStatus === 'loading'
+  );
+});
+
+function validate() {
+  instructionsStore.getInstructionSuggestionByAI(
+    instructionsStore.newInstruction.text,
+  );
+}
+
+onMounted(() => {
+  textareaRef.value?.focus();
+});
+</script>
+
+<style lang="scss" scoped>
+.new-instruction-drawer {
+  &__form {
+    border-radius: $unnnic-radius-2;
+    border: 1px solid $unnnic-color-border-base;
+    background-color: $unnnic-color-bg-base;
+
+    padding: $unnnic-space-4;
+
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: $unnnic-space-3;
+  }
+
+  &__textarea {
+    border-radius: $unnnic-radius-1;
+
+    resize: none;
+    width: 100%;
+    height: 80px;
+
+    color: $unnnic-color-fg-emphasized;
+    font: $unnnic-font-body;
+
+    &:focus {
+      outline: 1px solid $unnnic-color-border-accent-strong;
+    }
+  }
+}
+</style>

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/Form.spec.js
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/Form.spec.js
@@ -1,0 +1,150 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import Form from '../Form.vue';
+import i18n from '@/utils/plugins/i18n';
+import { useInstructionsStore } from '@/store/Instructions';
+
+describe('NewInstructionDrawer/Form.vue', () => {
+  let wrapper;
+  let instructionsStore;
+
+  const SELECTORS = {
+    form: '[data-testid="new-instruction-drawer-form"]',
+    textarea: '[data-testid="new-instruction-drawer-textarea"]',
+    validateButton: '[data-testid="new-instruction-drawer-validate-button"]',
+  };
+
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+  const findComponent = (selector) =>
+    wrapper.findComponent(SELECTORS[selector]);
+
+  const translation = (key) =>
+    i18n.global.t(`agents.instructions.new_instruction_drawer.${key}`);
+
+  const createWrapper = (initialState = {}) => {
+    const pinia = createTestingPinia({
+      initialState: {
+        Instructions: {
+          newInstruction: {
+            text: '',
+            status: null,
+          },
+          instructionSuggestedByAI: {
+            status: null,
+          },
+          ...initialState,
+        },
+      },
+    });
+
+    instructionsStore = useInstructionsStore(pinia);
+
+    return shallowMount(Form, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wrapper = createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  describe('Component rendering', () => {
+    it('renders the form, textarea and validate button', () => {
+      expect(find('form').exists()).toBe(true);
+      expect(find('textarea').exists()).toBe(true);
+      expect(findComponent('validateButton').exists()).toBe(true);
+    });
+
+    it('renders the validate button with the correct text', () => {
+      expect(findComponent('validateButton').props('text')).toBe(
+        translation('validate'),
+      );
+    });
+
+    it('binds the textarea value to the store newInstruction text', () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'My instruction', status: null },
+      });
+      expect(find('textarea').element.value).toBe('My instruction');
+    });
+  });
+
+  describe('Validate button states', () => {
+    it('disables the validate button when the text is empty', () => {
+      expect(findComponent('validateButton').props('disabled')).toBe(true);
+    });
+
+    it('disables the validate button when the text is only whitespace', () => {
+      wrapper = createWrapper({
+        newInstruction: { text: '   ', status: null },
+      });
+      expect(findComponent('validateButton').props('disabled')).toBe(true);
+    });
+
+    it('enables the validate button when the text has content and there is no suggestion status', () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'Valid text', status: null },
+      });
+      expect(findComponent('validateButton').props('disabled')).toBe(false);
+    });
+
+    it('disables the validate button when the suggestion status is loading', () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'Valid text', status: null },
+        instructionSuggestedByAI: { status: 'loading' },
+      });
+      expect(findComponent('validateButton').props('disabled')).toBe(true);
+    });
+
+    it('disables the validate button when the suggestion status is complete', () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'Valid text', status: null },
+        instructionSuggestedByAI: { status: 'complete' },
+      });
+      expect(findComponent('validateButton').props('disabled')).toBe(true);
+    });
+
+    it('enables the validate button when the suggestion status is error and the text has content', () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'Valid text', status: null },
+        instructionSuggestedByAI: { status: 'error' },
+      });
+      expect(findComponent('validateButton').props('disabled')).toBe(false);
+    });
+  });
+
+  describe('User interaction', () => {
+    it('requests the AI suggestion with the current text when the form is submitted', async () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'Validate me', status: null },
+      });
+
+      await find('form').trigger('submit');
+
+      expect(
+        instructionsStore.getInstructionSuggestionByAI,
+      ).toHaveBeenCalledWith('Validate me');
+    });
+  });
+
+  describe('onMounted behavior', () => {
+    it('focuses the textarea on mount', () => {
+      const focusSpy = vi.spyOn(HTMLTextAreaElement.prototype, 'focus');
+
+      wrapper = createWrapper();
+
+      expect(focusSpy).toHaveBeenCalled();
+
+      focusSpy.mockRestore();
+    });
+  });
+});

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/index.spec.js
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/index.spec.js
@@ -1,0 +1,79 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import NewInstructionDrawer from '../index.vue';
+import i18n from '@/utils/plugins/i18n';
+
+describe('NewInstructionDrawer/index.vue', () => {
+  let wrapper;
+
+  const SELECTORS = {
+    title: '[data-testid="new-instruction-drawer-title"]',
+    form: '[data-testid="new-instruction-drawer-form"]',
+    cancelButton: '[data-testid="new-instruction-drawer-cancel-button"]',
+    saveButton: '[data-testid="new-instruction-drawer-save-button"]',
+  };
+
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+  const findComponent = (selector) =>
+    wrapper.findComponent(SELECTORS[selector]);
+
+  const translation = (key) =>
+    i18n.global.t(`agents.instructions.new_instruction_drawer.${key}`);
+
+  const createWrapper = (props = {}) =>
+    mount(NewInstructionDrawer, {
+      props: {
+        modelValue: true,
+        ...props,
+      },
+      global: {
+        plugins: [createTestingPinia()],
+        stubs: {
+          UnnnicDrawerNext: false,
+          NewInstructionDrawerForm: true,
+        },
+      },
+    });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wrapper = createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  describe('Component rendering', () => {
+    it('renders the title with the correct text', () => {
+      expect(find('title').exists()).toBe(true);
+      expect(find('title').text()).toBe(translation('title'));
+    });
+
+    it('renders the instruction form inside the drawer section', () => {
+      expect(wrapper.find('.new-instruction-drawer').exists()).toBe(true);
+      expect(find('form').exists()).toBe(true);
+    });
+
+    it('renders the cancel and save buttons with the correct text', () => {
+      expect(findComponent('cancelButton').text()).toBe(translation('cancel'));
+      expect(findComponent('saveButton').text()).toBe(translation('save'));
+    });
+  });
+
+  describe('User interaction', () => {
+    it('closes the drawer when the cancel button is clicked', async () => {
+      await findComponent('cancelButton').trigger('click');
+
+      expect(wrapper.vm.modelValue).toBe(false);
+    });
+
+    it('keeps the drawer open when the save button is clicked', async () => {
+      await findComponent('saveButton').trigger('click');
+
+      expect(wrapper.vm.modelValue).toBe(true);
+    });
+  });
+});

--- a/src/components/Instructions/NewInstructionDrawer/index.vue
+++ b/src/components/Instructions/NewInstructionDrawer/index.vue
@@ -10,17 +10,21 @@
         </UnnnicDrawerTitle>
       </UnnnicDrawerHeader>
 
-      <section class="new-instruction-drawer"></section>
+      <section class="new-instruction-drawer">
+        <NewInstructionDrawerForm data-testid="new-instruction-drawer-form" />
+      </section>
 
       <UnnnicDrawerFooter>
         <UnnnicDrawerClose>
           <UnnnicButton
+            data-testid="new-instruction-drawer-cancel-button"
             :text="$t('agents.instructions.new_instruction_drawer.cancel')"
             type="tertiary"
             @click="close"
           />
         </UnnnicDrawerClose>
         <UnnnicButton
+          data-testid="new-instruction-drawer-save-button"
           :text="$t('agents.instructions.new_instruction_drawer.save')"
           type="primary"
           @click="save"
@@ -31,6 +35,8 @@
 </template>
 
 <script setup>
+import NewInstructionDrawerForm from './Form.vue';
+
 const modelValue = defineModel({
   type: Boolean,
   required: true,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -348,6 +348,7 @@
       "new_instruction": "New instruction",
       "new_instruction_drawer": {
         "title": "New instruction",
+        "validate": "Validate",
         "save": "Save",
         "cancel": "Cancel"
       }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -348,6 +348,7 @@
       "new_instruction": "Nueva instrucción",
       "new_instruction_drawer": {
         "title": "Nueva instrucción",
+        "validate": "Validar",
         "save": "Guardar",
         "cancel": "Cancelar"
       }

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -348,6 +348,7 @@
       "new_instruction": "Nova instrução",
       "new_instruction_drawer": {
         "title": "Nova instrução",
+        "validate": "Validar",
         "save": "Salvar",
         "cancel": "Cancelar"
       }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -347,6 +347,7 @@
       "new_instruction": "Instrucțiune nouă",
       "new_instruction_drawer": {
         "title": "Instrucțiune nouă",
+        "validate": "Validează",
         "save": "Salvează",
         "cancel": "Anulează"
       }


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other
```

### Motivation and Context

The New Instruction Drawer lacked a form for users to input and validate instructions before saving. This change introduces the input form with AI-powered validation support.

### Summary of Changes

- Added a `Form.vue` component inside `NewInstructionDrawer` that renders a textarea bound to `instructionsStore.newInstruction.text` and a "Validate" button that triggers `getInstructionSuggestionByAI`
- Integrated `NewInstructionDrawerForm` into the drawer's section slot in `index.vue`
- Added the `validate` translation key across all supported locales (en, es, pt_br, ro)
- Added unit tests for `Form.vue` covering rendering, validate button disabled states, form submission behavior, and textarea focus on mount
- Added unit tests for `index.vue` covering rendering of the title, form, and footer buttons, as well as cancel and save button interactions

### Demonstration  
![image.png](https://app.graphite.com/user-attachments/assets/51b28251-3971-4122-9268-27ca912f3194.png)

