### PR TITLE
feat: Show last updated date for custom agents in setup

### DIFF
--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/About.vue
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/About.vue
@@ -29,6 +29,14 @@
       </a>
     </section>
 
+    <p
+      v-if="lastUpdatedLabel"
+      class="start-setup-about__last-updated"
+      data-testid="start-setup-about-last-updated"
+    >
+      {{ lastUpdatedLabel }}
+    </p>
+
     <section
       v-if="agentSystems.length"
       class="start-setup-about__systems"
@@ -48,8 +56,11 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 
+import { useI18n } from 'vue-i18n';
+
 import SystemBadge from '@/components/AgentsTeam/SystemBadge.vue';
 import useTranslatedField from '@/composables/useTranslatedField';
+import { formatLongDate, formatTime } from '@/utils/formatters';
 import type { Agent } from '@/store/types/Agents.types';
 
 const GROUP_DOCS: Record<string, string> = {
@@ -65,7 +76,19 @@ const props = defineProps<{
   agent: Agent;
 }>();
 
+const { t } = useI18n();
+
 const translateField = useTranslatedField();
+
+const lastUpdatedLabel = computed(() => {
+  const { last_updated, is_official } = props.agent;
+  if (!last_updated || is_official) return undefined;
+
+  return t('agents.assign_agents.setup.last_updated', {
+    date: formatLongDate(last_updated),
+    time: formatTime(last_updated),
+  });
+});
 
 const documentationUrl = computed(() => {
   const group = props.agent.group;
@@ -102,6 +125,12 @@ const agentSystems = computed(() => props.agent.systems ?? []);
   &__description {
     color: $unnnic-color-fg-base;
     font: $unnnic-font-body;
+  }
+
+  &__last-updated {
+    color: $unnnic-color-fg-muted;
+    font: $unnnic-font-body;
+    margin-top: $unnnic-space-2;
   }
 
   &__view-documentation {

--- a/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/__tests__/About.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/ModalAssignAgentGroup/Group/StartSetup/__tests__/About.spec.js
@@ -42,6 +42,8 @@ describe('StartSetup About', () => {
     wrapper.find('[data-testid="start-setup-system-badges"]');
   const findBadges = () =>
     wrapper.findAllComponents('[data-testid="start-setup-about-skill"]');
+  const findLastUpdated = () =>
+    wrapper.find('[data-testid="start-setup-about-last-updated"]');
 
   it('renders title and description', () => {
     wrapper = createWrapper();
@@ -66,5 +68,39 @@ describe('StartSetup About', () => {
     });
 
     expect(findSystemBadges().exists()).toBe(false);
+  });
+
+  it('renders the formatted last updated label for a custom agent with last_updated', () => {
+    // Parsed as local time so the formatted output is timezone-independent.
+    wrapper = createWrapper({
+      agent: {
+        ...mockAgent,
+        is_official: false,
+        last_updated: '2026-05-13T15:15:00',
+      },
+    });
+
+    expect(findLastUpdated().exists()).toBe(true);
+    expect(findLastUpdated().text()).toBe(
+      'Updated on May 13, 2026, at 3:15 p.m.',
+    );
+  });
+
+  it('does not render the last updated label when agent has no last_updated', () => {
+    wrapper = createWrapper();
+
+    expect(findLastUpdated().exists()).toBe(false);
+  });
+
+  it('does not render the last updated label for an official agent', () => {
+    wrapper = createWrapper({
+      agent: {
+        ...mockAgent,
+        is_official: true,
+        last_updated: '2026-05-13T15:15:00',
+      },
+    });
+
+    expect(findLastUpdated().exists()).toBe(false);
   });
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -373,6 +373,7 @@
       },
       "setup": {
         "about": "About",
+        "last_updated": "Updated on {date}, at {time}",
         "view_documentation": "View documentation",
         "mcps_available": {
           "title": "MCPs available"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -373,6 +373,7 @@
       },
       "setup": {
         "about": "Sobre",
+        "last_updated": "Actualizado el {date}, a las {time}",
         "view_documentation": "Ver documentación",
         "mcps_available": {
           "title": "MCPs disponibles"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -373,6 +373,7 @@
       },
       "setup": {
         "about": "Sobre",
+        "last_updated": "Atualizado em {date}, às {time}",
         "view_documentation": "Ver documentação",
         "mcps_available": {
           "title": "MCPs disponíveis"

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -372,6 +372,7 @@
       },
       "setup": {
         "about": "Despre",
+        "last_updated": "Actualizat pe {date}, la {time}",
         "view_documentation": "Vizualizează documentația",
         "mcps_available": {
           "title": "MCP-uri disponibile"


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Custom agents can be updated over time, and users need visibility into when an agent was last modified. Official agents are managed externally, so this information is only relevant for custom agents.

### Summary of Changes
- Added a "last updated" label to the `About` section of the agent setup modal, displaying the formatted date and time of the agent's `last_updated` field.
- The label is only shown for non-official agents that have a `last_updated` value.
- Added the `last_updated` translation key in English, Spanish, Portuguese (BR), and Romanian locales with the format `"Updated on {date}, at {time}"`.
- Added test cases covering: rendering the label for a custom agent with `last_updated`, hiding it when `last_updated` is absent, and hiding it for official agents.