### PR TITLE
fix: Await feature flags before rendering RouterView

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -10,7 +10,7 @@
       class="agent-builder__content"
       data-testid="agent-builder-content"
     >
-      <RouterView />
+      <RouterView v-if="featureFlagsLoaded" />
     </main>
 
     <TestAgentsButton v-if="showTestAgentsButton" />
@@ -47,6 +47,7 @@ import { isFederatedModule } from './utils/moduleFederation';
 import initHotjar from '@/utils/plugins/Hotjar.js';
 
 import TestAgentsButton from '@/components/Preview/TestAgentsButton.vue';
+import { storeToRefs } from 'pinia';
 
 const { isAgentsModule, isKnowledgeModule } = useCurrentModule();
 
@@ -55,6 +56,8 @@ const agentsTeamStore = useAgentsTeamStore();
 const alertStore = useAlertStore();
 const userStore = useUserStore();
 const managerSelectorStore = useManagerSelectorStore();
+const featureFlagsStore = useFeatureFlagsStore();
+const { featureFlagsLoaded } = storeToRefs(featureFlagsStore);
 
 async function loadAgentsData() {
   agentsTeamStore.loadMyAgents();
@@ -64,7 +67,9 @@ async function loadAgentsData() {
   agentsTeamStore.loadActiveTeam();
 }
 
-onMounted(() => {
+onMounted(async () => {
+  await featureFlagsStore.getFeatureFlags();
+
   loadAgentsData();
 
   useTuningsStore().fetchCredentials();
@@ -72,7 +77,6 @@ onMounted(() => {
   userStore.getUserDetails();
   managerSelectorStore.loadManagerData();
   useProjectStore().getProject();
-  useFeatureFlagsStore().getFeatureFlags();
 });
 
 const showTestAgentsButton = computed(

--- a/src/store/FeatureFlags.js
+++ b/src/store/FeatureFlags.js
@@ -10,7 +10,7 @@ export const useFeatureFlagsStore = defineStore('FeatureFlags', () => {
   const currentProjectUuid = computed(() => useProjectStore().uuid || '');
 
   const activeFeatures = ref([]);
-  const isLoadingFeatureFlags = ref(false);
+  const featureFlagsLoaded = ref(false);
 
   const getListAtEnv = (key) => {
     return env(key)?.split(',') || [];
@@ -27,8 +27,6 @@ export const useFeatureFlagsStore = defineStore('FeatureFlags', () => {
 
   async function getFeatureFlags() {
     try {
-      isLoadingFeatureFlags.value = true;
-
       const { data } = await nexusaiAPI.feature_flags.read({
         projectUuid: currentProjectUuid.value,
       });
@@ -38,7 +36,7 @@ export const useFeatureFlagsStore = defineStore('FeatureFlags', () => {
       console.error('Error getting feature flags', error);
       activeFeatures.value = [];
     } finally {
-      isLoadingFeatureFlags.value = false;
+      featureFlagsLoaded.value = true;
     }
   }
 
@@ -54,7 +52,7 @@ export const useFeatureFlagsStore = defineStore('FeatureFlags', () => {
   return {
     flags,
     activeFeatures,
-    isLoadingFeatureFlags,
+    featureFlagsLoaded,
     getFeatureFlags,
     isFeatureFlagEnabled,
   };

--- a/src/store/__tests__/FeatureFlags.unit.spec.js
+++ b/src/store/__tests__/FeatureFlags.unit.spec.js
@@ -35,7 +35,7 @@ describe('FeatureFlags store', () => {
 
   it('starts with empty active features and not loading', () => {
     expect(store.activeFeatures).toEqual([]);
-    expect(store.isLoadingFeatureFlags).toBe(false);
+    expect(store.featureFlagsLoaded).toBe(false);
   });
 
   describe('getFeatureFlags', () => {
@@ -59,7 +59,7 @@ describe('FeatureFlags store', () => {
       await store.getFeatureFlags();
 
       expect(store.activeFeatures).toEqual(['categorization_of_instructions']);
-      expect(store.isLoadingFeatureFlags).toBe(false);
+      expect(store.featureFlagsLoaded).toBe(true);
     });
 
     it('defaults to an empty array when active_features is missing', async () => {
@@ -80,7 +80,7 @@ describe('FeatureFlags store', () => {
       await store.getFeatureFlags();
 
       expect(store.activeFeatures).toEqual([]);
-      expect(store.isLoadingFeatureFlags).toBe(false);
+      expect(store.featureFlagsLoaded).toBe(true);
       expect(consoleError).toHaveBeenCalled();
 
       consoleError.mockRestore();


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Feature flags need to be fully resolved before the application renders its routes, ensuring that flag-dependent logic is available on initial load rather than potentially being evaluated before the flags are fetched.

### Summary of Changes
- The `RouterView` component is now conditionally rendered using `v-if="featureFlagsLoaded"`, preventing route components from mounting until feature flags have been fetched.
- `getFeatureFlags` is now awaited in `onMounted` so the rest of the app initialization waits for flags to resolve before proceeding.
- Replaced the `isLoadingFeatureFlags` state with `featureFlagsLoaded`, which is set to `true` in the `finally` block after the feature flags request completes (regardless of success or failure), better reflecting the intent of tracking readiness rather than loading state.