### PR TITLE
feat: Add suggested category selector to AI analysis results

### DIFF
--- a/src/components/Instructions/NewInstructionDrawer/AIAnalysis.vue
+++ b/src/components/Instructions/NewInstructionDrawer/AIAnalysis.vue
@@ -23,6 +23,13 @@
       v-else-if="status === 'complete'"
       class="ai-analysis__results"
     >
+      <section class="results__suggested-category">
+        <h3 class="results__title">
+          {{ aiAnalysisT('suggested_category') }}
+        </h3>
+
+        <SuggestedCategory />
+      </section>
       <section class="results__issues">
         <h3 class="results__title">
           {{ aiAnalysisT('issues') }}
@@ -48,11 +55,10 @@
 import { toRefs } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-import { UnnnicIconLoading } from '@weni/unnnic-system';
-
 import { useInstructionsStore } from '@/store/Instructions';
 
 import IssuesFound from './IssuesFound.vue';
+import SuggestedCategory from './SuggestedCategory.vue';
 import SuggestedRewrite from './SuggestedRewrite.vue';
 
 const { t } = useI18n();

--- a/src/components/Instructions/NewInstructionDrawer/CategoryCreateForm.vue
+++ b/src/components/Instructions/NewInstructionDrawer/CategoryCreateForm.vue
@@ -1,0 +1,117 @@
+<template>
+  <section
+    class="category-create-form"
+    data-testid="category-create-form"
+  >
+    <header class="category-create-form__header">
+      <UnnnicButton
+        iconCenter="keyboard_arrow_left"
+        type="tertiary"
+        size="small"
+        data-testid="category-create-form-back"
+        @click="$emit('back')"
+      />
+
+      <h3 class="category-create-form__title">
+        {{ categoryT('create_title') }}
+      </h3>
+    </header>
+
+    <form
+      class="category-create-form__input-section"
+      @submit.prevent="submit"
+    >
+      <UnnnicInput
+        v-model="name"
+        :label="categoryT('name_label')"
+        :placeholder="categoryT('name_placeholder')"
+        :maxlength="MAX_LENGTH"
+        showMaxlengthCounter
+        :errors="displayedErrors"
+        data-testid="category-create-form-input"
+        @blur="touched = true"
+        @keyup.enter="submit"
+      />
+    </form>
+  </section>
+
+  <UnnnicPopoverFooter>
+    <UnnnicButton
+      type="tertiary"
+      :text="categoryT('cancel')"
+      data-testid="category-create-form-cancel"
+      @click="$emit('back')"
+    />
+    <UnnnicButton
+      type="primary"
+      :text="categoryT('create')"
+      :disabled="!isValid"
+      data-testid="category-create-form-create"
+      @click="submit"
+    />
+  </UnnnicPopoverFooter>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { UnnnicPopoverFooter } from '@weni/unnnic-system';
+
+import { useCategoryValidation } from './useCategoryValidation';
+
+const MAX_LENGTH = 50;
+
+const emit = defineEmits<{
+  back: [];
+  create: [name: string];
+}>();
+
+const { t } = useI18n();
+const categoryT = (key: string) =>
+  t(`agents.instructions.new_instruction_drawer.ai_analysis.category.${key}`);
+
+const name = ref('');
+const touched = ref(false);
+
+const { error, isValid } = useCategoryValidation(name);
+
+const displayedErrors = computed(() =>
+  touched.value && error.value ? [error.value] : [],
+);
+
+function submit() {
+  touched.value = true;
+  if (!isValid.value) return;
+  emit('create', name.value.trim());
+}
+</script>
+
+<style lang="scss">
+.suggested-category__content {
+  padding: 0;
+}
+</style>
+
+<style lang="scss" scoped>
+.category-create-form {
+  &__header {
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-2;
+
+    padding: $unnnic-space-4;
+
+    border-bottom: 1px solid $unnnic-color-border-base;
+  }
+
+  &__input-section {
+    padding: $unnnic-space-4;
+  }
+
+  &__title {
+    font: $unnnic-font-action;
+    color: $unnnic-color-fg-emphasized;
+  }
+}
+</style>

--- a/src/components/Instructions/NewInstructionDrawer/SuggestedCategory.vue
+++ b/src/components/Instructions/NewInstructionDrawer/SuggestedCategory.vue
@@ -1,0 +1,245 @@
+<template>
+  <UnnnicPopover
+    v-model:open="isOpen"
+    @update:open="handleOpenChange"
+  >
+    <UnnnicPopoverTrigger data-testid="suggested-category-trigger">
+      <section
+        :class="[
+          'suggested-category__field',
+          { 'suggested-category__field--open': isOpen },
+        ]"
+      >
+        <p
+          class="suggested-category__value"
+          data-testid="suggested-category-value"
+        >
+          {{ selectedLabel }}
+        </p>
+
+        <UnnnicTag
+          v-if="selectedCategoryIsNew"
+          scheme="gray"
+          size="small"
+          :text="categoryT('new_badge')"
+          data-testid="suggested-category-new-tag"
+        />
+
+        <UnnnicIcon
+          class="suggested-category__chevron"
+          :icon="isOpen ? 'keyboard_arrow_up' : 'keyboard_arrow_down'"
+          size="sm"
+          scheme="fg-base"
+        />
+      </section>
+    </UnnnicPopoverTrigger>
+
+    <UnnnicPopoverContent
+      align="start"
+      width="100%"
+      class="suggested-category__content"
+    >
+      <template v-if="mode === 'list'">
+        <section class="suggested-category__list">
+          <section
+            v-if="suggestedCategory"
+            class="suggested-category__category-section"
+          >
+            <p class="suggested-category__category-title">
+              {{ categoryT('suggested_category') }}
+            </p>
+
+            <UnnnicPopoverOption
+              data-testid="suggested-category-suggested-option"
+              :active="isActive(suggestedCategory)"
+              @click="selectCategory(suggestedCategory)"
+            >
+              <span class="suggested-category__suggested-value">
+                {{ suggestedCategory.name }}
+              </span>
+              <UnnnicTag
+                v-if="suggestedCategoryIsNew"
+                scheme="gray"
+                size="small"
+                :text="categoryT('new_badge')"
+                data-testid="suggested-category-suggested-new-tag"
+              />
+            </UnnnicPopoverOption>
+          </section>
+
+          <section
+            v-if="otherCategories.length > 0"
+            class="suggested-category__category-section"
+          >
+            <p class="suggested-category__category-title">
+              {{ categoryT('other_categories') }}
+            </p>
+
+            <UnnnicPopoverOption
+              v-for="option in otherCategories"
+              :key="option.name"
+              :label="option.name"
+              :active="isActive(option)"
+              :data-testid="`suggested-category-option-${option.name}`"
+              @click="selectCategory(option)"
+            />
+          </section>
+        </section>
+
+        <UnnnicPopoverFooter>
+          <UnnnicButton
+            iconLeft="add"
+            :text="categoryT('create_action')"
+            type="secondary"
+            data-testid="suggested-category-create-action"
+            @click="mode = 'create'"
+          />
+        </UnnnicPopoverFooter>
+      </template>
+
+      <CategoryCreateForm
+        v-else
+        data-testid="suggested-category-create-form"
+        @back="mode = 'list'"
+        @create="handleCreate"
+      />
+    </UnnnicPopoverContent>
+  </UnnnicPopover>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { useInstructionsStore } from '@/store/Instructions';
+import type { InstructionCategory } from '@/store/types/Instructions.types';
+
+import CategoryCreateForm from './CategoryCreateForm.vue';
+import { UnnnicPopoverOption } from '@weni/unnnic-system';
+
+const { t } = useI18n();
+const categoryT = (key: string) =>
+  t(`agents.instructions.new_instruction_drawer.ai_analysis.category.${key}`);
+
+const instructionsStore = useInstructionsStore();
+
+const isOpen = ref(false);
+const mode = ref<'list' | 'create'>('list');
+
+const categoryOptions = computed(() => instructionsStore.categoryOptions);
+const selectedCategory = computed(
+  () => instructionsStore.newInstruction.category,
+);
+const selectedCategoryIsNew = computed(
+  () => instructionsStore.selectedCategoryIsNew,
+);
+const suggestedCategory = computed(() => instructionsStore.suggestedCategory);
+const suggestedCategoryIsNew = computed(
+  () => instructionsStore.suggestedCategoryIsNew,
+);
+
+const selectedLabel = computed(
+  () => selectedCategory.value?.name ?? categoryT('placeholder'),
+);
+
+const otherCategories = computed(() =>
+  categoryOptions.value.filter(
+    (option) => option.name !== suggestedCategory.value?.name,
+  ),
+);
+
+function isActive(option: InstructionCategory | null) {
+  const selected = selectedCategory.value;
+  return !!selected && !!option && selected.name === option.name;
+}
+
+function selectCategory(option: InstructionCategory | null) {
+  if (!option) return;
+  instructionsStore.newInstruction.category = { ...option };
+  isOpen.value = false;
+}
+
+function handleCreate(name: string) {
+  instructionsStore.createCategory(name);
+  isOpen.value = false;
+  mode.value = 'list';
+}
+
+function handleOpenChange(open: boolean) {
+  if (!open) mode.value = 'list';
+}
+</script>
+
+<style lang="scss">
+.suggested-category__content {
+  padding: 0;
+
+  width: 320px;
+  height: 300px;
+}
+</style>
+
+<style lang="scss" scoped>
+.suggested-category {
+  &__field {
+    width: 320px;
+
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-2;
+
+    padding: $unnnic-space-3 $unnnic-space-4;
+
+    border-radius: $unnnic-radius-2;
+    border: 1px solid $unnnic-color-border-base;
+
+    cursor: pointer;
+
+    &--open {
+      border-color: $unnnic-color-border-accent-strong;
+    }
+  }
+
+  &__category-title {
+    font: $unnnic-font-caption-1;
+    color: $unnnic-color-fg-muted;
+  }
+
+  &__value {
+    flex: 1;
+
+    text-align: left;
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__chevron {
+    margin-left: auto;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-4;
+
+    padding: $unnnic-space-4;
+  }
+
+  &__category-section {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+  }
+
+  &__suggested-value {
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-4;
+  }
+}
+</style>

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/SuggestedCategory.spec.js
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/SuggestedCategory.spec.js
@@ -1,0 +1,290 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import SuggestedCategory from '../SuggestedCategory.vue';
+import i18n from '@/utils/plugins/i18n';
+import { useInstructionsStore } from '@/store/Instructions';
+
+vi.mock('@/store/Project', () => ({
+  useProjectStore: () => ({ uuid: 'test-project-uuid' }),
+}));
+
+vi.mock('@/store/FeatureFlags', () => ({
+  useFeatureFlagsStore: () => ({
+    flags: { categorizationOfInstructions: true },
+  }),
+}));
+
+const passThroughStub = {
+  template: '<div><slot /></div>',
+};
+
+const optionStub = {
+  props: ['label', 'active', 'icon', 'scheme'],
+  template: `<button v-bind="$attrs" :data-active="active" @click="$emit('click')"><slot>{{ label }}</slot></button>`,
+};
+
+const tagStub = {
+  props: ['text'],
+  template: '<span v-bind="$attrs">{{ text }}</span>',
+};
+
+const iconStub = {
+  template: '<i />',
+};
+
+const createFormStub = {
+  name: 'CategoryCreateForm',
+  template: `<div v-bind="$attrs">
+    <button data-testid="stub-back" @click="$emit('back')">back</button>
+    <button data-testid="stub-create" @click="$emit('create', 'Marketing')">create</button>
+  </div>`,
+};
+
+const categoryT = (key) =>
+  i18n.global.t(
+    `agents.instructions.new_instruction_drawer.ai_analysis.category.${key}`,
+  );
+
+describe('NewInstructionDrawer/SuggestedCategory.vue', () => {
+  let wrapper;
+  let store;
+
+  const SELECTORS = {
+    trigger: '[data-testid="suggested-category-trigger"]',
+    value: '[data-testid="suggested-category-value"]',
+    newTag: '[data-testid="suggested-category-new-tag"]',
+    suggestedOption: '[data-testid="suggested-category-suggested-option"]',
+    suggestedNewTag: '[data-testid="suggested-category-suggested-new-tag"]',
+    createAction: '[data-testid="suggested-category-create-action"]',
+    createForm: '[data-testid="suggested-category-create-form"]',
+  };
+
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+  const findOption = (name) =>
+    wrapper.find(`[data-testid="suggested-category-option-${name}"]`);
+
+  const createWrapper = (initialState = {}) => {
+    const pinia = createTestingPinia({
+      stubActions: false,
+      initialState: {
+        Instructions: {
+          categories: [
+            { id: 1, name: 'Sales' },
+            { id: 2, name: 'Support' },
+          ],
+          sessionCategories: [],
+          newInstruction: {
+            text: 'My instruction',
+            category: { id: 1, name: 'Sales' },
+            status: null,
+          },
+          instructionSuggestedByAI: {
+            data: {
+              instruction: '',
+              classification: [],
+              suggestion: '',
+              suggestedCategory: 'Personality',
+            },
+            suggestionApplied: '',
+            status: 'complete',
+          },
+          ...initialState,
+        },
+      },
+    });
+
+    store = useInstructionsStore(pinia);
+
+    return mount(SuggestedCategory, {
+      global: {
+        plugins: [pinia],
+        // UnnnicPopoverTrigger/Content have no `name`, so they can only be
+        // replaced by overriding the global registration.
+        components: {
+          UnnnicPopoverTrigger: passThroughStub,
+          UnnnicPopoverContent: passThroughStub,
+        },
+        stubs: {
+          UnnnicPopover: passThroughStub,
+          UnnnicPopoverOption: optionStub,
+          UnnnicTag: tagStub,
+          UnnnicIcon: iconStub,
+          CategoryCreateForm: createFormStub,
+        },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wrapper = createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  describe('Field rendering', () => {
+    it('renders the selected category name in the field', () => {
+      expect(find('value').text()).toBe('Sales');
+    });
+
+    it('does not show the New tag when the selected category has an id', () => {
+      expect(find('newTag').exists()).toBe(false);
+    });
+
+    it('shows the New tag when the selected category is new', () => {
+      wrapper = createWrapper({
+        newInstruction: {
+          text: 'My instruction',
+          category: { id: null, name: 'Brand new' },
+          status: null,
+        },
+      });
+
+      expect(find('newTag').exists()).toBe(true);
+      expect(find('newTag').text()).toBe(categoryT('new_badge'));
+    });
+
+    it('falls back to the placeholder when no category is selected', () => {
+      wrapper = createWrapper({
+        newInstruction: {
+          text: 'My instruction',
+          category: null,
+          status: null,
+        },
+      });
+
+      expect(find('value').text()).toBe(categoryT('placeholder'));
+    });
+  });
+
+  describe('Suggested category section', () => {
+    it('renders the AI-suggested category as the suggested option', () => {
+      expect(find('suggestedOption').exists()).toBe(true);
+      expect(find('suggestedOption').text()).toContain('Personality');
+    });
+
+    it('does not render the suggested section when there is no suggested category', () => {
+      wrapper = createWrapper({
+        instructionSuggestedByAI: {
+          data: {
+            instruction: '',
+            classification: [],
+            suggestion: '',
+            suggestedCategory: '',
+          },
+          suggestionApplied: '',
+          status: 'complete',
+        },
+      });
+
+      expect(find('suggestedOption').exists()).toBe(false);
+    });
+
+    it('shows the New tag when the suggested category does not exist yet', () => {
+      expect(find('suggestedNewTag').exists()).toBe(true);
+      expect(find('suggestedNewTag').text()).toBe(categoryT('new_badge'));
+    });
+
+    it('does not show the New tag when the suggested category already exists', () => {
+      wrapper = createWrapper({
+        instructionSuggestedByAI: {
+          data: {
+            instruction: '',
+            classification: [],
+            suggestion: '',
+            suggestedCategory: 'Sales',
+          },
+          suggestionApplied: '',
+          status: 'complete',
+        },
+      });
+
+      expect(find('suggestedNewTag').exists()).toBe(false);
+    });
+
+    it('marks the suggested option as active when it is the selected category', () => {
+      wrapper = createWrapper({
+        newInstruction: {
+          text: 'My instruction',
+          category: { id: null, name: 'Personality' },
+          status: null,
+        },
+      });
+
+      expect(find('suggestedOption').attributes('data-active')).toBe('true');
+    });
+
+    it('selects the suggested category when the suggested option is clicked', async () => {
+      await find('suggestedOption').trigger('click');
+
+      expect(store.newInstruction.category).toEqual({
+        id: null,
+        name: 'Personality',
+      });
+    });
+  });
+
+  describe('Other categories section', () => {
+    it('renders the categories excluding the suggested one', () => {
+      const options = wrapper.findAll(
+        '[data-testid^="suggested-category-option-"]',
+      );
+
+      expect(options.map((option) => option.text())).toEqual([
+        'Sales',
+        'Support',
+      ]);
+    });
+
+    it('marks an option as active when it is the selected category', () => {
+      expect(findOption('Sales').attributes('data-active')).toBe('true');
+      expect(findOption('Support').attributes('data-active')).toBe('false');
+    });
+
+    it('updates the selected category in the store when an option is clicked', async () => {
+      await findOption('Support').trigger('click');
+
+      expect(store.newInstruction.category).toEqual({ id: 2, name: 'Support' });
+    });
+
+    it('renders the create category action', () => {
+      expect(find('createAction').exists()).toBe(true);
+      expect(find('createAction').text()).toBe(categoryT('create_action'));
+    });
+  });
+
+  describe('Create category flow', () => {
+    it('shows the create form when the create action is clicked', async () => {
+      await find('createAction').trigger('click');
+
+      expect(find('createForm').exists()).toBe(true);
+    });
+
+    it('creates the category and selects it when the form emits create', async () => {
+      await find('createAction').trigger('click');
+
+      await wrapper.find('[data-testid="stub-create"]').trigger('click');
+
+      expect(store.sessionCategories).toContain('Marketing');
+      expect(store.newInstruction.category).toEqual({
+        id: null,
+        name: 'Marketing',
+      });
+      expect(store.selectedCategoryIsNew).toBe(true);
+    });
+
+    it('returns to the list when the form emits back', async () => {
+      await find('createAction').trigger('click');
+      expect(find('createForm').exists()).toBe(true);
+
+      await wrapper.find('[data-testid="stub-back"]').trigger('click');
+
+      expect(find('createForm').exists()).toBe(false);
+      expect(find('createAction').exists()).toBe(true);
+    });
+  });
+});

--- a/src/components/Instructions/NewInstructionDrawer/index.vue
+++ b/src/components/Instructions/NewInstructionDrawer/index.vue
@@ -32,6 +32,8 @@
           data-testid="new-instruction-drawer-save-button"
           :text="$t('agents.instructions.new_instruction_drawer.save')"
           type="primary"
+          :disabled="saveDisabled"
+          :loading="instructionsStore.newInstruction.status === 'loading'"
           @click="save"
         />
       </UnnnicDrawerFooter>
@@ -40,6 +42,8 @@
 </template>
 
 <script setup>
+import { computed } from 'vue';
+
 import NewInstructionDrawerForm from './Form.vue';
 import NewInstructionDrawerAIAnalysis from './AIAnalysis.vue';
 
@@ -52,12 +56,25 @@ const modelValue = defineModel({
   required: true,
 });
 
+const saveDisabled = computed(
+  () =>
+    !instructionsStore.newInstruction.text.trim() ||
+    instructionsStore.instructionSuggestedByAI.status !== 'complete',
+);
+
 function close() {
   modelValue.value = false;
 }
 
-function save() {
-  // TODO: Implement save
+async function save() {
+  if (saveDisabled.value) return;
+
+  await instructionsStore.addInstruction();
+
+  if (instructionsStore.newInstruction.status === 'error') return;
+
+  instructionsStore.resetInstructionSuggestedByAI();
+  close();
 }
 </script>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -354,6 +354,7 @@
         "ai_analysis": {
           "title": "AI analysis",
           "validating": "Validating instruction...",
+          "suggested_category": "Suggested category",
           "issues": "Issues found",
           "issues_types": {
             "duplicate": "Duplicate",
@@ -365,7 +366,22 @@
           "suggested_rewrite": "Suggested rewrite",
           "suggestion_applied": "Suggestion applied",
           "undo_button": "Undo",
-          "apply_button": "Apply"
+          "apply_button": "Apply",
+          "category": {
+            "new_badge": "New",
+            "suggested_category": "Suggested category",
+            "other_categories": "Other categories",
+            "create_action": "New category",
+            "create_title": "Create category",
+            "name_label": "Category name",
+            "name_placeholder": "Name",
+            "cancel": "Cancel",
+            "create": "Create",
+            "validation": {
+              "required": "Complete this field",
+              "invalid_chars": "Use only letters, numbers, spaces, and hyphens"
+            }
+          }
         }
       }
     },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -354,6 +354,7 @@
         "ai_analysis": {
           "title": "Análisis de IA",
           "validating": "Validando instrucción...",
+          "suggested_category": "Categoría sugerida",
           "issues": "Problemas encontrados",
           "issues_types": {
             "duplicate": "Duplicado",
@@ -365,7 +366,22 @@
           "suggested_rewrite": "Reescritura sugerida",
           "suggestion_applied": "Sugerencia aplicada",
           "undo_button": "Deshacer",
-          "apply_button": "Aplicar"
+          "apply_button": "Aplicar",
+          "category": {
+            "new_badge": "Nueva",
+            "suggested_category": "Categoría sugerida",
+            "other_categories": "Otras categorías",
+            "create_action": "Nueva categoría",
+            "create_title": "Crear categoría",
+            "name_label": "Nombre de la categoría",
+            "name_placeholder": "Nombre",
+            "cancel": "Cancelar",
+            "create": "Crear",
+            "validation": {
+              "required": "Completa este campo",
+              "invalid_chars": "Usa solo letras, números, espacios y guiones"
+            }
+          }
         }
       }
     },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -354,6 +354,7 @@
         "ai_analysis": {
           "title": "Análise de IA",
           "validating": "Validando instrução...",
+          "suggested_category": "Categoria sugerida",
           "issues": "Problemas encontrados",
           "issues_types": {
             "duplicate": "Duplicado",
@@ -365,7 +366,22 @@
           "suggested_rewrite": "Reescrita sugerida",
           "suggestion_applied": "Sugestão aplicada",
           "undo_button": "Desfazer",
-          "apply_button": "Aplicar"
+          "apply_button": "Aplicar",
+          "category": {
+            "new_badge": "Nova",
+            "suggested_category": "Categoria sugerida",
+            "other_categories": "Outras categorias",
+            "create_action": "Nova categoria",
+            "create_title": "Criar categoria",
+            "name_label": "Nome da categoria",
+            "name_placeholder": "Nome",
+            "cancel": "Cancelar",
+            "create": "Criar",
+            "validation": {
+              "required": "Preencha este campo",
+              "invalid_chars": "Use apenas letras, números, espaços e hifens"
+            }
+          }
         }
       }
     },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -353,6 +353,7 @@
         "ai_analysis": {
           "title": "Analiză AI",
           "validating": "Se validează instrucțiunea...",
+          "suggested_category": "Categorie sugerată",
           "issues": "Probleme găsite",
           "issues_types": {
             "duplicate": "Duplicat",
@@ -364,7 +365,22 @@
           "suggested_rewrite": "Rescriere sugerată",
           "suggestion_applied": "Sugestie aplicată",
           "undo_button": "Anulează",
-          "apply_button": "Aplică"
+          "apply_button": "Aplică",
+          "category": {
+            "new_badge": "Nouă",
+            "suggested_category": "Categorie sugerată",
+            "other_categories": "Alte categorii",
+            "create_action": "Nouă categorie",
+            "create_title": "Creează categorie",
+            "name_label": "Numele categoriei",
+            "name_placeholder": "Nume",
+            "cancel": "Anulează",
+            "create": "Creează",
+            "validation": {
+              "required": "Completează acest câmp",
+              "invalid_chars": "Folosește doar litere, cifre, spații și cratime"
+            }
+          }
         }
       }
     },


### PR DESCRIPTION
## Description

### Type of Change

- [ ]  Bugfix
- [x]  Feature
- [ ]  Code style update (formatting, local variables)
- [ ]  Refactoring (no functional changes, no api changes)
- [x]  Tests
- [ ]  Other

### Motivation and Context

The AI analysis step in the new instruction drawer needed to surface a suggested category so users can assign or override the category before saving. Additionally, the save action needed to be wired up to actually persist the instruction.

### Summary of Changes

- Added a `SuggestedCategory` popover component to the AI analysis results panel, displaying the AI-suggested category and all existing categories, with the ability to select any of them.
- Added a `CategoryCreateForm` component that allows users to create a new category inline from within the popover, with name validation (required field, allowed characters) and a back/cancel flow.
- The suggested category is highlighted separately from other categories, and newly created categories are badged as "New".
- The save button in the drawer is now disabled when the instruction text is empty or AI analysis is not yet complete, and shows a loading state while saving. On success, the AI suggestion state is reset and the drawer closes.
- Added unit tests for `SuggestedCategory` covering field rendering, suggested category section behavior, other categories selection, and the create category flow.
- Added all new i18n keys for category-related labels and validation messages in English, Spanish, Portuguese, Romanian.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/0add7ca4-241f-4804-8767-b722e21927c7.png)

![image.png](https://app.graphite.com/user-attachments/assets/4977151e-3955-4bf8-bfb1-84db203e0c3c.png)



![image.png](https://app.graphite.com/user-attachments/assets/2c4ca5df-a828-4324-992e-ca0a0e85ccfc.png)



