### PR TITLE
feat: Add useCategoryValidation composable

### DIFF
--- a/src/components/Instructions/NewInstructionDrawer/__tests__/useCategoryValidation.spec.ts
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/useCategoryValidation.spec.ts
@@ -1,0 +1,77 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import { ref } from 'vue';
+import type { Ref } from 'vue';
+
+import i18n from '@/utils/plugins/i18n';
+import { useCategoryValidation } from '../useCategoryValidation';
+
+const validationT = (key: string) =>
+  i18n.global.t(
+    `agents.instructions.new_instruction_drawer.ai_analysis.category.validation.${key}`,
+  );
+
+type ValidationResult = ReturnType<typeof useCategoryValidation>;
+
+const setup = (initialName = '') => {
+  const name = ref(initialName);
+  let validation: ValidationResult;
+
+  const wrapper = mount({
+    template: '<div />',
+    setup() {
+      validation = useCategoryValidation(name as Ref<string>);
+      return {};
+    },
+  });
+
+  return { name, validation: validation!, wrapper };
+};
+
+describe('useCategoryValidation', () => {
+  it('returns the required message and is invalid for an empty name', () => {
+    const { validation } = setup('');
+
+    expect(validation.error.value).toBe(validationT('required'));
+    expect(validation.isValid.value).toBe(false);
+  });
+
+  it('returns the required message for a whitespace-only name', () => {
+    const { validation } = setup('   ');
+
+    expect(validation.error.value).toBe(validationT('required'));
+    expect(validation.isValid.value).toBe(false);
+  });
+
+  it('returns the invalid chars message when disallowed characters are used', () => {
+    const { validation } = setup('Sales & Support');
+
+    expect(validation.error.value).toBe(validationT('invalid_chars'));
+    expect(validation.isValid.value).toBe(false);
+  });
+
+  it('is valid for a name with letters, numbers, spaces and hyphens', () => {
+    const { validation } = setup('Sales 2 - Support');
+
+    expect(validation.error.value).toBeNull();
+    expect(validation.isValid.value).toBe(true);
+  });
+
+  it('trims surrounding whitespace before validating', () => {
+    const { validation } = setup('  Sales  ');
+
+    expect(validation.error.value).toBeNull();
+    expect(validation.isValid.value).toBe(true);
+  });
+
+  it('reacts to name changes', async () => {
+    const { name, validation } = setup('');
+
+    expect(validation.isValid.value).toBe(false);
+
+    name.value = 'Support';
+
+    expect(validation.isValid.value).toBe(true);
+    expect(validation.error.value).toBeNull();
+  });
+});

--- a/src/components/Instructions/NewInstructionDrawer/useCategoryValidation.ts
+++ b/src/components/Instructions/NewInstructionDrawer/useCategoryValidation.ts
@@ -1,0 +1,29 @@
+import { computed, unref } from 'vue';
+import type { Ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+const ALLOWED_CHARS = /^[\p{L}\p{N}\s-]+$/u;
+
+export function useCategoryValidation(name: Ref<string> | string) {
+  const { t } = useI18n();
+
+  const validationT = (key: string) =>
+    t(
+      `agents.instructions.new_instruction_drawer.ai_analysis.category.validation.${key}`,
+    );
+
+  const trimmed = computed(() => unref(name).trim());
+
+  const error = computed<string | null>(() => {
+    const value = trimmed.value;
+
+    if (!value) return validationT('required');
+    if (!ALLOWED_CHARS.test(value)) return validationT('invalid_chars');
+
+    return null;
+  });
+
+  const isValid = computed(() => error.value === null);
+
+  return { error, isValid };
+}


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Category names in the new instruction drawer need to be validated before submission. A dedicated composable was needed to encapsulate this logic in a reusable and testable way.

### Summary of Changes
- Added `useCategoryValidation` composable that validates a category name against two rules: it must not be empty (or whitespace-only) and it must only contain letters, numbers, spaces, and hyphens (using a Unicode-aware regex).
- The composable exposes a reactive `error` message and an `isValid` flag, both derived from the trimmed input value.
- Added unit tests covering empty input, whitespace-only input, disallowed characters, valid names, whitespace trimming, and reactivity to name changes.