### PR TITLE
[NEXUS-5430] - feat: Display last updated date in agent detail modal

### DIFF
--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/AgentDetailSection.vue
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/AgentDetailSection.vue
@@ -16,6 +16,13 @@
     >
       {{ description }}
     </p>
+    <p
+      v-if="lastUpdated"
+      class="agent-detail-modal__section-last-updated"
+      data-testid="agent-detail-section-last-updated"
+    >
+      {{ lastUpdated }}
+    </p>
     <slot />
   </section>
 </template>
@@ -24,6 +31,7 @@
 defineProps<{
   title: string;
   description?: string;
+  lastUpdated?: string;
 }>();
 </script>
 
@@ -40,6 +48,11 @@ defineProps<{
 
   &-description {
     color: $unnnic-color-fg-base;
+    font: $unnnic-font-body;
+  }
+
+  &-last-updated {
+    color: $unnnic-color-fg-muted;
     font: $unnnic-font-body;
   }
 }

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/__tests__/AgentDetailModal.spec.js
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/__tests__/AgentDetailModal.spec.js
@@ -67,6 +67,46 @@ describe('AgentDetailModal', () => {
     expect(aboutSection.props('description')).toBe(agent.about.en);
   });
 
+  it('does not pass lastUpdated when the agent has no last_updated', () => {
+    const aboutSection = wrapper.findComponent(
+      '[data-testid="agent-detail-about-section"]',
+    );
+
+    expect(aboutSection.props('lastUpdated')).toBeUndefined();
+  });
+
+  it('passes the formatted last updated label for a custom agent with last_updated', async () => {
+    await wrapper.setProps({
+      agent: createAgent({
+        is_official: false,
+        last_updated: '2026-05-13T15:15:00',
+      }),
+    });
+
+    const aboutSection = wrapper.findComponent(
+      '[data-testid="agent-detail-about-section"]',
+    );
+
+    expect(aboutSection.props('lastUpdated')).toBe(
+      'Updated on May 13, 2026, at 3:15 p.m.',
+    );
+  });
+
+  it('does not pass lastUpdated for an official agent even with last_updated', async () => {
+    await wrapper.setProps({
+      agent: createAgent({
+        is_official: true,
+        last_updated: '2026-05-13T15:15:00',
+      }),
+    });
+
+    const aboutSection = wrapper.findComponent(
+      '[data-testid="agent-detail-about-section"]',
+    );
+
+    expect(aboutSection.props('lastUpdated')).toBeUndefined();
+  });
+
   it('emits update:open when the dialog emits update:open', async () => {
     const dialog = wrapper.findComponent('[data-testid="agent-detail-dialog"]');
 

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/__tests__/AgentDetailSection.spec.js
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/__tests__/AgentDetailSection.spec.js
@@ -21,6 +21,8 @@ describe('AgentDetailSection.vue', () => {
     wrapper.find('[data-testid="agent-detail-section-title"]');
   const findDescription = () =>
     wrapper.find('[data-testid="agent-detail-section-description"]');
+  const findLastUpdated = () =>
+    wrapper.find('[data-testid="agent-detail-section-last-updated"]');
 
   afterEach(() => {
     wrapper?.unmount();
@@ -55,6 +57,24 @@ describe('AgentDetailSection.vue', () => {
     createWrapper({ title: 'About', description: '' });
 
     expect(findDescription().exists()).toBe(false);
+  });
+
+  it('renders the last updated text when provided', () => {
+    createWrapper({
+      title: 'About',
+      lastUpdated: 'Updated on May 13, 2026, at 3:15 p.m.',
+    });
+
+    expect(findLastUpdated().exists()).toBe(true);
+    expect(findLastUpdated().text()).toBe(
+      'Updated on May 13, 2026, at 3:15 p.m.',
+    );
+  });
+
+  it('does not render the last updated text when not provided', () => {
+    createWrapper({ title: 'About' });
+
+    expect(findLastUpdated().exists()).toBe(false);
   });
 
   it('renders default slot content', () => {

--- a/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/index.vue
+++ b/src/components/AgentsTeam/DetailAgentCard/AgentDetailModal/index.vue
@@ -21,6 +21,7 @@
             <AgentDetailSection
               :title="$t('agents.assigned_agents.agent_details.about')"
               :description="aboutDescription"
+              :lastUpdated="lastUpdatedLabel"
               data-testid="agent-detail-about-section"
             />
 
@@ -49,8 +50,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
+import { useI18n } from 'vue-i18n';
+
 import { Agent } from '@/store/types/Agents.types';
 import useTranslatedField from '@/composables/useTranslatedField';
+import { formatLongDate, formatTime } from '@/utils/formatters';
 
 import AgentModalHeader from '@/components/AgentsTeam/AgentModalHeader.vue';
 import McpSection from './McpSection.vue';
@@ -62,9 +66,21 @@ const props = defineProps<{
   agent: Agent;
 }>();
 
+const { t } = useI18n();
+
 const translateField = useTranslatedField();
 
 const aboutDescription = computed(() => translateField(props.agent.about));
+
+const lastUpdatedLabel = computed(() => {
+  const { last_updated, is_official } = props.agent;
+  if (!last_updated || is_official) return undefined;
+
+  return t('agents.assigned_agents.agent_details.last_updated', {
+    date: formatLongDate(last_updated),
+    time: formatTime(last_updated),
+  });
+});
 
 const assignedMCP = computed(
   () => props.agent.mcps?.filter((mcp) => mcp.name)?.[0] ?? null,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -313,6 +313,7 @@
       },
       "agent_details": {
         "about": "About",
+        "last_updated": "Updated on {date}, at {time}",
         "mcp": "MCP",
         "system": "System",
         "view_options": "View options",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -313,6 +313,7 @@
       },
       "agent_details": {
         "about": "Sobre",
+        "last_updated": "Actualizado el {date}, a las {time}",
         "mcp": "MCP",
         "system": "Sistema",
         "view_options": "Ver opciones",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -313,6 +313,7 @@
       },
       "agent_details": {
         "about": "Sobre",
+        "last_updated": "Atualizado em {date}, às {time}",
         "mcp": "MCP",
         "system": "Sistema",
         "view_options": "Ver opções",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -312,6 +312,7 @@
       },
       "agent_details": {
         "about": "Despre",
+        "last_updated": "Actualizat pe {date}, la {time}",
         "mcp": "MCP",
         "system": "Sistem",
         "view_options": "Vizualizare opțiuni",

--- a/src/store/types/Agents.types.ts
+++ b/src/store/types/Agents.types.ts
@@ -80,6 +80,7 @@ export interface Agent {
   conversation_example?: TranslatedField<ConversationMessage[]> | null;
   icon: string;
   id?: string;
+  last_updated?: string | null;
 }
 
 type SelectOption = {

--- a/src/utils/__tests__/formatters.spec.js
+++ b/src/utils/__tests__/formatters.spec.js
@@ -1,5 +1,11 @@
-import { describe, it, expect } from 'vitest';
-import { formatListToReadable, formatWhatsappUrn } from '@/utils/formatters';
+import { afterEach, describe, it, expect } from 'vitest';
+import {
+  formatListToReadable,
+  formatWhatsappUrn,
+  formatLongDate,
+  formatTime,
+} from '@/utils/formatters';
+import i18n from '@/utils/plugins/i18n';
 
 describe('formatters', () => {
   describe('formatListToReadable', () => {
@@ -93,6 +99,48 @@ describe('formatters', () => {
       it(`should handle ${description} gracefully`, () => {
         expect(formatWhatsappUrn(input)).toBe(expected);
       });
+    });
+  });
+
+  describe('formatLongDate', () => {
+    const TIMESTAMP = '2026-05-13T15:15:00';
+
+    afterEach(() => {
+      i18n.global.locale.value = 'en';
+    });
+
+    it('formats the long date', () => {
+      expect(formatLongDate(TIMESTAMP)).toBe('May 13, 2026');
+    });
+
+    it('falls back to the en pattern for an unmapped locale', () => {
+      i18n.global.locale.value = 'unmapped';
+      expect(formatLongDate(TIMESTAMP)).toBe('May 13, 2026');
+    });
+
+    it('returns an empty string for an invalid date', () => {
+      expect(formatLongDate('not-a-date')).toBe('');
+    });
+  });
+
+  describe('formatTime', () => {
+    const TIMESTAMP = '2026-05-13T15:15:00';
+
+    afterEach(() => {
+      i18n.global.locale.value = 'en';
+    });
+
+    it('formats the time', () => {
+      expect(formatTime(TIMESTAMP)).toBe('3:15 p.m.');
+    });
+
+    it('falls back to the en pattern for an unmapped locale', () => {
+      i18n.global.locale.value = 'unmapped';
+      expect(formatTime(TIMESTAMP)).toBe('3:15 p.m.');
+    });
+
+    it('returns an empty string for an invalid date', () => {
+      expect(formatTime('not-a-date')).toBe('');
     });
   });
 });

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -3,6 +3,13 @@ import i18n from '@/utils/plugins/i18n';
 import { format } from 'date-fns';
 import { enUS, es as esLocale, ptBR, ro as roLocale } from 'date-fns/locale';
 
+const DATE_FNS_LOCALE_MAP = {
+  en: enUS,
+  es: esLocale,
+  'pt-br': ptBR,
+  ro: roLocale,
+};
+
 /**
  * Formats an array of items into a human-readable string with proper conjunction
  * @param {Array} items - Array of items to format
@@ -57,28 +64,72 @@ export function formatWhatsappUrn(urn: string): string {
   return `+${ddi} (${ddd}) ${formattedNumber}`;
 }
 
-export function formatTimestamp(timestamp: string) {
-  const { locale } = i18n.global;
-  const FALLBACK_PATTERN = 'MM/dd/yy HH:mm';
-  const DATE_LOCALE_MAP = {
-    en: enUS,
-    es: esLocale,
-    'pt-br': ptBR,
-    ro: roLocale,
-  };
-  const DATE_PATTERN_MAP = {
-    en: FALLBACK_PATTERN,
-    es: 'dd/MM/yy HH:mm',
-    'pt-br': 'dd/MM/yy HH:mm',
-    ro: 'dd/MM/yy HH:mm',
-  };
-
+/**
+ * Formats a timestamp using a locale-specific date-fns pattern.
+ * Parses and guards the timestamp, then resolves the pattern and locale for
+ * the active language, falling back to the provided pattern and enUS.
+ * @param {String} timestamp - The timestamp to format
+ * @param {Object} patternMap - Map of locale to date-fns pattern
+ * @param {String} fallbackPattern - Pattern used for unmapped locales
+ * @returns {String} Formatted timestamp or empty string for invalid dates
+ */
+function formatWithLocalePattern(
+  timestamp: string,
+  patternMap: Record<string, string>,
+  fallbackPattern: string,
+): string {
   const parsedDate = new Date(timestamp);
 
   if (Number.isNaN(parsedDate.getTime())) return '';
 
-  const dateLocale = DATE_LOCALE_MAP[locale] || enUS;
-  const displayPattern = DATE_PATTERN_MAP[locale] || FALLBACK_PATTERN;
+  const { locale } = i18n.global;
+  const dateLocale = DATE_FNS_LOCALE_MAP[locale.value] || enUS;
+  const displayPattern = patternMap[locale.value] || fallbackPattern;
 
   return format(parsedDate, displayPattern, { locale: dateLocale });
+}
+
+export function formatTimestamp(timestamp: string) {
+  const FALLBACK_PATTERN = 'MM/dd/yy HH:mm';
+
+  return formatWithLocalePattern(
+    timestamp,
+    {
+      en: FALLBACK_PATTERN,
+      es: 'dd/MM/yy HH:mm',
+      'pt-br': 'dd/MM/yy HH:mm',
+      ro: 'dd/MM/yy HH:mm',
+    },
+    FALLBACK_PATTERN,
+  );
+}
+
+export function formatLongDate(timestamp: string) {
+  const FALLBACK_PATTERN = 'MMMM d, yyyy';
+
+  return formatWithLocalePattern(
+    timestamp,
+    {
+      en: FALLBACK_PATTERN,
+      es: "d 'de' MMMM 'de' yyyy",
+      'pt-br': "d 'de' MMMM 'de' yyyy",
+      ro: 'd MMMM yyyy',
+    },
+    FALLBACK_PATTERN,
+  );
+}
+
+export function formatTime(timestamp: string) {
+  const FALLBACK_PATTERN = 'h:mm aaaa';
+
+  return formatWithLocalePattern(
+    timestamp,
+    {
+      en: FALLBACK_PATTERN,
+      es: 'HH:mm',
+      'pt-br': "HH'h'mm",
+      ro: 'HH:mm',
+    },
+    FALLBACK_PATTERN,
+  );
 }


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other
```

### Motivation and Context

Users should be able to see when an agent was last updated directly from the agent detail modal.

### Summary of Changes

- Added a `lastUpdated` optional prop to `AgentDetailSection` that renders a styled "last updated" paragraph when provided.
- Added `last_updated` as an optional field on the `Agent` type.
- Introduced `formatLongDate` and `formatTime` utility functions that format a timestamp into locale-aware date and time strings, with a shared `DATE_FNS_LOCALE_MAP` to avoid duplication across formatters.
- Computed a `lastUpdatedLabel` in the agent detail modal that combines the formatted date and time using the `agents.assigned_agents.agent_details.last_updated` i18n key.
- Added the `last_updated` translation key in English, Spanish, Portuguese (BR), and Romanian locales.
- Added unit tests for `formatLongDate` and `formatTime`, including locale fallback and invalid date handling, as well as tests for the new `lastUpdated` prop behavior in both `AgentDetailSection` and `AgentDetailModal`.

### Design Files

- [Design File](https://www.figma.com/design/dypV9U51xgTKfSywY3AbSC/Agents?node-id=9602-4453)

### Demonstration <!--- (If not appropriate, remove this topic) -->

<!--- Include a screenshot or video showcasing a feature or fix implemented in this pull request. -->