### PR TITLE
feat: Add categorized instructions support

### DIFF
--- a/src/api/adapters/instructions/classification.js
+++ b/src/api/adapters/instructions/classification.js
@@ -1,0 +1,13 @@
+export const InstructionClassificationAdapter = {
+  fromApi({
+    classification = [],
+    suggestion = '',
+    suggested_category = '',
+  } = {}) {
+    return {
+      classification,
+      suggestion,
+      suggestedCategory: suggested_category ?? '',
+    };
+  },
+};

--- a/src/api/adapters/instructions/grouped.js
+++ b/src/api/adapters/instructions/grouped.js
@@ -1,0 +1,52 @@
+export const InstructionsGroupedAdapter = {
+  fromApi({ categories = [], uncategorized_instructions = [] } = {}) {
+    const categorized = categories.flatMap((category) =>
+      (category.instructions || []).map((instruction) => ({
+        id: instruction.id,
+        text: instruction.instruction,
+        category: { id: category.id, name: category.name },
+      })),
+    );
+
+    const uncategorized = uncategorized_instructions.map((instruction) => ({
+      id: instruction.id,
+      text: instruction.instruction,
+      category: null,
+    }));
+
+    return {
+      instructions: [...categorized, ...uncategorized],
+      categories: categories.map((category) => ({
+        id: category.id,
+        name: category.name,
+      })),
+    };
+  },
+
+  toCreateApi({ text, category }) {
+    const body = { instruction: text.trim() };
+
+    if (category) {
+      body.category = category;
+    }
+
+    return body;
+  },
+
+  toUpdateApi({ categories = [], uncategorizedInstructions = [] } = {}) {
+    const toApiInstruction = ({ id, text }) => ({
+      id,
+      instruction: text,
+    });
+
+    return {
+      categories: categories.map((category) => ({
+        id: category.id,
+        name: category.name,
+        instructions: (category.instructions || []).map(toApiInstruction),
+      })),
+      uncategorized_instructions:
+        uncategorizedInstructions.map(toApiInstruction),
+    };
+  },
+};

--- a/src/api/nexus/Instructions.js
+++ b/src/api/nexus/Instructions.js
@@ -1,5 +1,7 @@
 import nexusRequest from '../nexusaiRequest';
 import { InstructionAdapter } from '../adapters/instructions/instruction';
+import { InstructionClassificationAdapter } from '../adapters/instructions/classification';
+import { InstructionsGroupedAdapter } from '../adapters/instructions/grouped';
 import { useInstructionsStore } from '@/store/Instructions';
 
 import i18n from '@/utils/plugins/i18n';
@@ -7,6 +9,45 @@ import i18n from '@/utils/plugins/i18n';
 const request = nexusRequest;
 
 export const Instructions = {
+  async listGrouped({ projectUuid }) {
+    const response = await request.$http.get(
+      `api/${projectUuid}/instructions/`,
+    );
+
+    return InstructionsGroupedAdapter.fromApi(response.data);
+  },
+
+  async create({ projectUuid, instruction, category }) {
+    const response = await request.$http.post(
+      `api/${projectUuid}/instructions/`,
+      InstructionsGroupedAdapter.toCreateApi({ text: instruction, category }),
+      {
+        hideGenericErrorAlert: true,
+      },
+    );
+
+    return InstructionsGroupedAdapter.fromApi(response.data);
+  },
+
+  async update({ projectUuid, ...groupedPayload }) {
+    const response = await request.$http.patch(
+      `api/${projectUuid}/instructions/`,
+      InstructionsGroupedAdapter.toUpdateApi(groupedPayload),
+    );
+
+    return InstructionsGroupedAdapter.fromApi(response.data);
+  },
+
+  async deleteInstruction({ projectUuid, id }) {
+    await request.$http.delete(`api/${projectUuid}/instructions/?id=${id}`);
+  },
+
+  async deleteCategory({ projectUuid, id }) {
+    await request.$http.delete(
+      `api/${projectUuid}/instructions/categories/${id}/`,
+    );
+  },
+
   async addInstruction({ projectUuid, instruction }) {
     const instructionsStore = useInstructionsStore();
     const body = {
@@ -60,7 +101,11 @@ export const Instructions = {
     await request.$http.delete(`api/${projectUuid}/customization/?id=${id}`);
   },
 
-  async getSuggestionByAI({ projectUuid, instruction }) {
+  async getSuggestionByAI({
+    projectUuid,
+    instruction,
+    instructionsCategories = [],
+  }) {
     const languageMap = {
       en: 'English',
       'pt-br': 'Portuguese',
@@ -73,9 +118,10 @@ export const Instructions = {
       `api/${projectUuid}/instructions-classification/`,
       {
         instruction,
+        instructions_categories: instructionsCategories,
         language,
       },
     );
-    return response;
+    return InstructionClassificationAdapter.fromApi(response.data);
   },
 };

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -1,10 +1,15 @@
 import { reactive, ref, computed } from 'vue';
 import { defineStore } from 'pinia';
 
-import type { InstructionSuggestedByAI } from './types/Instructions.types';
+import type {
+  InstructionSuggestedByAI,
+  InstructionCategory,
+  NewInstruction,
+} from './types/Instructions.types';
 
 import { useProjectStore } from './Project';
 import { useAlertStore } from './Alert';
+import { useFeatureFlagsStore } from './FeatureFlags';
 
 import nexusaiAPI from '@/api/nexusaiAPI';
 
@@ -21,16 +26,111 @@ function callAlert(type, alertText) {
 
 export const useInstructionsStore = defineStore('Instructions', () => {
   const projectUuid = computed(() => useProjectStore().uuid);
+  const featureFlags = useFeatureFlagsStore();
+  const useV2 = () => featureFlags.flags.categorizationOfInstructions;
 
   const instructions = reactive({
     data: [],
     status: null,
   });
 
-  const newInstruction = reactive({
+  const categories = ref<InstructionCategory[]>([]);
+  const sessionCategories = ref<string[]>([]);
+
+  const categoryOptions = computed<InstructionCategory[]>(() => {
+    const optionsByName = new Map<string, InstructionCategory>();
+
+    categories.value.forEach((category) => {
+      optionsByName.set(category.name, {
+        id: category.id,
+        name: category.name,
+      });
+    });
+
+    sessionCategories.value.forEach((name) => {
+      if (!optionsByName.has(name)) {
+        optionsByName.set(name, { id: null, name });
+      }
+    });
+
+    const suggested = instructionSuggestedByAI.data.suggestedCategory;
+    if (suggested && !optionsByName.has(suggested)) {
+      optionsByName.set(suggested, { id: null, name: suggested });
+    }
+
+    return [...optionsByName.values()];
+  });
+
+  const newInstruction = reactive<NewInstruction>({
     text: '',
+    category: null,
     status: null,
   });
+
+  const selectedCategoryIsNew = computed(
+    () => !!newInstruction.category && newInstruction.category.id === null,
+  );
+
+  const suggestedCategory = computed<InstructionCategory | null>(() => {
+    const name = instructionSuggestedByAI.data.suggestedCategory;
+    if (!name) return null;
+
+    return (
+      categoryOptions.value.find((category) => category.name === name) ?? {
+        id: null,
+        name,
+      }
+    );
+  });
+
+  const suggestedCategoryIsNew = computed(
+    () => !!suggestedCategory.value && suggestedCategory.value.id === null,
+  );
+
+  function createCategory(name: string) {
+    const trimmedName = name.trim();
+    if (!sessionCategories.value.includes(trimmedName)) {
+      sessionCategories.value.push(trimmedName);
+    }
+    newInstruction.category = { id: null, name: trimmedName };
+  }
+
+  function toCategoryPayload() {
+    const category = newInstruction.category;
+    if (!category) return undefined;
+    return category.id !== null ? { id: category.id } : { name: category.name };
+  }
+
+  function toGroupedPayload() {
+    type GroupedItem = { id: number; text: string };
+    const categoriesById = new Map<
+      number,
+      { id: number; name: string; instructions: GroupedItem[] }
+    >();
+    const uncategorizedInstructions: GroupedItem[] = [];
+
+    instructions.data.forEach((instruction) => {
+      const item = { id: instruction.id, text: instruction.text };
+
+      if (instruction.category) {
+        const { id, name } = instruction.category;
+        const group = categoriesById.get(id) ?? {
+          id,
+          name,
+          instructions: [],
+        };
+        group.instructions.push(item);
+        categoriesById.set(id, group);
+      } else {
+        uncategorizedInstructions.push(item);
+      }
+    });
+
+    return {
+      categories: [...categoriesById.values()],
+      uncategorizedInstructions,
+    };
+  }
 
   const storedValidation = moduleStorage.getItem('validateInstructionByAI');
 
@@ -41,6 +141,7 @@ export const useInstructionsStore = defineStore('Instructions', () => {
       instruction: '',
       classification: [],
       suggestion: '',
+      suggestedCategory: '',
     },
     suggestionApplied: '',
     status: null,
@@ -53,19 +154,32 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     activeInstructionsListTab.value = 'custom';
 
     try {
-      const instructionResponse =
-        await nexusaiAPI.agent_builder.instructions.addInstruction({
+      if (useV2()) {
+        const response = await nexusaiAPI.agent_builder.instructions.create({
           projectUuid: projectUuid.value,
-          instruction: newInstruction,
+          instruction: newInstruction.text,
+          category: toCategoryPayload(),
         });
 
-      instructions.data.unshift({
-        ...newInstruction,
-        status: 'complete',
-        id: instructionResponse.id,
-      });
+        instructions.data = response.instructions;
+        categories.value = response.categories;
+      } else {
+        const instructionResponse =
+          await nexusaiAPI.agent_builder.instructions.addInstruction({
+            projectUuid: projectUuid.value,
+            instruction: newInstruction,
+          });
+
+        instructions.data.unshift({
+          ...newInstruction,
+          status: 'complete',
+          id: instructionResponse.id,
+        });
+      }
+
       newInstruction.status = null;
       newInstruction.text = '';
+      newInstruction.category = null;
 
       callAlert('success', 'new_instruction.success_alert');
     } catch (error) {
@@ -77,11 +191,22 @@ export const useInstructionsStore = defineStore('Instructions', () => {
   async function loadInstructions() {
     instructions.status = 'loading';
     try {
-      const response = await nexusaiAPI.agent_builder.instructions.list({
-        projectUuid: projectUuid.value,
-      });
+      if (useV2()) {
+        const response =
+          await nexusaiAPI.agent_builder.instructions.listGrouped({
+            projectUuid: projectUuid.value,
+          });
 
-      instructions.data = [...instructions.data, ...response];
+        instructions.data = response.instructions;
+        categories.value = response.categories;
+      } else {
+        const response = await nexusaiAPI.agent_builder.instructions.list({
+          projectUuid: projectUuid.value,
+        });
+
+        instructions.data = [...instructions.data, ...response];
+      }
+
       instructions.status = 'complete';
     } catch (error) {
       instructions.status = 'error';
@@ -96,12 +221,30 @@ export const useInstructionsStore = defineStore('Instructions', () => {
 
     try {
       instruction.status = 'loading';
-      await nexusaiAPI.agent_builder.instructions.edit({
-        projectUuid: projectUuid.value,
-        id,
-        text,
-      });
-      instruction.text = text;
+
+
+      if (useV2()) {
+        const previousText = instruction.text;
+        try {
+          await nexusaiAPI.agent_builder.instructions.update({
+            projectUuid: projectUuid.value,
+            ...toGroupedPayload(),
+          });
+          instruction.text = text;
+        } catch (error) {
+          instruction.text = previousText;
+          throw error;
+        }
+      } else {
+        await nexusaiAPI.agent_builder.instructions.edit({
+          projectUuid: projectUuid.value,
+          id,
+          text,
+        });
+        instruction.text = text;
+      }
+
+
       instruction.status = 'complete';
 
       callAlert('success', 'edit_instruction.success_alert');
@@ -121,10 +264,17 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     instruction.status = 'loading';
 
     try {
-      await nexusaiAPI.agent_builder.instructions.delete({
-        projectUuid: projectUuid.value,
-        id,
-      });
+      if (useV2()) {
+        await nexusaiAPI.agent_builder.instructions.deleteInstruction({
+          projectUuid: projectUuid.value,
+          id,
+        });
+      } else {
+        await nexusaiAPI.agent_builder.instructions.delete({
+          projectUuid: projectUuid.value,
+          id,
+        });
+      }
       instructions.data = instructions.data.filter(
         (instruction) => instruction.id !== id,
       );
@@ -142,18 +292,35 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     instructionSuggestedByAI.status = 'loading';
 
     try {
-      const { data } =
+      const data =
         await nexusaiAPI.agent_builder.instructions.getSuggestionByAI({
           projectUuid: projectUuid.value,
           instruction,
+          instructionsCategories: categories.value.map(
+            (category) => category.name,
+          ),
         });
+
+      const suggestedCategory = data.suggestedCategory ?? '';
 
       instructionSuggestedByAI.data = {
         instruction,
-        ...data,
+        classification: data.classification ?? [],
+        suggestion: data.suggestion ?? '',
+        suggestedCategory,
       };
       instructionSuggestedByAI.suggestionApplied = '';
       instructionSuggestedByAI.status = 'complete';
+
+      if (suggestedCategory) {
+        const existing = categories.value.find(
+          (category) => category.name === suggestedCategory,
+        );
+        newInstruction.category = {
+          id: existing ? existing.id : null,
+          name: suggestedCategory,
+        };
+      }
     } catch (error) {
       instructionSuggestedByAI.status = 'error';
       callAlert(
@@ -173,15 +340,24 @@ export const useInstructionsStore = defineStore('Instructions', () => {
       instruction: '',
       classification: [],
       suggestion: '',
+      suggestedCategory: '',
     };
+    instructionSuggestedByAI.status = null;
   }
 
   return {
     instructions,
+    categories,
+    sessionCategories,
+    categoryOptions,
     newInstruction,
+    selectedCategoryIsNew,
+    suggestedCategory,
+    suggestedCategoryIsNew,
     validateInstructionByAI,
     instructionSuggestedByAI,
     activeInstructionsListTab,
+    createCategory,
     addInstruction,
     loadInstructions,
     editInstruction,

--- a/src/store/__tests__/Instructions.unit.spec.js
+++ b/src/store/__tests__/Instructions.unit.spec.js
@@ -14,6 +14,11 @@ vi.mock('@/api/nexusaiAPI', () => ({
         list: vi.fn(),
         edit: vi.fn(),
         delete: vi.fn(),
+        create: vi.fn(),
+        listGrouped: vi.fn(),
+        update: vi.fn(),
+        deleteInstruction: vi.fn(),
+        getSuggestionByAI: vi.fn(),
       },
     },
   },
@@ -21,6 +26,12 @@ vi.mock('@/api/nexusaiAPI', () => ({
 
 vi.mock('@/store/Project', () => ({
   useProjectStore: () => ({ uuid: 'test-project-uuid' }),
+}));
+
+const featureFlagsState = { categorizationOfInstructions: false };
+
+vi.mock('@/store/FeatureFlags', () => ({
+  useFeatureFlagsStore: () => ({ flags: featureFlagsState }),
 }));
 
 vi.mock('@/utils/storage', () => ({
@@ -35,6 +46,7 @@ describe('Instructions Store', () => {
   let alertStore;
 
   beforeEach(() => {
+    featureFlagsState.categorizationOfInstructions = false;
     setActivePinia(createPinia());
     store = useInstructionsStore();
     alertStore = useAlertStore();
@@ -54,6 +66,7 @@ describe('Instructions Store', () => {
     it('should have correct initial state for newInstruction', () => {
       expect(store.newInstruction).toEqual({
         text: '',
+        category: null,
         status: null,
       });
     });
@@ -101,6 +114,7 @@ describe('Instructions Store', () => {
         expect(store.instructions.data).toHaveLength(1);
         expect(store.instructions.data[0]).toEqual({
           text: 'New instruction text',
+          category: null,
           status: 'complete',
           id: 1,
         });
@@ -452,6 +466,7 @@ describe('Instructions Store', () => {
 
       expect(store.instructions.data[0]).toEqual({
         text: 'Updated instruction',
+        category: null,
         status: 'complete',
         id: 1,
       });
@@ -485,6 +500,168 @@ describe('Instructions Store', () => {
       await store.editInstruction(1, 'Updated instruction 1');
 
       expect(store.instructions.data[0].text).toBe('Updated instruction 1');
+    });
+  });
+
+  describe('Categorization flag (V2) branch', () => {
+    const groupedResponse = {
+      instructions: [
+        { id: 1, text: 'Instruction 1', category: { id: 10, name: 'Sales' } },
+        { id: 2, text: 'Instruction 2', category: null },
+      ],
+      categories: [{ id: 10, name: 'Sales' }],
+    };
+
+    beforeEach(() => {
+      featureFlagsState.categorizationOfInstructions = true;
+    });
+
+    describe('loadInstructions', () => {
+      it('loads grouped instructions and categories, replacing existing data', async () => {
+        store.instructions.data = [{ id: 99, text: 'Stale', category: null }];
+        nexusaiAPI.agent_builder.instructions.listGrouped.mockResolvedValue(
+          groupedResponse,
+        );
+
+        await store.loadInstructions();
+
+        expect(
+          nexusaiAPI.agent_builder.instructions.listGrouped,
+        ).toHaveBeenCalledWith({ projectUuid: 'test-project-uuid' });
+        expect(
+          nexusaiAPI.agent_builder.instructions.list,
+        ).not.toHaveBeenCalled();
+        expect(store.instructions.data).toEqual(groupedResponse.instructions);
+        expect(store.categories).toEqual(groupedResponse.categories);
+        expect(store.instructions.status).toBe('complete');
+      });
+    });
+
+    describe('addInstruction', () => {
+      beforeEach(() => {
+        store.newInstruction.text = 'New instruction text';
+        nexusaiAPI.agent_builder.instructions.create.mockResolvedValue(
+          groupedResponse,
+        );
+      });
+
+      it('sends the category id when an existing category is selected', async () => {
+        store.newInstruction.category = { id: 10, name: 'Sales' };
+
+        await store.addInstruction();
+
+        expect(
+          nexusaiAPI.agent_builder.instructions.create,
+        ).toHaveBeenCalledWith({
+          projectUuid: 'test-project-uuid',
+          instruction: 'New instruction text',
+          category: { id: 10 },
+        });
+        expect(store.instructions.data).toEqual(groupedResponse.instructions);
+        expect(store.categories).toEqual(groupedResponse.categories);
+        expect(store.newInstruction.text).toBe('');
+        expect(store.newInstruction.category).toBeNull();
+      });
+
+      it('sends the category name when a new category is selected', async () => {
+        store.newInstruction.category = { id: null, name: 'Marketing' };
+
+        await store.addInstruction();
+
+        expect(
+          nexusaiAPI.agent_builder.instructions.create,
+        ).toHaveBeenCalledWith({
+          projectUuid: 'test-project-uuid',
+          instruction: 'New instruction text',
+          category: { name: 'Marketing' },
+        });
+      });
+
+      it('omits the category when none is selected', async () => {
+        store.newInstruction.category = null;
+
+        await store.addInstruction();
+
+        expect(
+          nexusaiAPI.agent_builder.instructions.create,
+        ).toHaveBeenCalledWith({
+          projectUuid: 'test-project-uuid',
+          instruction: 'New instruction text',
+          category: undefined,
+        });
+      });
+
+      it('sets error status when the create request fails', async () => {
+        nexusaiAPI.agent_builder.instructions.create.mockRejectedValue(
+          new Error('API Error'),
+        );
+
+        await store.addInstruction();
+
+        expect(store.newInstruction.status).toBe('error');
+      });
+    });
+
+    describe('removeInstruction', () => {
+      beforeEach(() => {
+        store.instructions.data = [
+          { id: 1, text: 'Instruction 1', category: null },
+          { id: 2, text: 'Instruction 2', category: null },
+        ];
+      });
+
+      it('deletes a single instruction via the grouped endpoint', async () => {
+        nexusaiAPI.agent_builder.instructions.deleteInstruction.mockResolvedValue();
+
+        await store.removeInstruction(1);
+
+        expect(
+          nexusaiAPI.agent_builder.instructions.deleteInstruction,
+        ).toHaveBeenCalledWith({ projectUuid: 'test-project-uuid', id: 1 });
+        expect(
+          nexusaiAPI.agent_builder.instructions.delete,
+        ).not.toHaveBeenCalled();
+        expect(store.instructions.data).toHaveLength(1);
+        expect(store.instructions.data[0].id).toBe(2);
+      });
+    });
+
+    describe('getInstructionSuggestionByAI default category selection', () => {
+      it('attaches the existing category id when the suggestion matches a known category', async () => {
+        store.categories = [{ id: 10, name: 'Sales' }];
+        nexusaiAPI.agent_builder.instructions.getSuggestionByAI.mockResolvedValue(
+          {
+            classification: [],
+            suggestion: '',
+            suggestedCategory: 'Sales',
+          },
+        );
+
+        await store.getInstructionSuggestionByAI('Some instruction');
+
+        expect(store.newInstruction.category).toEqual({
+          id: 10,
+          name: 'Sales',
+        });
+      });
+
+      it('defaults to a new category when the suggestion is unknown', async () => {
+        store.categories = [{ id: 10, name: 'Sales' }];
+        nexusaiAPI.agent_builder.instructions.getSuggestionByAI.mockResolvedValue(
+          {
+            classification: [],
+            suggestion: '',
+            suggestedCategory: 'Logistics',
+          },
+        );
+
+        await store.getInstructionSuggestionByAI('Some instruction');
+
+        expect(store.newInstruction.category).toEqual({
+          id: null,
+          name: 'Logistics',
+        });
+      });
     });
   });
 });

--- a/src/store/types/Instructions.types.ts
+++ b/src/store/types/Instructions.types.ts
@@ -13,6 +13,18 @@ export interface InstructionSuggestedByAI {
     instruction: string;
     classification: Classification[] | [];
     suggestion: string;
+    suggestedCategory: string;
   };
+  status: 'loading' | 'complete' | 'error' | null;
+}
+
+export interface InstructionCategory {
+  id: number | null;
+  name: string;
+}
+
+export interface NewInstruction {
+  text: string;
+  category: InstructionCategory | null;
   status: 'loading' | 'complete' | 'error' | null;
 }


### PR DESCRIPTION
## Description

### Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other

### Motivation and Context

Enable instruction categorization: assign instructions to existing or new categories, with optional AI-suggested categories on validation.

### Summary of Changes

Adds a categorization flow behind the `categorizationOfInstructions` feature flag (V2 path).

**API**

- New adapters: `InstructionClassificationAdapter` (AI response, incl. `suggestedCategory`) and `InstructionsGroupedAdapter` (`fromApi`, `toCreateApi`, `toUpdateApi`).
- New/updated endpoints: `listGrouped`, `create`, `update`, `deleteInstruction`, `deleteCategory`; `getSuggestionByAI` now accepts `instructionsCategories` and returns normalized data.

**Store**

- Category state: `categories`, `sessionCategories`, `categoryOptions`, plus `newInstruction.category`.
- Computed helpers: `selectedCategoryIsNew`, `suggestedCategory`, `suggestedCategoryIsNew`.
- `createCategory` for session-local categories.
- `addInstruction`, `loadInstructions`, `editInstruction`, `removeInstruction`, and `getInstructionSuggestionByAI` branch on the flag (V2 grouped vs legacy).
- AI suggestion pre-fills `newInstruction.category` (matched by name when possible).

**Types**

- Added `InstructionCategory`, `NewInstruction`; extended `InstructionSuggestedByAI` with `suggestedCategory`.

**Tests**

- V2 suite for load, create (existing/new/no category), remove, and AI category pre-selection.