### PR TITLE
[NEXUS-5411] - feat: Add unclassified topic option to conversation filters

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -107,7 +107,8 @@
           "very_dissatisfied": "😡 Very dissatisfied"
         },
         "topic": {
-          "topic": "Topic"
+          "topic": "Topic",
+          "unclassified": "Not classified"
         }
       },
       "load_conversations": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -107,7 +107,8 @@
           "very_dissatisfied": "😡 Muy insatisfecho"
         },
         "topic": {
-          "topic": "Tópico"
+          "topic": "Tópico",
+          "unclassified": "No clasificado"
         }
       },
       "load_conversations": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -107,7 +107,8 @@
           "very_dissatisfied": "😡 Muito insatisfeito"
         },
         "topic": {
-          "topic": "Tópico"
+          "topic": "Tópico",
+          "unclassified": "Não classificado"
         }
       },
       "load_conversations": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -107,7 +107,8 @@
           "very_dissatisfied": "😡 Foarte nemulțumit"
         },
         "topic": {
-          "topic": "Subiect"
+          "topic": "Subiect",
+          "unclassified": "Neclasificat"
         }
       },
       "load_conversations": {

--- a/src/views/Supervisor/SupervisorFilters/FilterTopics.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterTopics.vue
@@ -22,11 +22,17 @@ import { useSupervisorStore } from '@/store/Supervisor';
 
 const supervisorStore = useSupervisorStore();
 
+const UNCLASSIFIED_TOPIC = {
+  label: i18n.global.t('agent_builder.supervisor.filters.topic.unclassified'),
+  value: 'unclassified',
+};
+
 const topicOptions = computed(() => [
   {
     label: i18n.global.t(`agent_builder.supervisor.filters.topic.topic`),
     value: '',
   },
+  UNCLASSIFIED_TOPIC,
   ...supervisorStore.topics,
 ]);
 const topicFilter = ref(
@@ -37,7 +43,10 @@ watch(
   () => topicFilter.value,
   () => {
     supervisorStore.temporaryFilters.topics = topicFilter.value.map(
-      (subject) => subject?.label || '',
+      (subject) =>
+        subject?.value === UNCLASSIFIED_TOPIC.value
+          ? subject.value
+          : subject?.label || '',
     );
   },
   { immediate: true, deep: true },

--- a/src/views/Supervisor/SupervisorFilters/__tests__/FilterTopics.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/FilterTopics.spec.js
@@ -81,7 +81,19 @@ describe('FilterTopics.vue', () => {
       const options = topicSelect().props('options');
       expect(options).toStrictEqual(wrapper.vm.topicOptions);
       expect(Array.isArray(options)).toBe(true);
-      expect(options.length).toBe(5); // 1 default + 4 topic options
+      expect(options.length).toBe(6); // 1 default + 1 unclassified + 4 topic options
+    });
+
+    it('provides a fixed unclassified topic option', () => {
+      const options = topicSelect().props('options');
+      const unclassifiedOption = options.find(
+        (option) => option.value === 'unclassified',
+      );
+
+      expect(unclassifiedOption).toStrictEqual({
+        label: 'Not classified',
+        value: 'unclassified',
+      });
     });
   });
 
@@ -127,6 +139,27 @@ describe('FilterTopics.vue', () => {
 
       expect(store.temporaryFilters.topics).toEqual(['Billing']);
     });
+
+    it('stores the unclassified topic by its id', async () => {
+      const selection = [{ label: 'Not classified', value: 'unclassified' }];
+
+      await topicSelect().vm.$emit('update:modelValue', selection);
+      await nextTick();
+
+      expect(store.temporaryFilters.topics).toEqual(['unclassified']);
+    });
+
+    it('stores the unclassified topic by id alongside regular topics by label', async () => {
+      const selection = [
+        { label: 'Not classified', value: 'unclassified' },
+        { label: 'Billing', value: 'billing' },
+      ];
+
+      await topicSelect().vm.$emit('update:modelValue', selection);
+      await nextTick();
+
+      expect(store.temporaryFilters.topics).toEqual(['unclassified', 'Billing']);
+    });
   });
 
   describe('Topic options validation', () => {
@@ -134,6 +167,7 @@ describe('FilterTopics.vue', () => {
       const options = topicSelect().props('options');
       const expectedLabels = [
         'Topic', // default option
+        'Not classified', // fixed unclassified option
         'Billing',
         'Support',
         'Technical',


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other
```

### Motivation and Context

Conversations without an assigned topic could not be filtered in the Conversations view, as there was no option to represent unclassified conversations.

### Summary of Changes

- Added a fixed "Not classified" option to the topic filter dropdown.
- When the "Not classified" option is selected, its value (`unclassified`) is stored by ID rather than by label, distinguishing it from regular topics which are stored by label.
- Added the `unclassified` translation key to all supported locales: English, Spanish, Brazilian Portuguese, and Romanian.
- Added tests to verify the presence of the unclassified option, its correct storage behavior when selected alone, and its correct behavior when selected alongside regular topics.  


## Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/de9e7c44-aeac-4c99-ba06-4258834ac0a7.png)

