### PR TITLE
feat: Add InstructionsCategorization component with view toggle and search

### DIFF
--- a/src/components/Instructions/InstructionsCategorization/__tests__/index.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/index.spec.js
@@ -1,0 +1,127 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import InstructionsCategorization from '../index.vue';
+import { useInstructionsStore } from '@/store/Instructions';
+import i18n from '@/utils/plugins/i18n';
+
+vi.mock('@/store/Project', () => ({
+  useProjectStore: () => ({ uuid: 'test-project-uuid' }),
+}));
+
+vi.mock('@/store/FeatureFlags', () => ({
+  useFeatureFlagsStore: () => ({
+    flags: { categorizationOfInstructions: true },
+  }),
+}));
+
+const viewT = (key) => i18n.global.t(`agents.instructions.view.${key}`);
+
+describe('InstructionsCategorization/index.vue', () => {
+  let wrapper;
+  let instructionsStore;
+
+  const SELECTORS = {
+    search: '[data-testid="instructions-search"]',
+    segmented: '[data-testid="instructions-view-segmented"]',
+    triggerCategories: '[data-testid="instructions-view-trigger-categories"]',
+    triggerList: '[data-testid="instructions-view-trigger-list"]',
+    baselineList: '[data-testid="instructions-baseline-list"]',
+  };
+
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+  const findComponent = (selector) =>
+    wrapper.findComponent(SELECTORS[selector]);
+
+  const createWrapper = (instructionsState = {}) => {
+    const pinia = createTestingPinia({
+      initialState: {
+        Instructions: {
+          instructions: { data: [], status: 'complete', ...instructionsState },
+          activeInstructionsView: 'categories',
+          searchTerm: '',
+        },
+      },
+    });
+
+    instructionsStore = useInstructionsStore();
+
+    return shallowMount(InstructionsCategorization, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          UnnnicTabs: { template: '<div v-bind="$attrs"><slot /></div>' },
+          SegmentedControlList: { template: '<div><slot /></div>' },
+          SegmentedControlTrigger: {
+            inheritAttrs: false,
+            template: '<button v-bind="$attrs"><slot /></button>',
+          },
+        },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    wrapper = createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Toolbar rendering', () => {
+    it('renders the search input with the localized placeholder', () => {
+      expect(find('search').exists()).toBe(true);
+      expect(findComponent('search').props('placeholder')).toBe(
+        viewT('search_placeholder'),
+      );
+    });
+
+    it('renders both segmented control triggers with localized labels', () => {
+      expect(find('triggerCategories').text()).toBe(
+        viewT('segmented.categories'),
+      );
+      expect(find('triggerList').text()).toBe(viewT('segmented.list'));
+    });
+
+    it('renders the baseline instructions list', () => {
+      expect(find('baselineList').exists()).toBe(true);
+    });
+  });
+
+  describe('View toggle', () => {
+    it('updates the active view in the store when the segmented control changes', async () => {
+      await findComponent('segmented').vm.$emit('update:modelValue', 'list');
+
+      expect(instructionsStore.activeInstructionsView).toBe('list');
+    });
+  });
+
+  describe('Search', () => {
+    it('binds the search input to the store search term', async () => {
+      await findComponent('search').vm.$emit('update:modelValue', 'tracking');
+
+      expect(instructionsStore.searchTerm).toBe('tracking');
+    });
+  });
+
+  describe('Loading instructions', () => {
+    it('loads instructions on mount when status is null', () => {
+      wrapper = createWrapper({ status: null });
+
+      expect(instructionsStore.loadInstructions).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not load instructions when they are already loaded', () => {
+      expect(instructionsStore.loadInstructions).not.toHaveBeenCalled();
+    });
+
+    it('passes the loading state to the baseline list', () => {
+      wrapper = createWrapper({ status: 'loading' });
+
+      expect(findComponent('baselineList').props('isLoading')).toBe(true);
+    });
+  });
+});

--- a/src/components/Instructions/InstructionsCategorization/index.vue
+++ b/src/components/Instructions/InstructionsCategorization/index.vue
@@ -1,0 +1,76 @@
+<template>
+  <section
+    class="instructions-categorization"
+    data-testid="instructions-categorization"
+  >
+    <header class="instructions-categorization__toolbar">
+      <UnnnicInput
+        v-model="instructionsStore.searchTerm"
+        iconLeft="search"
+        :placeholder="$t('agents.instructions.view.search_placeholder')"
+        data-testid="instructions-search"
+      />
+
+      <UnnnicSegmentedControl
+        v-model="instructionsStore.activeInstructionsView"
+        data-testid="instructions-view-segmented"
+      >
+        <UnnnicSegmentedControlList>
+          <UnnnicSegmentedControlTrigger
+            v-for="view in views"
+            :key="view"
+            :value="view"
+            :data-testid="`instructions-view-trigger-${view}`"
+          >
+            {{ $t(`agents.instructions.view.segmented.${view}`) }}
+          </UnnnicSegmentedControlTrigger>
+        </UnnnicSegmentedControlList>
+      </UnnnicSegmentedControl>
+    </header>
+
+    <InstructionsList
+      :instructions="instructionsStore.instructions.data"
+      :isLoading="isLoading"
+      showActions
+      data-testid="instructions-baseline-list"
+    />
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+import { useInstructionsStore } from '@/store/Instructions';
+
+import InstructionsList from '@/components/Instructions/InstructionsList.vue';
+
+const views = ['categories', 'list'];
+
+const instructionsStore = useInstructionsStore();
+
+if (instructionsStore.instructions.status === null) {
+  instructionsStore.loadInstructions();
+}
+
+const isLoading = computed(
+  () => instructionsStore.instructions.status === 'loading',
+);
+</script>
+
+<style lang="scss" scoped>
+.instructions-categorization {
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-4;
+
+  // Mirrors UnnnicPageHeader's grid (1fr + minmax(250px, 20%))
+  &__toolbar {
+    display: grid;
+    grid-template-columns: 1fr minmax(250px, 20%);
+    align-items: center;
+    gap: $unnnic-space-4;
+  }
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -346,6 +346,13 @@
       "description": "Define the rules that guide how Manager responds, communicates, and makes decisions",
       "export_instructions": "Export instructions",
       "new_instruction": "New instruction",
+      "view": {
+        "search_placeholder": "Search...",
+        "segmented": {
+          "categories": "Categories",
+          "list": "List"
+        }
+      },
       "new_instruction_drawer": {
         "title": "New instruction",
         "validate": "Validate",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -346,6 +346,13 @@
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
       "export_instructions": "Exportar instrucciones",
       "new_instruction": "Nueva instrucción",
+      "view": {
+        "search_placeholder": "Buscar...",
+        "segmented": {
+          "categories": "Categorías",
+          "list": "Lista"
+        }
+      },
       "new_instruction_drawer": {
         "title": "Nueva instrucción",
         "validate": "Validar",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -346,6 +346,13 @@
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
       "export_instructions": "Exportar instruções",
       "new_instruction": "Nova instrução",
+      "view": {
+        "search_placeholder": "Buscar...",
+        "segmented": {
+          "categories": "Categorias",
+          "list": "Lista"
+        }
+      },
       "new_instruction_drawer": {
         "title": "Nova instrução",
         "validate": "Validar",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -345,6 +345,13 @@
       "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
       "export_instructions": "Exportă instrucțiuni",
       "new_instruction": "Instrucțiune nouă",
+      "view": {
+        "search_placeholder": "Caută...",
+        "segmented": {
+          "categories": "Categorii",
+          "list": "Listă"
+        }
+      },
       "new_instruction_drawer": {
         "title": "Instrucțiune nouă",
         "validate": "Validează",

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -148,6 +148,8 @@ export const useInstructionsStore = defineStore('Instructions', () => {
   });
 
   const activeInstructionsListTab = ref('custom');
+  const activeInstructionsView = ref<'categories' | 'list'>('categories');
+  const searchTerm = ref('');
 
   async function addInstruction() {
     newInstruction.status = 'loading';
@@ -359,6 +361,8 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     validateInstructionByAI,
     instructionSuggestedByAI,
     activeInstructionsListTab,
+    activeInstructionsView,
+    searchTerm,
     createCategory,
     addInstruction,
     loadInstructions,

--- a/src/views/Instructions/__tests__/Instructions.spec.js
+++ b/src/views/Instructions/__tests__/Instructions.spec.js
@@ -1,17 +1,23 @@
 import { shallowMount } from '@vue/test-utils';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 
 import Instructions from '../index.vue';
+
+const mockFlags = { categorizationOfInstructions: false };
+
+vi.mock('@/store/FeatureFlags', () => ({
+  useFeatureFlagsStore: () => ({
+    get flags() {
+      return mockFlags;
+    },
+  }),
+}));
 
 describe('Instructions.vue', () => {
   let wrapper;
 
-  beforeEach(() => {
-    wrapper = shallowMount(Instructions);
-  });
-
   const SELECTORS = {
-    instructionsHeader: '[data-testid="instructions-header"]',
+    categorization: '[data-testid="instructions-categorization"]',
     newInstruction: '[data-testid="new-instruction"]',
     instructionsSection: '[data-testid="instructions-section"]',
   };
@@ -19,14 +25,44 @@ describe('Instructions.vue', () => {
   const findComponent = (component) =>
     wrapper.findComponent(SELECTORS[component]);
 
-  describe('Component rendering', () => {
-    it('should match snapshot', () => {
-      expect(wrapper.html()).toMatchSnapshot();
+  const createWrapper = (categorizationOfInstructions) => {
+    mockFlags.categorizationOfInstructions = categorizationOfInstructions;
+
+    return shallowMount(Instructions);
+  };
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('When categorization flag is disabled', () => {
+    beforeEach(() => {
+      wrapper = createWrapper(false);
     });
 
-    it('renders components correctly', () => {
+    it('renders the legacy new instruction and instructions section', () => {
       expect(findComponent('newInstruction').exists()).toBe(true);
       expect(findComponent('instructionsSection').exists()).toBe(true);
+    });
+
+    it('does not render the categorization layout', () => {
+      expect(findComponent('categorization').exists()).toBe(false);
+    });
+  });
+
+  describe('When categorization flag is enabled', () => {
+    beforeEach(() => {
+      wrapper = createWrapper(true);
+    });
+
+    it('renders the categorization layout', () => {
+      expect(findComponent('categorization').exists()).toBe(true);
+    });
+
+    it('does not render the legacy components', () => {
+      expect(findComponent('newInstruction').exists()).toBe(false);
+      expect(findComponent('instructionsSection').exists()).toBe(false);
     });
   });
 });

--- a/src/views/Instructions/__tests__/__snapshots__/Instructions.spec.js.snap
+++ b/src/views/Instructions/__tests__/__snapshots__/Instructions.spec.js.snap
@@ -1,8 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`Instructions.vue > Component rendering > should match snapshot 1`] = `
-"<section data-v-e9634d10="" class="instructions">
-  <new-instruction-stub data-v-e9634d10="" data-testid="new-instruction"></new-instruction-stub>
-  <instructions-section-stub data-v-e9634d10="" data-testid="instructions-section"></instructions-section-stub>
-</section>"
-`;

--- a/src/views/Instructions/index.vue
+++ b/src/views/Instructions/index.vue
@@ -1,13 +1,31 @@
 <template>
   <section class="instructions">
-    <NewInstruction data-testid="new-instruction" />
-    <InstructionsSection data-testid="instructions-section" />
+    <InstructionsCategorization
+      v-if="categorizationEnabled"
+      data-testid="instructions-categorization"
+    />
+
+    <template v-else>
+      <NewInstruction data-testid="new-instruction" />
+      <InstructionsSection data-testid="instructions-section" />
+    </template>
   </section>
 </template>
 
 <script setup>
+import { computed } from 'vue';
+
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
+
 import NewInstruction from '@/components/Instructions/NewInstruction.vue';
 import InstructionsSection from '@/components/Instructions/InstructionsSection.vue';
+import InstructionsCategorization from '@/components/Instructions/InstructionsCategorization/index.vue';
+
+const featureFlagsStore = useFeatureFlagsStore();
+
+const categorizationEnabled = computed(
+  () => featureFlagsStore.flags.categorizationOfInstructions,
+);
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
## Description

### Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other

### Motivation and Context

The instructions view needed a new layout that allows users to switch between a categorized view and a flat list view, along with a search input — gated behind a feature flag so the existing behavior is preserved when the flag is off.

### Summary of Changes

- Added a new `InstructionsCategorization` component that renders a toolbar with a search input and a segmented control (`Categories` / `List`) above the baseline instructions list.
- The `Instructions` view now conditionally renders `InstructionsCategorization` when the `categorizationOfInstructions` feature flag is enabled, falling back to the legacy `NewInstruction` + `InstructionsSection` layout otherwise.
- Added `activeInstructionsView` and `searchTerm` reactive refs to the `Instructions` store and exposed them for use by the new component.
- Added localized strings for the search placeholder and segmented control labels (`categories`, `list`) in English, Spanish, Portuguese, and Romanian.
- Added unit tests for `InstructionsCategorization` covering toolbar rendering, view toggle, search binding, and loading state behavior.
- Updated `Instructions.spec.js` to cover both the flag-enabled and flag-disabled rendering paths, and removed the outdated snapshot test.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/baaf1e4b-f2ff-49fa-88ec-3e8a2d05abee.png)  