### PR TITLE
feat: Add error state to AIAnalysis component

### DIFF
--- a/src/components/Instructions/NewInstructionDrawer/AIAnalysis.vue
+++ b/src/components/Instructions/NewInstructionDrawer/AIAnalysis.vue
@@ -7,21 +7,39 @@
     <section
       v-if="status === 'loading'"
       class="ai-analysis__loading"
+      data-testid="ai-analysis-loading"
     >
       <UnnnicIconLoading size="20px" />
 
       <p class="ai-analysis__loading-text">
-        {{
-          $t(
-            'agents.instructions.new_instruction_drawer.ai_analysis.validating',
-          )
-        }}
+        {{ aiAnalysisT('validating') }}
+      </p>
+    </section>
+
+    <section
+      v-else-if="status === 'error'"
+      class="ai-analysis__error"
+      data-testid="ai-analysis-error"
+    >
+      <UnnnicIcon
+        icon="cancel"
+        size="avatar-nano"
+        scheme="fg-critical"
+        data-testid="ai-analysis-error-icon"
+      />
+
+      <p
+        class="ai-analysis__error-text"
+        data-testid="ai-analysis-error-text"
+      >
+        {{ aiAnalysisT('error') }}
       </p>
     </section>
 
     <section
       v-else-if="status === 'complete'"
       class="ai-analysis__results"
+      data-testid="ai-analysis-results"
     >
       <section class="results__suggested-category">
         <h3 class="results__title">
@@ -90,6 +108,17 @@ const { data, status } = toRefs(instructionsStore.instructionSuggestedByAI);
     &__loading-text {
       font: $unnnic-font-body;
       color: $unnnic-color-fg-muted;
+    }
+
+    &__error {
+      display: flex;
+      align-items: center;
+      gap: $unnnic-space-2;
+    }
+
+    &__error-text {
+      font: $unnnic-font-body;
+      color: $unnnic-color-fg-critical;
     }
 
     &__results {

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/AIAnalysis.spec.js
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/AIAnalysis.spec.js
@@ -1,0 +1,133 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import AIAnalysis from '../AIAnalysis.vue';
+import i18n from '@/utils/plugins/i18n';
+
+vi.mock('@/store/Project', () => ({
+  useProjectStore: () => ({ uuid: 'test-project-uuid' }),
+}));
+
+vi.mock('@/store/FeatureFlags', () => ({
+  useFeatureFlagsStore: () => ({
+    flags: { categorizationOfInstructions: true },
+  }),
+}));
+
+const childStub = {
+  template: '<div />',
+};
+
+const aiAnalysisT = (key) =>
+  i18n.global.t(
+    `agents.instructions.new_instruction_drawer.ai_analysis.${key}`,
+  );
+
+describe('NewInstructionDrawer/AIAnalysis.vue', () => {
+  let wrapper;
+
+  const SELECTORS = {
+    loading: '[data-testid="ai-analysis-loading"]',
+    error: '[data-testid="ai-analysis-error"]',
+    errorIcon: '[data-testid="ai-analysis-error-icon"]',
+    errorText: '[data-testid="ai-analysis-error-text"]',
+    results: '[data-testid="ai-analysis-results"]',
+  };
+
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+
+  const createWrapper = (suggestedByAI = {}) => {
+    const pinia = createTestingPinia({
+      stubActions: false,
+      initialState: {
+        Instructions: {
+          instructionSuggestedByAI: {
+            data: {
+              instruction: '',
+              classification: [],
+              suggestion: '',
+              suggested_category: '',
+            },
+            suggestionApplied: '',
+            status: null,
+            ...suggestedByAI,
+          },
+        },
+      },
+    });
+
+    return shallowMount(AIAnalysis, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          SuggestedCategory: childStub,
+          IssuesFound: childStub,
+          SuggestedRewrite: childStub,
+        },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  describe('Loading state', () => {
+    it('renders only the loading section when status is loading', () => {
+      wrapper = createWrapper({ status: 'loading' });
+
+      expect(find('loading').exists()).toBe(true);
+      expect(find('error').exists()).toBe(false);
+      expect(find('results').exists()).toBe(false);
+    });
+  });
+
+  describe('Error state', () => {
+    beforeEach(() => {
+      wrapper = createWrapper({ status: 'error' });
+    });
+
+    it('renders only the error section when status is error', () => {
+      expect(find('error').exists()).toBe(true);
+      expect(find('loading').exists()).toBe(false);
+      expect(find('results').exists()).toBe(false);
+    });
+
+    it('renders the error icon with the critical scheme', () => {
+      const icon = find('errorIcon');
+
+      expect(icon.exists()).toBe(true);
+      expect(icon.attributes('icon')).toBe('cancel');
+      expect(icon.attributes('scheme')).toBe('fg-critical');
+    });
+
+    it('renders the error message', () => {
+      expect(find('errorText').text()).toBe(aiAnalysisT('error'));
+    });
+  });
+
+  describe('Complete state', () => {
+    it('renders only the results section when status is complete', () => {
+      wrapper = createWrapper({ status: 'complete' });
+
+      expect(find('results').exists()).toBe(true);
+      expect(find('loading').exists()).toBe(false);
+      expect(find('error').exists()).toBe(false);
+    });
+  });
+
+  describe('Idle state', () => {
+    it('renders none of the status sections when status is null', () => {
+      wrapper = createWrapper({ status: null });
+
+      expect(find('loading').exists()).toBe(false);
+      expect(find('error').exists()).toBe(false);
+      expect(find('results').exists()).toBe(false);
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -352,6 +352,7 @@
         "save": "Save",
         "cancel": "Cancel",
         "ai_analysis": {
+          "error": "The instruction couldn't be validated. Try again.",
           "title": "AI analysis",
           "validating": "Validating instruction...",
           "suggested_category": "Suggested category",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -352,6 +352,7 @@
         "save": "Guardar",
         "cancel": "Cancelar",
         "ai_analysis": {
+          "error": "No se pudo validar la instrucción. Inténtalo de nuevo.",
           "title": "Análisis de IA",
           "validating": "Validando instrucción...",
           "suggested_category": "Categoría sugerida",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -352,6 +352,7 @@
         "save": "Salvar",
         "cancel": "Cancelar",
         "ai_analysis": {
+          "error": "Não foi possível validar a instrução. Tente novamente.",
           "title": "Análise de IA",
           "validating": "Validando instrução...",
           "suggested_category": "Categoria sugerida",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -351,6 +351,7 @@
         "save": "Salvează",
         "cancel": "Anulează",
         "ai_analysis": {
+          "error": "Instrucțiunea nu a putut fi validată. Încearcă din nou.",
           "title": "Analiză AI",
           "validating": "Se validează instrucțiunea...",
           "suggested_category": "Categorie sugerată",

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -323,10 +323,12 @@ export const useInstructionsStore = defineStore('Instructions', () => {
       }
     } catch (error) {
       instructionSuggestedByAI.status = 'error';
-      callAlert(
-        'error',
-        'new_instruction.validate_instruction_by_ai.error_alert',
-      );
+      if (!useV2()) {
+        callAlert(
+          'error',
+          'new_instruction.validate_instruction_by_ai.error_alert',
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Description

### Type of Change

- [ ]  Bugfix
- [ ]  Feature
- [ ]  Code style update (formatting, local variables)
- [ ]  Refactoring (no functional changes, no api changes)
- [x]  Tests
- [ ]  Other

### Motivation and Context

When the AI analysis fails to validate an instruction, there was no visual feedback shown to the user in the `AIAnalysis` component. The error was only communicated via an alert, and only in the v1 flow. Users needed a clear, inline error state to understand that validation failed and that they should try again.

### Summary of Changes

- Added an error state section to the `AIAnalysis` component that displays when `status === 'error'`, showing a critical icon and a localized error message.
- Suppressed the error alert when using the v2 flow (`useV2()`), since the inline error state in the component now handles user feedback instead.
- Added `data-testid` attributes to the loading, error, and results sections to support reliable test targeting.
- Added localized error messages for all supported locales (en, es, pt_br, ro): `"The instruction couldn't be validated. Try again."` and equivalents.
- Added a full test suite for `AIAnalysis.vue` covering loading, error, complete, and idle states, verifying correct rendering and mutual exclusivity of each state section.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/25af4c2a-58f2-4666-a927-6971aa864d23.png)

