### PR TITLE
feat: Add flat list view for instructions categorization

### DIFF
--- a/src/components/Instructions/InstructionsCategorization/CategoriesView.vue
+++ b/src/components/Instructions/InstructionsCategorization/CategoriesView.vue
@@ -3,28 +3,16 @@
     class="categories-view"
     data-testid="categories-view"
   >
-    <template v-if="isLoading">
-      <UnnnicSkeletonLoading
-        v-for="index in 7"
-        :key="index"
-        width="100%"
-        height="68px"
-        data-testid="categories-view-loading"
-      />
-    </template>
-
-    <template v-else>
-      <CategoryAccordion
-        v-for="(group, index) in groups"
-        :key="group.key"
-        :group="group"
-        :initiallyExpanded="index === 0"
-        :forceExpanded="instructionsStore.isSearching"
-        :data-testid="`categories-view-group-${group.key}`"
-        @delete-category="$emit('delete-category', $event)"
-        @edit="$emit('edit', $event)"
-      />
-    </template>
+    <CategoryAccordion
+      v-for="(group, index) in groups"
+      :key="group.key"
+      :group="group"
+      :initiallyExpanded="index === 0"
+      :forceExpanded="instructionsStore.isSearching"
+      :data-testid="`categories-view-group-${group.key}`"
+      @delete-category="$emit('delete-category', $event)"
+      @edit="$emit('edit', $event)"
+    />
   </section>
 </template>
 
@@ -34,13 +22,6 @@ import { computed } from 'vue';
 import { useInstructionsStore } from '@/store/Instructions';
 
 import CategoryAccordion from './CategoryAccordion.vue';
-
-defineProps({
-  isLoading: {
-    type: Boolean,
-    default: false,
-  },
-});
 
 defineEmits(['delete-category', 'edit']);
 

--- a/src/components/Instructions/InstructionsCategorization/ListInstructionRow.vue
+++ b/src/components/Instructions/InstructionsCategorization/ListInstructionRow.vue
@@ -1,0 +1,134 @@
+<template>
+  <article
+    class="list-instruction-row"
+    data-testid="list-instruction-row"
+  >
+    <p
+      class="list-instruction-row__instruction"
+      data-testid="list-instruction-row-text"
+    >
+      {{ instruction.text }}
+    </p>
+
+    <section class="list-instruction-row__category-area">
+      <UnnnicToolTip
+        v-if="instruction.categoryLocked"
+        side="top"
+        :text="lockedTooltip"
+        enabled
+        data-testid="list-instruction-row-locked-tooltip"
+      >
+        <UnnnicTag
+          scheme="gray"
+          leftIcon="lock"
+          :text="instruction.categoryLabel"
+          data-testid="list-instruction-row-tag"
+        />
+      </UnnnicToolTip>
+
+      <UnnnicTag
+        v-else
+        scheme="gray"
+        :text="instruction.categoryLabel"
+        data-testid="list-instruction-row-tag"
+      />
+
+      <ContentItemActions
+        v-if="!instruction.locked"
+        :actions="actions"
+        data-testid="list-instruction-row-actions"
+      />
+    </section>
+
+    <ModalRemoveInstruction
+      v-model="showRemoveModal"
+      :instruction="removeTarget"
+      data-testid="list-instruction-row-remove-modal"
+    />
+  </article>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { useInstructionsStore } from '@/store/Instructions';
+
+import ContentItemActions from '@/components/ContentItemActions.vue';
+import ModalRemoveInstruction from '@/components/Instructions/ModalRemoveInstruction.vue';
+
+const props = defineProps({
+  instruction: {
+    type: Object,
+    required: true,
+  },
+});
+
+const emit = defineEmits(['edit']);
+
+const { t } = useI18n();
+
+const instructionsStore = useInstructionsStore();
+
+const showRemoveModal = ref(false);
+
+const status = computed(
+  () =>
+    instructionsStore.instructions.data.find(
+      (item) => item.id === props.instruction.id,
+    )?.status,
+);
+
+const removeTarget = computed(() => ({
+  id: props.instruction.id,
+  status: status.value,
+}));
+
+const lockedTooltip = computed(() =>
+  t('agents.instructions.view.locked_tooltip'),
+);
+
+const actions = computed(() => [
+  {
+    text: t('agent_builder.instructions.edit_instruction.title'),
+    icon: 'edit_square',
+    scheme: 'fg-base',
+    onClick: () => emit('edit', props.instruction),
+  },
+  {
+    text: t('agent_builder.instructions.remove_instruction.title'),
+    icon: 'delete',
+    scheme: 'red-10',
+    onClick: () => (showRemoveModal.value = true),
+  },
+]);
+</script>
+
+<style lang="scss" scoped>
+.list-instruction-row {
+  display: grid;
+  grid-template-columns: 1fr minmax(250px, 20%);
+  align-items: center;
+  gap: $unnnic-space-4;
+
+  padding: $unnnic-space-4 $unnnic-space-3;
+
+  border-top: $unnnic-border-width-thinner solid $unnnic-color-border-base;
+
+  &:last-child {
+    border-bottom: $unnnic-border-width-thinner solid $unnnic-color-border-base;
+  }
+
+  &__instruction {
+    color: $unnnic-color-fg-base;
+    font: $unnnic-font-body;
+  }
+
+  &__category-area {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $unnnic-space-4;
+  }
+}
+</style>

--- a/src/components/Instructions/InstructionsCategorization/ListView.vue
+++ b/src/components/Instructions/InstructionsCategorization/ListView.vue
@@ -1,0 +1,72 @@
+<template>
+  <section
+    class="list-view"
+    data-testid="list-view"
+  >
+    <header
+      class="list-view__columns"
+      data-testid="list-view-columns"
+    >
+      <p class="list-view__column">
+        {{ columnsT('instruction') }}
+      </p>
+      <p class="list-view__column">
+        {{ columnsT('category') }}
+      </p>
+    </header>
+
+    <ListInstructionRow
+      v-for="instruction in instructions"
+      :key="instruction.id"
+      :instruction="instruction"
+      :data-testid="`list-view-row-${instruction.id}`"
+      @edit="$emit('edit', $event)"
+    />
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { useInstructionsStore } from '@/store/Instructions';
+
+import ListInstructionRow from './ListInstructionRow.vue';
+
+defineEmits(['edit']);
+
+const { t } = useI18n();
+const columnsT = (key) => t(`agents.instructions.view.list_columns.${key}`);
+
+const instructionsStore = useInstructionsStore();
+
+const instructions = computed(() => instructionsStore.flatInstructions);
+</script>
+
+<style lang="scss" scoped>
+.list-view {
+  display: flex;
+  flex-direction: column;
+
+  &__columns {
+    margin: $unnnic-space-2 0;
+
+    display: grid;
+    grid-template-columns: 1fr minmax(250px, 20%);
+    gap: $unnnic-space-4;
+  }
+
+  &__column {
+    color: $unnnic-color-fg-base;
+    font: $unnnic-font-caption-1;
+
+    &:first-of-type {
+      margin-left: $unnnic-space-3;
+    }
+
+    &:last-of-type {
+      margin-right: $unnnic-space-3;
+    }
+  }
+}
+</style>

--- a/src/components/Instructions/InstructionsCategorization/__tests__/CategoriesView.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/CategoriesView.spec.js
@@ -19,13 +19,7 @@ vi.mock('@/store/FeatureFlags', () => ({
 describe('CategoriesView.vue', () => {
   let wrapper;
 
-  const SELECTORS = {
-    loading: '[data-testid="categories-view-loading"]',
-  };
-
-  const find = (selector) => wrapper.find(SELECTORS[selector]);
-
-  const createWrapper = ({ instructionsState = {}, props = {} } = {}) => {
+  const createWrapper = ({ instructionsState = {} } = {}) => {
     const pinia = createTestingPinia({
       initialState: {
         Instructions: {
@@ -41,7 +35,6 @@ describe('CategoriesView.vue', () => {
     useInstructionsStore();
 
     return shallowMount(CategoriesView, {
-      props,
       global: { plugins: [pinia] },
     });
   };
@@ -49,13 +42,6 @@ describe('CategoriesView.vue', () => {
   afterEach(() => {
     wrapper?.unmount();
     vi.clearAllMocks();
-  });
-
-  it('renders skeleton loaders while loading', () => {
-    wrapper = createWrapper({ props: { isLoading: true } });
-
-    expect(find('loading').exists()).toBe(true);
-    expect(wrapper.findAllComponents(CategoryAccordion)).toHaveLength(0);
   });
 
   it('renders an accordion for each group from the store', () => {

--- a/src/components/Instructions/InstructionsCategorization/__tests__/ListInstructionRow.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/ListInstructionRow.spec.js
@@ -1,0 +1,133 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import ListInstructionRow from '../ListInstructionRow.vue';
+import ModalRemoveInstruction from '@/components/Instructions/ModalRemoveInstruction.vue';
+import { useInstructionsStore } from '@/store/Instructions';
+import i18n from '@/utils/plugins/i18n';
+
+vi.mock('@/store/Project', () => ({
+  useProjectStore: () => ({ uuid: 'test-project-uuid' }),
+}));
+
+vi.mock('@/store/FeatureFlags', () => ({
+  useFeatureFlagsStore: () => ({
+    flags: { categorizationOfInstructions: true },
+  }),
+}));
+
+const customItem = (overrides = {}) => ({
+  id: 1,
+  text: 'Always track orders',
+  categoryLabel: 'Sales',
+  categoryLocked: false,
+  locked: false,
+  ...overrides,
+});
+
+const lockedItem = (overrides = {}) => ({
+  id: 'default-1',
+  text: 'Be concise',
+  categoryLabel: 'Default instruction',
+  categoryLocked: true,
+  locked: true,
+  ...overrides,
+});
+
+describe('ListInstructionRow.vue', () => {
+  let wrapper;
+
+  const SELECTORS = {
+    text: '[data-testid="list-instruction-row-text"]',
+    tag: '[data-testid="list-instruction-row-tag"]',
+    lockedTooltip: '[data-testid="list-instruction-row-locked-tooltip"]',
+    actions: '[data-testid="list-instruction-row-actions"]',
+  };
+
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+
+  const createWrapper = (instruction = customItem(), instructionsData = []) => {
+    const pinia = createTestingPinia({
+      initialState: {
+        Instructions: {
+          instructions: { data: instructionsData, status: 'complete' },
+        },
+      },
+    });
+
+    useInstructionsStore();
+
+    return shallowMount(ListInstructionRow, {
+      props: { instruction },
+      global: { plugins: [pinia], renderStubDefaultSlot: true },
+    });
+  };
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('renders the instruction text and the category tag', () => {
+    wrapper = createWrapper();
+
+    expect(find('text').text()).toBe('Always track orders');
+    expect(find('tag').attributes('text')).toBe('Sales');
+  });
+
+  it('shows the actions menu for editable rows without a locked tag', () => {
+    wrapper = createWrapper();
+
+    expect(find('actions').exists()).toBe(true);
+    expect(find('lockedTooltip').exists()).toBe(false);
+  });
+
+  it('renders a locked tag with tooltip and no menu for locked rows', () => {
+    wrapper = createWrapper(lockedItem());
+
+    expect(find('tag').attributes('lefticon')).toBe('lock');
+    expect(find('lockedTooltip').exists()).toBe(true);
+    expect(find('lockedTooltip').attributes('text')).toBe(
+      i18n.global.t('agents.instructions.view.locked_tooltip'),
+    );
+    expect(find('actions').exists()).toBe(false);
+  });
+
+  it('keeps the actions menu for an uncategorized row with a locked tag', () => {
+    wrapper = createWrapper(
+      customItem({ categoryLabel: 'Uncategorized', categoryLocked: true }),
+    );
+
+    expect(find('tag').attributes('lefticon')).toBe('lock');
+    expect(find('actions').exists()).toBe(true);
+  });
+
+  it('emits edit with the instruction when the edit action is clicked', async () => {
+    const item = customItem();
+    wrapper = createWrapper(item);
+
+    const [editAction] = wrapper
+      .findComponent(SELECTORS.actions)
+      .props('actions');
+    editAction.onClick();
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted('edit')).toEqual([[item]]);
+  });
+
+  it('opens the remove modal from the actions menu', async () => {
+    wrapper = createWrapper();
+
+    const modal = wrapper.findComponent(ModalRemoveInstruction);
+    expect(modal.attributes('modelvalue')).not.toBe('true');
+
+    const [, removeAction] = wrapper
+      .findComponent(SELECTORS.actions)
+      .props('actions');
+    removeAction.onClick();
+    await wrapper.vm.$nextTick();
+
+    expect(modal.attributes('modelvalue')).toBe('true');
+  });
+});

--- a/src/components/Instructions/InstructionsCategorization/__tests__/ListView.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/ListView.spec.js
@@ -1,0 +1,101 @@
+import { shallowMount } from '@vue/test-utils';
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import ListView from '../ListView.vue';
+import ListInstructionRow from '../ListInstructionRow.vue';
+import { useInstructionsStore } from '@/store/Instructions';
+import i18n from '@/utils/plugins/i18n';
+
+vi.mock('@/store/Project', () => ({
+  useProjectStore: () => ({ uuid: 'test-project-uuid' }),
+}));
+
+vi.mock('@/store/FeatureFlags', () => ({
+  useFeatureFlagsStore: () => ({
+    flags: { categorizationOfInstructions: true },
+  }),
+}));
+
+const viewT = (key) => i18n.global.t(`agents.instructions.view.${key}`);
+
+describe('ListView.vue', () => {
+  let wrapper;
+
+  const SELECTORS = {
+    columns: '[data-testid="list-view-columns"]',
+  };
+
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+
+  const createWrapper = ({ instructionsState = {} } = {}) => {
+    const pinia = createTestingPinia({
+      initialState: {
+        Instructions: {
+          instructions: { data: [], status: 'complete' },
+          categories: [],
+          searchTerm: '',
+          ...instructionsState,
+        },
+      },
+    });
+
+    useInstructionsStore();
+
+    return shallowMount(ListView, {
+      global: { plugins: [pinia] },
+    });
+  };
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  it('renders the column headers with localized labels', () => {
+    wrapper = createWrapper();
+
+    expect(find('columns').text()).toContain(viewT('list_columns.instruction'));
+    expect(find('columns').text()).toContain(viewT('list_columns.category'));
+  });
+
+  it('renders a row for every flat instruction', () => {
+    wrapper = createWrapper({
+      instructionsState: {
+        instructions: {
+          data: [
+            { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+            { id: 2, text: 'Loose B', category: null },
+          ],
+          status: 'complete',
+        },
+        categories: [{ id: 10, name: 'Sales' }],
+      },
+    });
+
+    // 2 custom/uncategorized rows + the mocked default instructions
+    expect(
+      wrapper.findAllComponents(ListInstructionRow).length,
+    ).toBeGreaterThanOrEqual(2);
+    expect(wrapper.find('[data-testid="list-view-row-1"]').exists()).toBe(true);
+  });
+
+  it('forwards the edit event from a row', async () => {
+    wrapper = createWrapper({
+      instructionsState: {
+        instructions: {
+          data: [
+            { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+          ],
+          status: 'complete',
+        },
+        categories: [{ id: 10, name: 'Sales' }],
+      },
+    });
+
+    const row = { id: 1 };
+    await wrapper.findComponent(ListInstructionRow).vm.$emit('edit', row);
+
+    expect(wrapper.emitted('edit')).toEqual([[row]]);
+  });
+});

--- a/src/components/Instructions/InstructionsCategorization/__tests__/index.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/index.spec.js
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
 import InstructionsCategorization from '../index.vue';
+import InstructionsResultsCount from '../InstructionsResultsCount.vue';
 import { useInstructionsStore } from '@/store/Instructions';
 import i18n from '@/utils/plugins/i18n';
 
@@ -28,7 +29,8 @@ describe('InstructionsCategorization/index.vue', () => {
     triggerCategories: '[data-testid="instructions-view-trigger-categories"]',
     triggerList: '[data-testid="instructions-view-trigger-list"]',
     categoriesView: '[data-testid="instructions-categories-view"]',
-    baselineList: '[data-testid="instructions-baseline-list"]',
+    listView: '[data-testid="instructions-list-view"]',
+    loading: '[data-testid="instructions-loading"]',
   };
 
   const find = (selector) => wrapper.find(SELECTORS[selector]);
@@ -89,13 +91,19 @@ describe('InstructionsCategorization/index.vue', () => {
 
     it('renders the categories view by default', () => {
       expect(find('categoriesView').exists()).toBe(true);
-      expect(find('baselineList').exists()).toBe(false);
+      expect(find('listView').exists()).toBe(false);
     });
 
-    it('renders the baseline list when the list view is active', () => {
+    it('renders the shared results count above the views', () => {
+      expect(wrapper.findComponent(InstructionsResultsCount).exists()).toBe(
+        true,
+      );
+    });
+
+    it('renders the list view when the list view is active', () => {
       wrapper = createWrapper({}, 'list');
 
-      expect(find('baselineList').exists()).toBe(true);
+      expect(find('listView').exists()).toBe(true);
       expect(find('categoriesView').exists()).toBe(false);
     });
   });
@@ -127,16 +135,12 @@ describe('InstructionsCategorization/index.vue', () => {
       expect(instructionsStore.loadInstructions).not.toHaveBeenCalled();
     });
 
-    it('passes the loading state to the categories view', () => {
+    it('renders the shared loading state and hides the views while loading', () => {
       wrapper = createWrapper({ status: 'loading' });
 
-      expect(findComponent('categoriesView').props('isLoading')).toBe(true);
-    });
-
-    it('passes the loading state to the baseline list in the list view', () => {
-      wrapper = createWrapper({ status: 'loading' }, 'list');
-
-      expect(findComponent('baselineList').props('isLoading')).toBe(true);
+      expect(find('loading').exists()).toBe(true);
+      expect(find('categoriesView').exists()).toBe(false);
+      expect(find('listView').exists()).toBe(false);
     });
   });
 });

--- a/src/components/Instructions/InstructionsCategorization/index.vue
+++ b/src/components/Instructions/InstructionsCategorization/index.vue
@@ -28,21 +28,29 @@
       </UnnnicSegmentedControl>
     </header>
 
-    <InstructionsResultsCount />
+    <template v-if="isLoading">
+      <UnnnicSkeletonLoading
+        v-for="index in 7"
+        :key="index"
+        width="100%"
+        height="69px"
+        data-testid="instructions-loading"
+      />
+    </template>
 
-    <CategoriesView
-      v-if="instructionsStore.activeInstructionsView === 'categories'"
-      :isLoading="isLoading"
-      data-testid="instructions-categories-view"
-    />
+    <template v-else>
+      <InstructionsResultsCount />
 
-    <InstructionsList
-      v-else
-      :instructions="instructionsStore.instructions.data"
-      :isLoading="isLoading"
-      showActions
-      data-testid="instructions-baseline-list"
-    />
+      <CategoriesView
+        v-if="showCategoriesView"
+        data-testid="instructions-categories-view"
+      />
+
+      <ListView
+        v-if="showListView"
+        data-testid="instructions-list-view"
+      />
+    </template>
   </section>
 </template>
 
@@ -51,9 +59,9 @@ import { computed } from 'vue';
 
 import { useInstructionsStore } from '@/store/Instructions';
 
-import InstructionsList from '@/components/Instructions/InstructionsList.vue';
 import InstructionsResultsCount from './InstructionsResultsCount.vue';
 import CategoriesView from './CategoriesView.vue';
+import ListView from './ListView.vue';
 
 const views = ['categories', 'list'];
 
@@ -65,6 +73,20 @@ if (instructionsStore.instructions.status === null) {
 
 const isLoading = computed(
   () => instructionsStore.instructions.status === 'loading',
+);
+
+const showCategoriesView = computed(
+  () =>
+    !isLoading.value &&
+    instructionsStore.flatInstructions.length > 0 &&
+    instructionsStore.activeInstructionsView === 'categories',
+);
+
+const showListView = computed(
+  () =>
+    !isLoading.value &&
+    instructionsStore.flatInstructions.length > 0 &&
+    instructionsStore.activeInstructionsView === 'list',
 );
 </script>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -347,9 +347,14 @@
       "export_instructions": "Export instructions",
       "new_instruction": "New instruction",
       "view": {
+        "default_instruction": "Default instruction",
         "default_instructions": "Default instructions",
         "delete_category": "Delete category",
         "empty_category": "No instructions in this category yet",
+        "list_columns": {
+          "category": "Category",
+          "instruction": "Instruction"
+        },
         "locked_tooltip": "Default instructions can't be edited or removed",
         "results_count": "{count, plural, =0 {No instructions found} one {{count} instruction found} other {{count} instructions found}}",
         "search_placeholder": "Search...",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -347,9 +347,14 @@
       "export_instructions": "Exportar instrucciones",
       "new_instruction": "Nueva instrucción",
       "view": {
+        "default_instruction": "Instrucción predeterminada",
         "default_instructions": "Instrucciones predeterminadas",
         "delete_category": "Eliminar categoría",
         "empty_category": "Aún no hay instrucciones en esta categoría",
+        "list_columns": {
+          "category": "Categoría",
+          "instruction": "Instrucción"
+        },
         "locked_tooltip": "Las instrucciones predeterminadas no se pueden editar ni eliminar",
         "results_count": "{count, plural, =0 {No se encontraron instrucciones} one {{count} instrucción encontrada} other {{count} instrucciones encontradas}}",
         "search_placeholder": "Buscar...",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -347,9 +347,14 @@
       "export_instructions": "Exportar instruções",
       "new_instruction": "Nova instrução",
       "view": {
+        "default_instruction": "Instrução padrão",
         "default_instructions": "Instruções padrão",
         "delete_category": "Excluir categoria",
         "empty_category": "Ainda não há instruções nesta categoria",
+        "list_columns": {
+          "category": "Categoria",
+          "instruction": "Instrução"
+        },
         "locked_tooltip": "As instruções padrão não podem ser editadas nem removidas",
         "results_count": "{count, plural, =0 {Nenhuma instrução encontrada} one {{count} instrução encontrada} other {{count} instruções encontradas}}",
         "search_placeholder": "Buscar...",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -346,9 +346,14 @@
       "export_instructions": "Exportă instrucțiuni",
       "new_instruction": "Instrucțiune nouă",
       "view": {
+        "default_instruction": "Instrucțiune implicită",
         "default_instructions": "Instrucțiuni implicite",
         "delete_category": "Șterge categoria",
         "empty_category": "Încă nu există instrucțiuni în această categorie",
+        "list_columns": {
+          "category": "Categorie",
+          "instruction": "Instrucțiune"
+        },
         "locked_tooltip": "Instrucțiunile implicite nu pot fi editate sau eliminate",
         "results_count": "{count, plural, =0 {Nu s-au găsit instrucțiuni} one {{count} instrucțiune găsită} few {{count} instrucțiuni găsite} other {{count} de instrucțiuni găsite}}",
         "search_placeholder": "Caută...",

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -5,15 +5,19 @@ import type {
   InstructionSuggestedByAI,
   InstructionCategory,
   NewInstruction,
-  GroupedInstructionItem,
+  Instruction,
   InstructionGroup,
+  FlatInstruction,
 } from './types/Instructions.types';
 
 import { useProjectStore } from './Project';
 import { useAlertStore } from './Alert';
 import { useFeatureFlagsStore } from './FeatureFlags';
 
-import { buildInstructionGroups } from './helpers/instructionGroups';
+import {
+  buildInstructionGroups,
+  buildFlatInstructions,
+} from './helpers/instructionViewModels';
 
 import nexusaiAPI from '@/api/nexusaiAPI';
 
@@ -160,7 +164,7 @@ export const useInstructionsStore = defineStore('Instructions', () => {
   const groupT = (key: string) =>
     i18n.global.t(`agents.instructions.view.${key}`);
 
-  const defaultInstructionsMock = computed<GroupedInstructionItem[]>(() => {
+  const defaultInstructionsMock = computed<Instruction[]>(() => {
     const globalI18n = i18n.global as { tm: (_key: string) => string[] };
     const mockedInstructions = globalI18n.tm(
       'agent_builder.instructions.instructions_list.default_instructions',
@@ -182,6 +186,18 @@ export const useInstructionsStore = defineStore('Instructions', () => {
       labels: {
         uncategorized: groupT('uncategorized'),
         default: groupT('default_instructions'),
+      },
+    }),
+  );
+
+  const flatInstructions = computed<FlatInstruction[]>(() =>
+    buildFlatInstructions({
+      instructions: instructions.data,
+      defaultInstructions: defaultInstructionsMock.value,
+      searchTerm: searchTerm.value,
+      labels: {
+        uncategorized: groupT('uncategorized'),
+        defaultInstruction: groupT('default_instruction'),
       },
     }),
   );
@@ -398,6 +414,7 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     searchTerm,
     isSearching,
     groupedInstructions,
+    flatInstructions,
     createCategory,
     addInstruction,
     loadInstructions,

--- a/src/store/helpers/__tests__/instructionViewModels.spec.js
+++ b/src/store/helpers/__tests__/instructionViewModels.spec.js
@@ -2,8 +2,9 @@ import { describe, it, expect } from 'vitest';
 
 import {
   buildInstructionGroups,
+  buildFlatInstructions,
   INSTRUCTION_GROUP_KEYS,
-} from '../instructionGroups';
+} from '../instructionViewModels';
 
 const LABELS = {
   uncategorized: 'Uncategorized',
@@ -143,5 +144,95 @@ describe('buildInstructionGroups', () => {
     });
 
     expect(byKey(groups, 'category-10').instructions).toHaveLength(1);
+  });
+});
+
+describe('buildFlatInstructions', () => {
+  const FLAT_LABELS = {
+    uncategorized: 'Uncategorized',
+    defaultInstruction: 'Default instruction',
+  };
+
+  const buildFlat = (overrides = {}) =>
+    buildFlatInstructions({
+      instructions: [],
+      defaultInstructions: [],
+      searchTerm: '',
+      labels: FLAT_LABELS,
+      ...overrides,
+    });
+
+  it('lists custom instructions newest first, then default instructions', () => {
+    const rows = buildFlat({
+      instructions: [
+        { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+        { id: 3, text: 'Loose B', category: null },
+      ],
+      defaultInstructions: [
+        { id: 'default-1', text: 'Default A', locked: true },
+      ],
+    });
+
+    expect(rows.map((row) => row.text)).toEqual([
+      'Loose B',
+      'Sales A',
+      'Default A',
+    ]);
+  });
+
+  it('maps a custom instruction to an unlocked row with its category name', () => {
+    const [row] = buildFlat({
+      instructions: [
+        { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+      ],
+    });
+
+    expect(row).toEqual({
+      id: 1,
+      text: 'Sales A',
+      categoryLabel: 'Sales',
+      categoryLocked: false,
+      locked: false,
+    });
+  });
+
+  it('marks uncategorized rows with a locked category but keeps them editable', () => {
+    const [row] = buildFlat({
+      instructions: [{ id: 1, text: 'Loose', category: null }],
+    });
+
+    expect(row.categoryLabel).toBe(FLAT_LABELS.uncategorized);
+    expect(row.categoryLocked).toBe(true);
+    expect(row.locked).toBe(false);
+  });
+
+  it('marks default instructions as fully locked', () => {
+    const [row] = buildFlat({
+      defaultInstructions: [
+        { id: 'default-1', text: 'Default A', locked: true },
+      ],
+    });
+
+    expect(row.categoryLabel).toBe(FLAT_LABELS.defaultInstruction);
+    expect(row.categoryLocked).toBe(true);
+    expect(row.locked).toBe(true);
+  });
+
+  it('filters rows by the search term across custom and default instructions', () => {
+    const rows = buildFlat({
+      instructions: [
+        { id: 1, text: 'tracking number', category: { id: 10, name: 'Sales' } },
+        { id: 2, text: 'refund policy', category: { id: 10, name: 'Sales' } },
+      ],
+      defaultInstructions: [
+        { id: 'default-1', text: 'tracking defaults', locked: true },
+      ],
+      searchTerm: 'tracking',
+    });
+
+    expect(rows.map((row) => row.text)).toEqual([
+      'tracking number',
+      'tracking defaults',
+    ]);
   });
 });

--- a/src/store/helpers/instructionViewModels.ts
+++ b/src/store/helpers/instructionViewModels.ts
@@ -1,19 +1,25 @@
 import type {
   InstructionCategory,
-  GroupedInstructionItem,
+  Instruction,
   InstructionGroup,
+  FlatInstruction,
 } from '../types/Instructions.types';
+
+import { includesNormalized } from '@/utils/strings';
 
 export const INSTRUCTION_GROUP_KEYS = {
   uncategorized: 'uncategorized',
   default: 'default',
 } as const;
 
-interface BuildInstructionGroupsParams {
-  instructions: GroupedInstructionItem[];
-  categories: InstructionCategory[];
-  defaultInstructions: GroupedInstructionItem[];
+interface BuildViewParams {
+  instructions: Instruction[];
+  defaultInstructions: Instruction[];
   searchTerm: string;
+}
+
+interface BuildInstructionGroupsParams extends BuildViewParams {
+  categories: InstructionCategory[];
   labels: {
     uncategorized: string;
     default: string;
@@ -23,15 +29,15 @@ interface BuildInstructionGroupsParams {
 interface CategoryWithInstructions {
   id: InstructionCategory['id'];
   name: string;
-  instructions: GroupedInstructionItem[];
+  instructions: Instruction[];
 }
 
-const recencyOf = (item: GroupedInstructionItem) => Number(item.id) || 0;
+const recencyOf = (item: Instruction) => Number(item.id) || 0;
 
-const newestFirst = (items: GroupedInstructionItem[]) =>
+const newestFirst = (items: Instruction[]) =>
   [...items].sort((a, b) => recencyOf(b) - recencyOf(a));
 
-const lastAddedId = (items: GroupedInstructionItem[]) =>
+const lastAddedId = (items: Instruction[]) =>
   items.reduce((newest, item) => Math.max(newest, recencyOf(item)), -Infinity);
 
 const createCategoryGroup = (category: InstructionCategory) => ({
@@ -41,7 +47,7 @@ const createCategoryGroup = (category: InstructionCategory) => ({
 });
 
 function partitionByCategory(
-  instructions: GroupedInstructionItem[],
+  instructions: Instruction[],
   categories: InstructionCategory[],
 ) {
   const byCategory = new Map<
@@ -56,7 +62,7 @@ function partitionByCategory(
     }
   });
 
-  const uncategorized: GroupedInstructionItem[] = [];
+  const uncategorized: Instruction[] = [];
 
   instructions.forEach((instruction) => {
     const { category } = instruction;
@@ -90,8 +96,8 @@ function toCustomGroups(
 
 // System groups are mocked and are always read-only.
 function buildSystemGroups(
-  uncategorized: GroupedInstructionItem[],
-  defaultInstructions: GroupedInstructionItem[],
+  uncategorized: Instruction[],
+  defaultInstructions: Instruction[],
   labels: BuildInstructionGroupsParams['labels'],
 ): InstructionGroup[] {
   return [
@@ -110,13 +116,11 @@ function buildSystemGroups(
   ];
 }
 
-// With an active search: keep only matching instructions and drop empty groups.
-// Without a search: keep every group, except an empty Uncategorized.
 function applySearch(
   groups: InstructionGroup[],
   searchTerm: string,
 ): InstructionGroup[] {
-  const term = searchTerm.trim().toLowerCase();
+  const term = searchTerm.trim();
 
   if (!term) {
     return groups.filter(
@@ -130,7 +134,7 @@ function applySearch(
     .map((group) => ({
       ...group,
       instructions: group.instructions.filter((item) =>
-        item.text.toLowerCase().includes(term),
+        includesNormalized(item.text, term),
       ),
     }))
     .filter((group) => group.instructions.length > 0);
@@ -154,4 +158,47 @@ export function buildInstructionGroups({
   ];
 
   return applySearch(groups, searchTerm);
+}
+
+interface BuildFlatInstructionsParams extends BuildViewParams {
+  labels: {
+    uncategorized: string;
+    defaultInstruction: string;
+  };
+}
+
+export function buildFlatInstructions({
+  instructions,
+  defaultInstructions,
+  searchTerm,
+  labels,
+}: BuildFlatInstructionsParams): FlatInstruction[] {
+  const customRows: FlatInstruction[] = newestFirst(instructions).map(
+    (instruction) => ({
+      id: instruction.id,
+      text: instruction.text,
+      categoryLabel: instruction.category
+        ? instruction.category.name
+        : labels.uncategorized,
+      categoryLocked: !instruction.category,
+      locked: false,
+    }),
+  );
+
+  const defaultRows: FlatInstruction[] = defaultInstructions.map(
+    (instruction) => ({
+      id: instruction.id,
+      text: instruction.text,
+      categoryLabel: labels.defaultInstruction,
+      categoryLocked: true,
+      locked: true,
+    }),
+  );
+
+  const rows = [...customRows, ...defaultRows];
+
+  const term = searchTerm.trim();
+  if (!term) return rows;
+
+  return rows.filter((row) => includesNormalized(row.text, term));
 }

--- a/src/store/types/Instructions.types.ts
+++ b/src/store/types/Instructions.types.ts
@@ -1,3 +1,5 @@
+export type RequestStatus = 'loading' | 'complete' | 'error' | null;
+
 export interface Classification {
   name:
     | 'duplicate'
@@ -15,7 +17,7 @@ export interface InstructionSuggestedByAI {
     suggestion: string;
     suggestedCategory: string;
   };
-  status: 'loading' | 'complete' | 'error' | null;
+  status: RequestStatus;
 }
 
 export interface InstructionCategory {
@@ -23,7 +25,7 @@ export interface InstructionCategory {
   name: string;
 }
 
-export interface GroupedInstructionItem {
+export interface Instruction {
   id: number | string;
   text: string;
   category?: InstructionCategory | null;
@@ -34,11 +36,19 @@ export interface InstructionGroup {
   key: string;
   label: string;
   locked: boolean;
-  instructions: GroupedInstructionItem[];
+  instructions: Instruction[];
+}
+
+export interface FlatInstruction {
+  id: number | string;
+  text: string;
+  categoryLabel: string;
+  categoryLocked: boolean;
+  locked: boolean;
 }
 
 export interface NewInstruction {
   text: string;
   category: InstructionCategory | null;
-  status: 'loading' | 'complete' | 'error' | null;
+  status: RequestStatus;
 }


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other
```

### Motivation and Context

The instructions panel previously only offered a grouped accordion (categories) view. A flat list view was needed so users can see all instructions alongside their category labels in a single scrollable table, making it easier to scan and manage instructions across categories.

### Summary of Changes

- Added a new `ListView` component that renders all instructions in a flat table layout with "Instruction" and "Category" column headers.
- Added a new `ListInstructionRow` component that displays each instruction's text, its category tag (with a lock icon and tooltip for locked categories), and an actions menu for editing or removing editable instructions.
- Replaced `InstructionsList` in `InstructionsCategorization/index.vue` with the new `ListView` for the list view mode.
- Moved the shared skeleton loading state up to `index.vue` so a single loading indicator covers both views, removing the per-view `isLoading` prop from `CategoriesView`.
- Added a `flatInstructions` computed property to the Instructions store, powered by a new `buildFlatInstructions` helper in `instructionViewModels.ts` (renamed from `instructionGroups.ts`), which flattens custom and default instructions into a single sorted, searchable list.
- Renamed `GroupedInstructionItem` to `Instruction` and extracted `RequestStatus` as a shared type in `Instructions.types.ts`. Added the new `FlatInstruction` type.
- Added localization keys for `default_instruction`, `list_columns.instruction`, and `list_columns.category` across all four locale files (en, es, pt_br, ro).
- Added full test coverage for `ListView`, `ListInstructionRow`, and `buildFlatInstructions`, and updated existing tests for `CategoriesView` and `InstructionsCategorization/index.vue` to reflect the loading state consolidation.

### Desmonstration

![image.png](https://app.graphite.com/user-attachments/assets/c7c401b3-0fee-449d-bae5-cdbc88ceafa5.png)

