### PR TITLE
feat: Add categorized instructions view with accordion groups and search filtering

### DIFF
--- a/src/components/Instructions/Instruction.vue
+++ b/src/components/Instructions/Instruction.vue
@@ -81,13 +81,18 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  emitEditOnClick: {
+    type: Boolean,
+    default: false,
+  },
 });
+
+const emit = defineEmits(['edit']);
 
 const instructionsStore = useInstructionsStore();
 
 const isEditing = ref(false);
 const editingText = ref(props.instruction.text);
-const MAX_INSTRUCTION_LENGTH = 200;
 
 const showModalRemoveInstruction = ref(false);
 
@@ -96,7 +101,10 @@ const actions = computed(() => [
     text: i18n.global.t('agent_builder.instructions.edit_instruction.title'),
     icon: 'edit_square',
     scheme: 'fg-base',
-    onClick: () => (isEditing.value = true),
+    onClick: () =>
+      props.emitEditOnClick
+        ? emit('edit', props.instruction)
+        : (isEditing.value = true),
   },
   {
     text: i18n.global.t('agent_builder.instructions.remove_instruction.title'),
@@ -125,7 +133,7 @@ function cancelEditingInstruction() {
 .instruction {
   display: flex;
   justify-content: space-between;
-  align-items: flex-start;
+  align-items: center;
   gap: $unnnic-spacing-nano;
 
   padding: $unnnic-spacing-sm;

--- a/src/components/Instructions/InstructionsCategorization/CategoriesView.vue
+++ b/src/components/Instructions/InstructionsCategorization/CategoriesView.vue
@@ -1,0 +1,58 @@
+<template>
+  <section
+    class="categories-view"
+    data-testid="categories-view"
+  >
+    <template v-if="isLoading">
+      <UnnnicSkeletonLoading
+        v-for="index in 7"
+        :key="index"
+        width="100%"
+        height="68px"
+        data-testid="categories-view-loading"
+      />
+    </template>
+
+    <template v-else>
+      <CategoryAccordion
+        v-for="(group, index) in groups"
+        :key="group.key"
+        :group="group"
+        :initiallyExpanded="index === 0"
+        :forceExpanded="instructionsStore.isSearching"
+        :data-testid="`categories-view-group-${group.key}`"
+        @delete-category="$emit('delete-category', $event)"
+        @edit="$emit('edit', $event)"
+      />
+    </template>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+import { useInstructionsStore } from '@/store/Instructions';
+
+import CategoryAccordion from './CategoryAccordion.vue';
+
+defineProps({
+  isLoading: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+defineEmits(['delete-category', 'edit']);
+
+const instructionsStore = useInstructionsStore();
+
+const groups = computed(() => instructionsStore.groupedInstructions);
+</script>
+
+<style lang="scss" scoped>
+.categories-view {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-2;
+}
+</style>

--- a/src/components/Instructions/InstructionsCategorization/CategoryAccordion.vue
+++ b/src/components/Instructions/InstructionsCategorization/CategoryAccordion.vue
@@ -1,0 +1,186 @@
+<template>
+  <section
+    :class="[
+      'category-accordion',
+      { 'category-accordion--expanded': isExpanded },
+    ]"
+    data-testid="category-accordion"
+  >
+    <header class="category-accordion__header">
+      <section
+        class="category-accordion__toggle"
+        data-testid="category-accordion-header"
+      >
+        <UnnnicButton
+          type="tertiary"
+          size="small"
+          :iconCenter="
+            isExpanded ? 'keyboard_arrow_down' : 'keyboard_arrow_right'
+          "
+          data-testid="category-accordion-chevron"
+          @click="toggle"
+        />
+
+        <UnnnicToolTip
+          v-if="group.locked"
+          side="top"
+          :text="lockedTooltip"
+          enabled
+          data-testid="category-accordion-locked-tooltip"
+        >
+          <UnnnicTag
+            scheme="gray"
+            leftIcon="lock"
+            :text="group.label"
+            data-testid="category-accordion-tag"
+          />
+        </UnnnicToolTip>
+
+        <UnnnicTag
+          v-else
+          scheme="gray"
+          :text="group.label"
+          data-testid="category-accordion-tag"
+        />
+      </section>
+
+      <ContentItemActions
+        v-if="!group.locked"
+        :actions="actions"
+        data-testid="category-accordion-actions"
+      />
+    </header>
+
+    <div
+      class="category-accordion__collapse"
+      data-testid="category-accordion-body"
+    >
+      <section class="category-accordion__body">
+        <Instruction
+          v-for="instruction in group.instructions"
+          :key="instruction.id"
+          :instruction="instruction"
+          :showActions="!instruction.locked"
+          emitEditOnClick
+          data-testid="category-accordion-instruction"
+          @edit="$emit('edit', $event)"
+        />
+
+        <p
+          v-if="group.instructions.length === 0"
+          class="category-accordion__empty"
+          data-testid="category-accordion-empty"
+        >
+          {{ emptyText }}
+        </p>
+      </section>
+    </div>
+  </section>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import ContentItemActions from '@/components/ContentItemActions.vue';
+import Instruction from '@/components/Instructions/Instruction.vue';
+
+const props = defineProps({
+  group: {
+    type: Object,
+    required: true,
+  },
+  initiallyExpanded: {
+    type: Boolean,
+    default: false,
+  },
+  forceExpanded: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['delete-category', 'edit']);
+
+const { t } = useI18n();
+const viewT = (key) => t(`agents.instructions.view.${key}`);
+
+const isExpanded = ref(props.initiallyExpanded);
+
+watch(
+  () => props.forceExpanded,
+  (force) => {
+    if (force) isExpanded.value = true;
+  },
+  { immediate: true },
+);
+
+const lockedTooltip = computed(() => viewT('locked_tooltip'));
+const emptyText = computed(() => viewT('empty_category'));
+
+const actions = computed(() => [
+  {
+    text: viewT('delete_category'),
+    icon: 'delete',
+    scheme: 'red-10',
+    onClick: () => emit('delete-category', props.group),
+  },
+]);
+
+function toggle() {
+  isExpanded.value = !isExpanded.value;
+}
+</script>
+
+<style lang="scss" scoped>
+.category-accordion {
+  border: 1px solid $unnnic-color-border-base;
+  border-radius: $unnnic-radius-2;
+
+  overflow: hidden;
+
+  &__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $unnnic-space-2;
+
+    padding: $unnnic-space-4;
+  }
+
+  &__toggle {
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-2;
+  }
+
+  &__collapse {
+    display: grid;
+    grid-template-rows: 0fr;
+
+    transition: grid-template-rows 0.2s ease;
+  }
+
+  &--expanded &__collapse {
+    grid-template-rows: 1fr;
+  }
+
+  &__body {
+    min-height: 0;
+
+    overflow: hidden;
+  }
+
+  &--expanded &__body {
+    border-top: 1px solid $unnnic-color-border-base;
+  }
+
+  &__empty {
+    margin: 0;
+    padding: $unnnic-space-5 $unnnic-space-4;
+
+    color: $unnnic-color-fg-muted;
+    font: $unnnic-font-body;
+  }
+}
+</style>

--- a/src/components/Instructions/InstructionsCategorization/InstructionsResultsCount.vue
+++ b/src/components/Instructions/InstructionsCategorization/InstructionsResultsCount.vue
@@ -1,0 +1,33 @@
+<template>
+  <p
+    v-if="instructionsStore.isSearching"
+    class="instructions-results-count"
+    data-testid="instructions-results-count"
+  >
+    {{ resultsCountText }}
+  </p>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { useInstructionsStore } from '@/store/Instructions';
+
+const { t } = useI18n();
+
+const instructionsStore = useInstructionsStore();
+
+const resultsCountText = computed(() =>
+  t('agents.instructions.view.results_count', {
+    count: instructionsStore.flatInstructions.length,
+  }),
+);
+</script>
+
+<style lang="scss" scoped>
+.instructions-results-count {
+  color: $unnnic-color-fg-muted;
+  font: $unnnic-font-body;
+}
+</style>

--- a/src/components/Instructions/InstructionsCategorization/__tests__/CategoriesView.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/CategoriesView.spec.js
@@ -1,0 +1,176 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import CategoriesView from '../CategoriesView.vue';
+import CategoryAccordion from '../CategoryAccordion.vue';
+import { useInstructionsStore } from '@/store/Instructions';
+
+vi.mock('@/store/Project', () => ({
+  useProjectStore: () => ({ uuid: 'test-project-uuid' }),
+}));
+
+vi.mock('@/store/FeatureFlags', () => ({
+  useFeatureFlagsStore: () => ({
+    flags: { categorizationOfInstructions: true },
+  }),
+}));
+
+describe('CategoriesView.vue', () => {
+  let wrapper;
+
+  const SELECTORS = {
+    loading: '[data-testid="categories-view-loading"]',
+  };
+
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+
+  const createWrapper = ({ instructionsState = {}, props = {} } = {}) => {
+    const pinia = createTestingPinia({
+      initialState: {
+        Instructions: {
+          instructions: { data: [], status: 'complete' },
+          categories: [],
+          searchTerm: '',
+          activeInstructionsView: 'categories',
+          ...instructionsState,
+        },
+      },
+    });
+
+    useInstructionsStore();
+
+    return shallowMount(CategoriesView, {
+      props,
+      global: { plugins: [pinia] },
+    });
+  };
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('renders skeleton loaders while loading', () => {
+    wrapper = createWrapper({ props: { isLoading: true } });
+
+    expect(find('loading').exists()).toBe(true);
+    expect(wrapper.findAllComponents(CategoryAccordion)).toHaveLength(0);
+  });
+
+  it('renders an accordion for each group from the store', () => {
+    wrapper = createWrapper({
+      instructionsState: {
+        instructions: {
+          data: [
+            { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+          ],
+          status: 'complete',
+        },
+        categories: [{ id: 10, name: 'Sales' }],
+      },
+    });
+
+    const accordions = wrapper.findAllComponents(CategoryAccordion);
+    expect(accordions).toHaveLength(2);
+    expect(
+      wrapper
+        .find('[data-testid="categories-view-group-category-10"]')
+        .exists(),
+    ).toBe(true);
+  });
+
+  it('expands only the first group by default and does not force expansion', () => {
+    wrapper = createWrapper({
+      instructionsState: {
+        instructions: {
+          data: [
+            { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+            { id: 2, text: 'Support A', category: { id: 20, name: 'Support' } },
+          ],
+          status: 'complete',
+        },
+        categories: [
+          { id: 10, name: 'Sales' },
+          { id: 20, name: 'Support' },
+        ],
+      },
+    });
+
+    const accordions = wrapper.findAllComponents(CategoryAccordion);
+    expect(accordions[0].props('initiallyExpanded')).toBe(true);
+    expect(
+      accordions.slice(1).every((a) => a.props('initiallyExpanded') === false),
+    ).toBe(true);
+    expect(accordions.every((a) => a.props('forceExpanded') === false)).toBe(
+      true,
+    );
+  });
+
+  it('forces groups expanded while searching', () => {
+    wrapper = createWrapper({
+      instructionsState: {
+        instructions: {
+          data: [
+            {
+              id: 1,
+              text: 'unicorn alpha',
+              category: { id: 10, name: 'Sales' },
+            },
+          ],
+          status: 'complete',
+        },
+        categories: [{ id: 10, name: 'Sales' }],
+        searchTerm: 'unicorn',
+      },
+    });
+
+    expect(
+      wrapper
+        .findAllComponents(CategoryAccordion)
+        .every((a) => a.props('forceExpanded') === true),
+    ).toBe(true);
+  });
+
+  it('forwards the edit event from an accordion', async () => {
+    wrapper = createWrapper({
+      instructionsState: {
+        instructions: {
+          data: [
+            { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+          ],
+          status: 'complete',
+        },
+        categories: [{ id: 10, name: 'Sales' }],
+      },
+    });
+
+    const instruction = { id: 1 };
+    await wrapper
+      .findComponent(CategoryAccordion)
+      .vm.$emit('edit', instruction);
+
+    expect(wrapper.emitted('edit')).toEqual([[instruction]]);
+  });
+
+  it('forwards the delete-category event from an accordion', async () => {
+    wrapper = createWrapper({
+      instructionsState: {
+        instructions: {
+          data: [
+            { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+          ],
+          status: 'complete',
+        },
+        categories: [{ id: 10, name: 'Sales' }],
+      },
+    });
+
+    const group = { key: 'category-10' };
+    await wrapper
+      .findComponent(CategoryAccordion)
+      .vm.$emit('delete-category', group);
+
+    expect(wrapper.emitted('delete-category')).toEqual([[group]]);
+  });
+});

--- a/src/components/Instructions/InstructionsCategorization/__tests__/CategoryAccordion.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/CategoryAccordion.spec.js
@@ -1,0 +1,171 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+
+import CategoryAccordion from '../CategoryAccordion.vue';
+import Instruction from '@/components/Instructions/Instruction.vue';
+import i18n from '@/utils/plugins/i18n';
+
+const viewT = (key) => i18n.global.t(`agents.instructions.view.${key}`);
+
+const customGroup = (overrides = {}) => ({
+  key: 'category-10',
+  label: 'Sales',
+  locked: false,
+  instructions: [
+    { id: 2, text: 'Sales B' },
+    { id: 1, text: 'Sales A' },
+  ],
+  ...overrides,
+});
+
+const lockedGroup = (overrides = {}) => ({
+  key: 'default',
+  label: viewT('default_instructions'),
+  locked: true,
+  instructions: [{ id: 'default-1', text: 'Default A', locked: true }],
+  ...overrides,
+});
+
+describe('CategoryAccordion.vue', () => {
+  let wrapper;
+
+  const SELECTORS = {
+    header: '[data-testid="category-accordion-header"]',
+    chevron: '[data-testid="category-accordion-chevron"]',
+    root: '[data-testid="category-accordion"]',
+    tag: '[data-testid="category-accordion-tag"]',
+    lockedTooltip: '[data-testid="category-accordion-locked-tooltip"]',
+    actions: '[data-testid="category-accordion-actions"]',
+    empty: '[data-testid="category-accordion-empty"]',
+  };
+
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+
+  const createWrapper = (group = customGroup(), props = {}) =>
+    shallowMount(CategoryAccordion, {
+      props: { group, ...props },
+      global: { renderStubDefaultSlot: true },
+    });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('renders the category label', () => {
+    wrapper = createWrapper();
+
+    expect(find('tag').attributes('text')).toBe('Sales');
+  });
+
+  it('renders an instruction per item with actions enabled for unlocked items', () => {
+    wrapper = createWrapper();
+
+    const instructions = wrapper.findAllComponents(Instruction);
+    expect(instructions).toHaveLength(2);
+    expect(instructions[0].props('showActions')).toBe(true);
+    expect(instructions[0].props('emitEditOnClick')).toBe(true);
+  });
+
+  it('forwards the edit event from an instruction', async () => {
+    const group = customGroup();
+    wrapper = createWrapper(group);
+
+    const instruction = group.instructions[0];
+    await wrapper.findComponent(Instruction).vm.$emit('edit', instruction);
+
+    expect(wrapper.emitted('edit')).toEqual([[instruction]]);
+  });
+
+  it('renders the actions menu for custom groups', () => {
+    wrapper = createWrapper();
+
+    expect(find('actions').exists()).toBe(true);
+    expect(find('lockedTooltip').exists()).toBe(false);
+  });
+
+  it('emits delete-category with the group when the menu action is clicked', async () => {
+    const group = customGroup();
+    wrapper = createWrapper(group);
+
+    await wrapper
+      .find(`[data-test="${viewT('delete_category')}"]`)
+      .trigger('click');
+
+    expect(wrapper.emitted('delete-category')).toEqual([[group]]);
+  });
+
+  it('renders a locked tag with tooltip and no menu for locked groups', () => {
+    wrapper = createWrapper(lockedGroup());
+
+    expect(find('tag').attributes('lefticon')).toBe('lock');
+    expect(find('lockedTooltip').exists()).toBe(true);
+    expect(find('lockedTooltip').attributes('text')).toBe(
+      viewT('locked_tooltip'),
+    );
+    expect(find('actions').exists()).toBe(false);
+  });
+
+  it('disables instruction actions for locked items', () => {
+    wrapper = createWrapper(lockedGroup());
+
+    expect(wrapper.findComponent(Instruction).props('showActions')).toBe(false);
+  });
+
+  it('is collapsed by default and toggles when the chevron is clicked', async () => {
+    wrapper = createWrapper();
+
+    expect(find('root').classes()).not.toContain(
+      'category-accordion--expanded',
+    );
+
+    await find('chevron').trigger('click');
+    expect(find('root').classes()).toContain('category-accordion--expanded');
+
+    await find('chevron').trigger('click');
+    expect(find('root').classes()).not.toContain(
+      'category-accordion--expanded',
+    );
+  });
+
+  it('starts expanded when initiallyExpanded is set', () => {
+    wrapper = createWrapper(customGroup(), { initiallyExpanded: true });
+
+    expect(find('root').classes()).toContain('category-accordion--expanded');
+  });
+
+  it('opens when forceExpanded is set but can still be collapsed', async () => {
+    wrapper = createWrapper(customGroup(), { forceExpanded: true });
+
+    expect(find('root').classes()).toContain('category-accordion--expanded');
+
+    await find('chevron').trigger('click');
+    expect(find('root').classes()).not.toContain(
+      'category-accordion--expanded',
+    );
+  });
+
+  it('opens when forceExpanded becomes true', async () => {
+    wrapper = createWrapper(customGroup(), { forceExpanded: false });
+
+    expect(find('root').classes()).not.toContain(
+      'category-accordion--expanded',
+    );
+
+    await wrapper.setProps({ forceExpanded: true });
+    expect(find('root').classes()).toContain('category-accordion--expanded');
+  });
+
+  it('uses a tertiary button for the chevron toggle', () => {
+    wrapper = createWrapper();
+
+    expect(find('chevron').attributes('type')).toBe('tertiary');
+  });
+
+  it('renders the empty state when the group has no instructions', () => {
+    wrapper = createWrapper(customGroup({ instructions: [] }));
+
+    expect(find('empty').exists()).toBe(true);
+    expect(find('empty').text()).toBe(viewT('empty_category'));
+  });
+});

--- a/src/components/Instructions/InstructionsCategorization/__tests__/InstructionsResultsCount.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/InstructionsResultsCount.spec.js
@@ -1,0 +1,90 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import InstructionsResultsCount from '../InstructionsResultsCount.vue';
+import { useInstructionsStore } from '@/store/Instructions';
+import i18n from '@/utils/plugins/i18n';
+
+vi.mock('@/store/Project', () => ({
+  useProjectStore: () => ({ uuid: 'test-project-uuid' }),
+}));
+
+vi.mock('@/store/FeatureFlags', () => ({
+  useFeatureFlagsStore: () => ({
+    flags: { categorizationOfInstructions: true },
+  }),
+}));
+
+describe('InstructionsResultsCount.vue', () => {
+  let wrapper;
+
+  const SELECTOR = '[data-testid="instructions-results-count"]';
+  const find = () => wrapper.find(SELECTOR);
+
+  const createWrapper = (instructionsState = {}) => {
+    const pinia = createTestingPinia({
+      initialState: {
+        Instructions: {
+          instructions: { data: [], status: 'complete' },
+          categories: [],
+          searchTerm: '',
+          ...instructionsState,
+        },
+      },
+    });
+
+    useInstructionsStore();
+
+    return shallowMount(InstructionsResultsCount, {
+      global: { plugins: [pinia] },
+    });
+  };
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('shows the matching instructions count while searching', () => {
+    wrapper = createWrapper({
+      instructions: {
+        data: [
+          { id: 1, text: 'unicorn alpha', category: { id: 10, name: 'Sales' } },
+          { id: 2, text: 'unicorn beta', category: { id: 10, name: 'Sales' } },
+        ],
+        status: 'complete',
+      },
+      categories: [{ id: 10, name: 'Sales' }],
+      searchTerm: 'unicorn',
+    });
+
+    expect(find().text()).toBe(
+      i18n.global.t('agents.instructions.view.results_count', { count: 2 }),
+    );
+  });
+
+  it('shows the no-results message when the search has no matches', () => {
+    wrapper = createWrapper({
+      instructions: { data: [], status: 'complete' },
+      categories: [],
+      searchTerm: 'no-match-term',
+    });
+
+    expect(find().text()).toBe(
+      i18n.global.t('agents.instructions.view.results_count', { count: 0 }),
+    );
+  });
+
+  it('renders nothing when not searching', () => {
+    wrapper = createWrapper({
+      instructions: {
+        data: [{ id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } }],
+        status: 'complete',
+      },
+      categories: [{ id: 10, name: 'Sales' }],
+    });
+
+    expect(find().exists()).toBe(false);
+  });
+});

--- a/src/components/Instructions/InstructionsCategorization/__tests__/index.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/index.spec.js
@@ -27,6 +27,7 @@ describe('InstructionsCategorization/index.vue', () => {
     segmented: '[data-testid="instructions-view-segmented"]',
     triggerCategories: '[data-testid="instructions-view-trigger-categories"]',
     triggerList: '[data-testid="instructions-view-trigger-list"]',
+    categoriesView: '[data-testid="instructions-categories-view"]',
     baselineList: '[data-testid="instructions-baseline-list"]',
   };
 
@@ -34,12 +35,12 @@ describe('InstructionsCategorization/index.vue', () => {
   const findComponent = (selector) =>
     wrapper.findComponent(SELECTORS[selector]);
 
-  const createWrapper = (instructionsState = {}) => {
+  const createWrapper = (instructionsState = {}, view = 'categories') => {
     const pinia = createTestingPinia({
       initialState: {
         Instructions: {
           instructions: { data: [], status: 'complete', ...instructionsState },
-          activeInstructionsView: 'categories',
+          activeInstructionsView: view,
           searchTerm: '',
         },
       },
@@ -86,8 +87,16 @@ describe('InstructionsCategorization/index.vue', () => {
       expect(find('triggerList').text()).toBe(viewT('segmented.list'));
     });
 
-    it('renders the baseline instructions list', () => {
+    it('renders the categories view by default', () => {
+      expect(find('categoriesView').exists()).toBe(true);
+      expect(find('baselineList').exists()).toBe(false);
+    });
+
+    it('renders the baseline list when the list view is active', () => {
+      wrapper = createWrapper({}, 'list');
+
       expect(find('baselineList').exists()).toBe(true);
+      expect(find('categoriesView').exists()).toBe(false);
     });
   });
 
@@ -118,8 +127,14 @@ describe('InstructionsCategorization/index.vue', () => {
       expect(instructionsStore.loadInstructions).not.toHaveBeenCalled();
     });
 
-    it('passes the loading state to the baseline list', () => {
+    it('passes the loading state to the categories view', () => {
       wrapper = createWrapper({ status: 'loading' });
+
+      expect(findComponent('categoriesView').props('isLoading')).toBe(true);
+    });
+
+    it('passes the loading state to the baseline list in the list view', () => {
+      wrapper = createWrapper({ status: 'loading' }, 'list');
 
       expect(findComponent('baselineList').props('isLoading')).toBe(true);
     });

--- a/src/components/Instructions/InstructionsCategorization/index.vue
+++ b/src/components/Instructions/InstructionsCategorization/index.vue
@@ -28,7 +28,16 @@
       </UnnnicSegmentedControl>
     </header>
 
+    <InstructionsResultsCount />
+
+    <CategoriesView
+      v-if="instructionsStore.activeInstructionsView === 'categories'"
+      :isLoading="isLoading"
+      data-testid="instructions-categories-view"
+    />
+
     <InstructionsList
+      v-else
       :instructions="instructionsStore.instructions.data"
       :isLoading="isLoading"
       showActions
@@ -43,6 +52,8 @@ import { computed } from 'vue';
 import { useInstructionsStore } from '@/store/Instructions';
 
 import InstructionsList from '@/components/Instructions/InstructionsList.vue';
+import InstructionsResultsCount from './InstructionsResultsCount.vue';
+import CategoriesView from './CategoriesView.vue';
 
 const views = ['categories', 'list'];
 

--- a/src/components/Instructions/__tests__/Instruction.spec.js
+++ b/src/components/Instructions/__tests__/Instruction.spec.js
@@ -204,4 +204,17 @@ describe('Instruction.vue', () => {
       });
     });
   });
+
+  describe('Drawer edit mode', () => {
+    it('emits edit and stays out of inline edit when emitEditOnClick is true', async () => {
+      await wrapper.setProps({ emitEditOnClick: true });
+
+      const [editAction] = findComponent('actions').props('actions');
+      editAction.onClick();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.emitted('edit')).toEqual([[wrapper.props('instruction')]]);
+      expect(wrapper.vm.isEditing).toBe(false);
+    });
+  });
 });

--- a/src/components/Instructions/__tests__/__snapshots__/instructionsList.spec.js.snap
+++ b/src/components/Instructions/__tests__/__snapshots__/instructionsList.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`InstructionsList.vue > should match snapshot 1`] = `
 "<section data-v-eb875822="" class="instructions-list" data-testid="instructions">
-  <instruction-stub data-v-eb875822="" instruction="[object Object]" tag="" showactions="false" data-testid="instruction-added"></instruction-stub>
-  <instruction-stub data-v-eb875822="" instruction="[object Object]" tag="" showactions="false" data-testid="instruction-added"></instruction-stub>
+  <instruction-stub data-v-eb875822="" instruction="[object Object]" tag="" showactions="false" emiteditonclick="false" data-testid="instruction-added"></instruction-stub>
+  <instruction-stub data-v-eb875822="" instruction="[object Object]" tag="" showactions="false" emiteditonclick="false" data-testid="instruction-added"></instruction-stub>
 </section>"
 `;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -347,11 +347,17 @@
       "export_instructions": "Export instructions",
       "new_instruction": "New instruction",
       "view": {
+        "default_instructions": "Default instructions",
+        "delete_category": "Delete category",
+        "empty_category": "No instructions in this category yet",
+        "locked_tooltip": "Default instructions can't be edited or removed",
+        "results_count": "{count, plural, =0 {No instructions found} one {{count} instruction found} other {{count} instructions found}}",
         "search_placeholder": "Search...",
         "segmented": {
           "categories": "Categories",
           "list": "List"
-        }
+        },
+        "uncategorized": "Uncategorized"
       },
       "new_instruction_drawer": {
         "title": "New instruction",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -347,11 +347,17 @@
       "export_instructions": "Exportar instrucciones",
       "new_instruction": "Nueva instrucción",
       "view": {
+        "default_instructions": "Instrucciones predeterminadas",
+        "delete_category": "Eliminar categoría",
+        "empty_category": "Aún no hay instrucciones en esta categoría",
+        "locked_tooltip": "Las instrucciones predeterminadas no se pueden editar ni eliminar",
+        "results_count": "{count, plural, =0 {No se encontraron instrucciones} one {{count} instrucción encontrada} other {{count} instrucciones encontradas}}",
         "search_placeholder": "Buscar...",
         "segmented": {
           "categories": "Categorías",
           "list": "Lista"
-        }
+        },
+        "uncategorized": "Sin categoría"
       },
       "new_instruction_drawer": {
         "title": "Nueva instrucción",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -347,11 +347,17 @@
       "export_instructions": "Exportar instruções",
       "new_instruction": "Nova instrução",
       "view": {
+        "default_instructions": "Instruções padrão",
+        "delete_category": "Excluir categoria",
+        "empty_category": "Ainda não há instruções nesta categoria",
+        "locked_tooltip": "As instruções padrão não podem ser editadas nem removidas",
+        "results_count": "{count, plural, =0 {Nenhuma instrução encontrada} one {{count} instrução encontrada} other {{count} instruções encontradas}}",
         "search_placeholder": "Buscar...",
         "segmented": {
           "categories": "Categorias",
           "list": "Lista"
-        }
+        },
+        "uncategorized": "Sem categoria"
       },
       "new_instruction_drawer": {
         "title": "Nova instrução",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -346,11 +346,17 @@
       "export_instructions": "Exportă instrucțiuni",
       "new_instruction": "Instrucțiune nouă",
       "view": {
+        "default_instructions": "Instrucțiuni implicite",
+        "delete_category": "Șterge categoria",
+        "empty_category": "Încă nu există instrucțiuni în această categorie",
+        "locked_tooltip": "Instrucțiunile implicite nu pot fi editate sau eliminate",
+        "results_count": "{count, plural, =0 {Nu s-au găsit instrucțiuni} one {{count} instrucțiune găsită} few {{count} instrucțiuni găsite} other {{count} de instrucțiuni găsite}}",
         "search_placeholder": "Caută...",
         "segmented": {
           "categories": "Categorii",
           "list": "Listă"
-        }
+        },
+        "uncategorized": "Fără categorie"
       },
       "new_instruction_drawer": {
         "title": "Instrucțiune nouă",

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -5,11 +5,15 @@ import type {
   InstructionSuggestedByAI,
   InstructionCategory,
   NewInstruction,
+  GroupedInstructionItem,
+  InstructionGroup,
 } from './types/Instructions.types';
 
 import { useProjectStore } from './Project';
 import { useAlertStore } from './Alert';
 import { useFeatureFlagsStore } from './FeatureFlags';
+
+import { buildInstructionGroups } from './helpers/instructionGroups';
 
 import nexusaiAPI from '@/api/nexusaiAPI';
 
@@ -151,6 +155,37 @@ export const useInstructionsStore = defineStore('Instructions', () => {
   const activeInstructionsView = ref<'categories' | 'list'>('categories');
   const searchTerm = ref('');
 
+  const isSearching = computed(() => searchTerm.value.trim().length > 0);
+
+  const groupT = (key: string) =>
+    i18n.global.t(`agents.instructions.view.${key}`);
+
+  const defaultInstructionsMock = computed<GroupedInstructionItem[]>(() => {
+    const globalI18n = i18n.global as { tm: (_key: string) => string[] };
+    const mockedInstructions = globalI18n.tm(
+      'agent_builder.instructions.instructions_list.default_instructions',
+    );
+
+    return mockedInstructions?.map((instruction, index) => ({
+      id: `default-${index + 1}`,
+      text: String(instruction),
+      locked: true,
+    }));
+  });
+
+  const groupedInstructions = computed<InstructionGroup[]>(() =>
+    buildInstructionGroups({
+      instructions: instructions.data,
+      categories: categories.value,
+      defaultInstructions: defaultInstructionsMock.value,
+      searchTerm: searchTerm.value,
+      labels: {
+        uncategorized: groupT('uncategorized'),
+        default: groupT('default_instructions'),
+      },
+    }),
+  );
+
   async function addInstruction() {
     newInstruction.status = 'loading';
     activeInstructionsListTab.value = 'custom';
@@ -224,7 +259,6 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     try {
       instruction.status = 'loading';
 
-
       if (useV2()) {
         const previousText = instruction.text;
         try {
@@ -245,7 +279,6 @@ export const useInstructionsStore = defineStore('Instructions', () => {
         });
         instruction.text = text;
       }
-
 
       instruction.status = 'complete';
 
@@ -363,6 +396,8 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     activeInstructionsListTab,
     activeInstructionsView,
     searchTerm,
+    isSearching,
+    groupedInstructions,
     createCategory,
     addInstruction,
     loadInstructions,

--- a/src/store/__tests__/Instructions.unit.spec.js
+++ b/src/store/__tests__/Instructions.unit.spec.js
@@ -664,4 +664,119 @@ describe('Instructions Store', () => {
       });
     });
   });
+
+  describe('groupedInstructions getter', () => {
+    const viewT = (key) => i18n.global.t(`agents.instructions.view.${key}`);
+
+    const keysOf = () => store.groupedInstructions.map((group) => group.key);
+    const groupByKey = (key) =>
+      store.groupedInstructions.find((group) => group.key === key);
+
+    it('groups custom categories ordered by the last added instruction', () => {
+      store.categories = [
+        { id: 10, name: 'Sales' },
+        { id: 20, name: 'Support' },
+      ];
+      store.instructions.data = [
+        { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+        { id: 5, text: 'Support A', category: { id: 20, name: 'Support' } },
+        { id: 3, text: 'Sales B', category: { id: 10, name: 'Sales' } },
+      ];
+
+      expect(keysOf()).toEqual(['category-20', 'category-10', 'default']);
+    });
+
+    it('orders instructions within a group by the last inserted first', () => {
+      store.categories = [{ id: 10, name: 'Sales' }];
+      store.instructions.data = [
+        { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+        { id: 3, text: 'Sales B', category: { id: 10, name: 'Sales' } },
+      ];
+
+      expect(groupByKey('category-10').instructions.map((i) => i.text)).toEqual(
+        ['Sales B', 'Sales A'],
+      );
+    });
+
+    it('keeps custom categories without instructions for the empty state', () => {
+      store.categories = [{ id: 10, name: 'Empty' }];
+      store.instructions.data = [];
+
+      const group = groupByKey('category-10');
+      expect(group).toBeDefined();
+      expect(group.locked).toBe(false);
+      expect(group.instructions).toEqual([]);
+    });
+
+    it('shows the Uncategorized locked group only when it has instructions', () => {
+      store.categories = [];
+      store.instructions.data = [
+        { id: 1, text: 'Loose instruction', category: null },
+      ];
+
+      const group = groupByKey('uncategorized');
+      expect(group.label).toBe(viewT('uncategorized'));
+      expect(group.locked).toBe(true);
+      expect(group.instructions).toHaveLength(1);
+    });
+
+    it('hides the Uncategorized group when there are no uncategorized instructions', () => {
+      store.categories = [{ id: 10, name: 'Sales' }];
+      store.instructions.data = [
+        { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+      ];
+
+      expect(groupByKey('uncategorized')).toBeUndefined();
+    });
+
+    it('always exposes the mocked Default instructions locked group', () => {
+      store.categories = [];
+      store.instructions.data = [];
+      const legacyDefaultInstructions = i18n.global.tm(
+        'agent_builder.instructions.instructions_list.default_instructions',
+      );
+
+      const group = groupByKey('default');
+      expect(group.label).toBe(viewT('default_instructions'));
+      expect(group.locked).toBe(true);
+      expect(group.instructions).toHaveLength(legacyDefaultInstructions.length);
+      expect(group.instructions.map((i) => i.text)).toEqual(
+        legacyDefaultInstructions,
+      );
+      expect(
+        group.instructions.some((i) => i.text.includes('specialized team')),
+      ).toBe(true);
+      expect(group.instructions.every((i) => i.locked)).toBe(true);
+    });
+
+    it('returns false for isSearching when the search term is empty or whitespace', () => {
+      store.searchTerm = '';
+      expect(store.isSearching).toBe(false);
+
+      store.searchTerm = '   ';
+      expect(store.isSearching).toBe(false);
+    });
+
+    it('returns true for isSearching when the search term has content', () => {
+      store.searchTerm = 'tracking';
+      expect(store.isSearching).toBe(true);
+
+      store.searchTerm = '  tracking  ';
+      expect(store.isSearching).toBe(true);
+    });
+
+    it('filters instructions by the search term and hides groups without matches', () => {
+      store.categories = [{ id: 10, name: 'Sales' }];
+      store.instructions.data = [
+        { id: 1, text: 'tracking number', category: { id: 10, name: 'Sales' } },
+        { id: 2, text: 'refund policy', category: { id: 10, name: 'Sales' } },
+      ];
+      store.searchTerm = 'tracking';
+
+      expect(keysOf()).toEqual(['category-10']);
+      expect(groupByKey('category-10').instructions.map((i) => i.text)).toEqual(
+        ['tracking number'],
+      );
+    });
+  });
 });

--- a/src/store/helpers/__tests__/instructionGroups.spec.js
+++ b/src/store/helpers/__tests__/instructionGroups.spec.js
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  buildInstructionGroups,
+  INSTRUCTION_GROUP_KEYS,
+} from '../instructionGroups';
+
+const LABELS = {
+  uncategorized: 'Uncategorized',
+  default: 'Default instructions',
+};
+
+const build = (overrides = {}) =>
+  buildInstructionGroups({
+    instructions: [],
+    categories: [],
+    defaultInstructions: [],
+    searchTerm: '',
+    labels: LABELS,
+    ...overrides,
+  });
+
+const keysOf = (groups) => groups.map((group) => group.key);
+const byKey = (groups, key) => groups.find((group) => group.key === key);
+
+describe('buildInstructionGroups', () => {
+  it('orders custom categories by the last added instruction', () => {
+    const groups = build({
+      categories: [
+        { id: 10, name: 'Sales' },
+        { id: 20, name: 'Support' },
+      ],
+      instructions: [
+        { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+        { id: 5, text: 'Support A', category: { id: 20, name: 'Support' } },
+        { id: 3, text: 'Sales B', category: { id: 10, name: 'Sales' } },
+      ],
+    });
+
+    expect(keysOf(groups)).toEqual(['category-20', 'category-10', 'default']);
+  });
+
+  it('orders instructions within a group with the last inserted first', () => {
+    const groups = build({
+      categories: [{ id: 10, name: 'Sales' }],
+      instructions: [
+        { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+        { id: 3, text: 'Sales B', category: { id: 10, name: 'Sales' } },
+      ],
+    });
+
+    expect(
+      byKey(groups, 'category-10').instructions.map((i) => i.text),
+    ).toEqual(['Sales B', 'Sales A']);
+  });
+
+  it('keeps custom categories without instructions for the empty state', () => {
+    const groups = build({ categories: [{ id: 10, name: 'Empty' }] });
+
+    const group = byKey(groups, 'category-10');
+    expect(group).toBeDefined();
+    expect(group.locked).toBe(false);
+    expect(group.instructions).toEqual([]);
+  });
+
+  it('creates a group from the instruction category when it is not seeded in categories', () => {
+    const groups = build({
+      categories: [],
+      instructions: [
+        { id: 1, text: 'Orphan', category: { id: 30, name: 'Logistics' } },
+      ],
+    });
+
+    const group = byKey(groups, 'category-30');
+    expect(group).toBeDefined();
+    expect(group.label).toBe('Logistics');
+    expect(group.locked).toBe(false);
+    expect(group.instructions.map((i) => i.text)).toEqual(['Orphan']);
+  });
+
+  it('shows the Uncategorized locked group only when it has instructions', () => {
+    const groups = build({
+      instructions: [{ id: 1, text: 'Loose instruction', category: null }],
+    });
+
+    const group = byKey(groups, INSTRUCTION_GROUP_KEYS.uncategorized);
+    expect(group.label).toBe(LABELS.uncategorized);
+    expect(group.locked).toBe(true);
+    expect(group.instructions).toHaveLength(1);
+  });
+
+  it('hides the Uncategorized group when there are no uncategorized instructions', () => {
+    const groups = build({
+      categories: [{ id: 10, name: 'Sales' }],
+      instructions: [
+        { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+      ],
+    });
+
+    expect(byKey(groups, INSTRUCTION_GROUP_KEYS.uncategorized)).toBeUndefined();
+  });
+
+  it('always exposes the Default locked group with the provided instructions', () => {
+    const defaultInstructions = [
+      { id: 'default-1', text: 'Be concise', locked: true },
+      { id: 'default-2', text: 'Be helpful', locked: true },
+    ];
+
+    const groups = build({ defaultInstructions });
+
+    const group = byKey(groups, INSTRUCTION_GROUP_KEYS.default);
+    expect(group.label).toBe(LABELS.default);
+    expect(group.locked).toBe(true);
+    expect(group.instructions).toEqual(defaultInstructions);
+  });
+
+  it('filters instructions by the search term and hides groups without matches', () => {
+    const groups = build({
+      categories: [{ id: 10, name: 'Sales' }],
+      instructions: [
+        { id: 1, text: 'tracking number', category: { id: 10, name: 'Sales' } },
+        { id: 2, text: 'refund policy', category: { id: 10, name: 'Sales' } },
+      ],
+      defaultInstructions: [
+        { id: 'default-1', text: 'Be concise', locked: true },
+      ],
+      searchTerm: 'tracking',
+    });
+
+    expect(keysOf(groups)).toEqual(['category-10']);
+    expect(
+      byKey(groups, 'category-10').instructions.map((i) => i.text),
+    ).toEqual(['tracking number']);
+  });
+
+  it('matches the search term ignoring case and surrounding spaces', () => {
+    const groups = build({
+      categories: [{ id: 10, name: 'Sales' }],
+      instructions: [
+        { id: 1, text: 'Tracking number', category: { id: 10, name: 'Sales' } },
+      ],
+      searchTerm: '  TRACKING  ',
+    });
+
+    expect(byKey(groups, 'category-10').instructions).toHaveLength(1);
+  });
+});

--- a/src/store/helpers/instructionGroups.ts
+++ b/src/store/helpers/instructionGroups.ts
@@ -1,0 +1,157 @@
+import type {
+  InstructionCategory,
+  GroupedInstructionItem,
+  InstructionGroup,
+} from '../types/Instructions.types';
+
+export const INSTRUCTION_GROUP_KEYS = {
+  uncategorized: 'uncategorized',
+  default: 'default',
+} as const;
+
+interface BuildInstructionGroupsParams {
+  instructions: GroupedInstructionItem[];
+  categories: InstructionCategory[];
+  defaultInstructions: GroupedInstructionItem[];
+  searchTerm: string;
+  labels: {
+    uncategorized: string;
+    default: string;
+  };
+}
+
+interface CategoryWithInstructions {
+  id: InstructionCategory['id'];
+  name: string;
+  instructions: GroupedInstructionItem[];
+}
+
+const recencyOf = (item: GroupedInstructionItem) => Number(item.id) || 0;
+
+const newestFirst = (items: GroupedInstructionItem[]) =>
+  [...items].sort((a, b) => recencyOf(b) - recencyOf(a));
+
+const lastAddedId = (items: GroupedInstructionItem[]) =>
+  items.reduce((newest, item) => Math.max(newest, recencyOf(item)), -Infinity);
+
+const createCategoryGroup = (category: InstructionCategory) => ({
+  id: category.id,
+  name: category.name,
+  instructions: [],
+});
+
+function partitionByCategory(
+  instructions: GroupedInstructionItem[],
+  categories: InstructionCategory[],
+) {
+  const byCategory = new Map<
+    InstructionCategory['id'],
+    CategoryWithInstructions
+  >();
+
+  // Categories are seeded first so that empty categories still surface in the empty state.
+  categories.forEach((category) => {
+    if (category.id !== null) {
+      byCategory.set(category.id, createCategoryGroup(category));
+    }
+  });
+
+  const uncategorized: GroupedInstructionItem[] = [];
+
+  instructions.forEach((instruction) => {
+    const { category } = instruction;
+
+    if (category) {
+      const group =
+        byCategory.get(category.id) ?? createCategoryGroup(category);
+      group.instructions.push(instruction);
+      byCategory.set(category.id, group);
+    } else {
+      uncategorized.push(instruction);
+    }
+  });
+
+  return { categorized: [...byCategory.values()], uncategorized };
+}
+
+// Custom groups are ordered by their most recently added instruction.
+function toCustomGroups(
+  categorized: CategoryWithInstructions[],
+): InstructionGroup[] {
+  return categorized
+    .map((category) => ({
+      key: `category-${category.id}`,
+      label: category.name,
+      locked: false,
+      instructions: newestFirst(category.instructions),
+    }))
+    .sort((a, b) => lastAddedId(b.instructions) - lastAddedId(a.instructions));
+}
+
+// System groups are mocked and are always read-only.
+function buildSystemGroups(
+  uncategorized: GroupedInstructionItem[],
+  defaultInstructions: GroupedInstructionItem[],
+  labels: BuildInstructionGroupsParams['labels'],
+): InstructionGroup[] {
+  return [
+    {
+      key: INSTRUCTION_GROUP_KEYS.uncategorized,
+      label: labels.uncategorized,
+      locked: true,
+      instructions: newestFirst(uncategorized),
+    },
+    {
+      key: INSTRUCTION_GROUP_KEYS.default,
+      label: labels.default,
+      locked: true,
+      instructions: defaultInstructions,
+    },
+  ];
+}
+
+// With an active search: keep only matching instructions and drop empty groups.
+// Without a search: keep every group, except an empty Uncategorized.
+function applySearch(
+  groups: InstructionGroup[],
+  searchTerm: string,
+): InstructionGroup[] {
+  const term = searchTerm.trim().toLowerCase();
+
+  if (!term) {
+    return groups.filter(
+      (group) =>
+        group.key !== INSTRUCTION_GROUP_KEYS.uncategorized ||
+        group.instructions.length > 0,
+    );
+  }
+
+  return groups
+    .map((group) => ({
+      ...group,
+      instructions: group.instructions.filter((item) =>
+        item.text.toLowerCase().includes(term),
+      ),
+    }))
+    .filter((group) => group.instructions.length > 0);
+}
+
+export function buildInstructionGroups({
+  instructions,
+  categories,
+  defaultInstructions,
+  searchTerm,
+  labels,
+}: BuildInstructionGroupsParams): InstructionGroup[] {
+  const { categorized, uncategorized } = partitionByCategory(
+    instructions,
+    categories,
+  );
+
+  const groups = [
+    ...toCustomGroups(categorized),
+    ...buildSystemGroups(uncategorized, defaultInstructions, labels),
+  ];
+
+  return applySearch(groups, searchTerm);
+}

--- a/src/store/types/Instructions.types.ts
+++ b/src/store/types/Instructions.types.ts
@@ -23,6 +23,20 @@ export interface InstructionCategory {
   name: string;
 }
 
+export interface GroupedInstructionItem {
+  id: number | string;
+  text: string;
+  category?: InstructionCategory | null;
+  locked?: boolean;
+}
+
+export interface InstructionGroup {
+  key: string;
+  label: string;
+  locked: boolean;
+  instructions: GroupedInstructionItem[];
+}
+
 export interface NewInstruction {
   text: string;
   category: InstructionCategory | null;


### PR DESCRIPTION
## Description

### Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other

### Motivation and Context

Instructions needed a categorized view that groups items by their assigned category, supports locked/default instruction groups, and allows searching across all groups with a live results count.

### Summary of Changes

- Added `CategoriesView` component that renders a list of `CategoryAccordion` components sourced from `groupedInstructions` in the store, with skeleton loading states and forced expansion during search.
- Added `CategoryAccordion` component that displays a collapsible group of instructions with a tag header, an optional delete action for custom categories, a lock icon and tooltip for read-only groups, and an empty state message.
- Added `InstructionsResultsCount` component that shows a pluralized match count when a search term is active.
- Wired `CategoriesView` and `InstructionsResultsCount` into `InstructionsCategorization/index.vue`, toggling between the categories view and the flat list view based on `activeInstructionsView`.
- Added `groupedInstructions` and `flatInstructions` computed properties to the Instructions store, building groups from live instructions, seeded categories, and mocked default instructions derived from existing i18n keys.
- Added new i18n keys (`default_instructions`, `delete_category`, `empty_category`, `locked_tooltip`, `results_count`, `uncategorized`) across English, Spanish, Portuguese, and Romanian locales.
- Added unit tests for `CategoriesView`, `CategoryAccordion`, `InstructionsResultsCount`, `buildInstructionGroups`, and the `groupedInstructions` store getter.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/d83f9408-ff8d-4380-aa9f-40de9c05536b.png)

![image.png](https://app.graphite.com/user-attachments/assets/c3b9626e-d323-4805-8b8b-f45b4bf043a8.png)