### PR TITLE
feat: Add instruction edit mode in drawer

### DIFF
--- a/src/components/Instructions/InstructionsCategorization/index.vue
+++ b/src/components/Instructions/InstructionsCategorization/index.vue
@@ -44,11 +44,13 @@
       <CategoriesView
         v-if="showCategoriesView"
         data-testid="instructions-categories-view"
+        @edit="instructionsStore.startEditingInstruction"
       />
 
       <ListView
         v-if="showListView"
         data-testid="instructions-list-view"
+        @edit="instructionsStore.startEditingInstruction"
       />
     </template>
   </section>

--- a/src/components/Instructions/InstructionsHeaderActions.vue
+++ b/src/components/Instructions/InstructionsHeaderActions.vue
@@ -10,27 +10,20 @@
     data-testid="new-instruction-button"
     type="primary"
     :text="$t('agents.instructions.new_instruction')"
-    @click="newInstruction"
+    @click="instructionsStore.openNewInstructionDrawer"
   />
 
-  <NewInstructionDrawer
-    v-model="showNewInstructionDrawer"
-    data-testid="new-instruction-drawer"
-  />
+  <NewInstructionDrawer data-testid="new-instruction-drawer" />
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { useInstructionsStore } from '@/store/Instructions';
 
 import NewInstructionDrawer from '@/components/Instructions/NewInstructionDrawer/index.vue';
 
-const showNewInstructionDrawer = ref(false);
+const instructionsStore = useInstructionsStore();
 
 function exportInstructions() {
   // TODO: Implement export instructions
-}
-
-function newInstruction() {
-  showNewInstructionDrawer.value = true;
 }
 </script>

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/index.spec.js
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/index.spec.js
@@ -3,14 +3,17 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
 import NewInstructionDrawer from '../index.vue';
+import { useInstructionsStore } from '@/store/Instructions';
 import i18n from '@/utils/plugins/i18n';
 
 describe('NewInstructionDrawer/index.vue', () => {
   let wrapper;
+  let store;
 
   const SELECTORS = {
     title: '[data-testid="new-instruction-drawer-title"]',
     form: '[data-testid="new-instruction-drawer-form"]',
+    category: '[data-testid="new-instruction-drawer-category"]',
     cancelButton: '[data-testid="new-instruction-drawer-cancel-button"]',
     saveButton: '[data-testid="new-instruction-drawer-save-button"]',
   };
@@ -22,20 +25,33 @@ describe('NewInstructionDrawer/index.vue', () => {
   const translation = (key) =>
     i18n.global.t(`agents.instructions.new_instruction_drawer.${key}`);
 
-  const createWrapper = (props = {}) =>
-    mount(NewInstructionDrawer, {
-      props: {
-        modelValue: true,
-        ...props,
-      },
-      global: {
-        plugins: [createTestingPinia()],
-        stubs: {
-          UnnnicDrawerNext: false,
-          NewInstructionDrawerForm: true,
+  const createWrapper = (instructionsState = {}) => {
+    const pinia = createTestingPinia({
+      initialState: {
+        Instructions: {
+          isInstructionDrawerOpen: true,
+          instructionDrawerMode: 'create',
+          newInstruction: { text: '', category: null, status: null },
+          instructionSuggestedByAI: { status: null },
+          ...instructionsState,
         },
       },
     });
+
+    store = useInstructionsStore();
+
+    return mount(NewInstructionDrawer, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          UnnnicDrawerNext: false,
+          NewInstructionDrawerForm: true,
+          NewInstructionDrawerAIAnalysis: true,
+          SuggestedCategory: true,
+        },
+      },
+    });
+  };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -46,34 +62,81 @@ describe('NewInstructionDrawer/index.vue', () => {
     wrapper?.unmount();
   });
 
-  describe('Component rendering', () => {
-    it('renders the title with the correct text', () => {
-      expect(find('title').exists()).toBe(true);
+  describe('Create mode', () => {
+    it('renders the create title and the instruction form', () => {
       expect(find('title').text()).toBe(translation('title'));
-    });
-
-    it('renders the instruction form inside the drawer section', () => {
-      expect(wrapper.find('.new-instruction-drawer').exists()).toBe(true);
       expect(find('form').exists()).toBe(true);
     });
 
-    it('renders the cancel and save buttons with the correct text', () => {
-      expect(findComponent('cancelButton').text()).toBe(translation('cancel'));
-      expect(findComponent('saveButton').text()).toBe(translation('save'));
+    it('does not render the standalone category section', () => {
+      expect(find('category').exists()).toBe(false);
+    });
+
+    it('disables save until the AI validation is complete', () => {
+      expect(findComponent('saveButton').props('disabled')).toBe(true);
+    });
+
+    it('adds the instruction when saving a validated instruction', async () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'New rule', category: null, status: null },
+        instructionSuggestedByAI: { status: 'complete' },
+      });
+
+      await findComponent('saveButton').trigger('click');
+
+      expect(store.addInstruction).toHaveBeenCalledTimes(1);
     });
   });
 
-  describe('User interaction', () => {
+  describe('Edit mode', () => {
+    const editState = {
+      instructionDrawerMode: 'edit',
+      editingInstructionId: 1,
+      newInstruction: { text: 'Be concise', category: null, status: null },
+    };
+
+    it('renders the edit title and the standalone category section', () => {
+      wrapper = createWrapper(editState);
+
+      expect(find('title').text()).toBe(translation('edit_title'));
+      expect(find('category').exists()).toBe(true);
+    });
+
+    it('enables save without requiring AI validation', () => {
+      wrapper = createWrapper(editState);
+
+      expect(findComponent('saveButton').props('disabled')).toBe(false);
+    });
+
+    it('updates the instruction when saving', async () => {
+      wrapper = createWrapper(editState);
+
+      await findComponent('saveButton').trigger('click');
+
+      expect(store.updateEditingInstruction).toHaveBeenCalledTimes(1);
+      expect(store.addInstruction).not.toHaveBeenCalled();
+    });
+
+    it('moves the category into the AI analysis once validated', () => {
+      wrapper = createWrapper({
+        ...editState,
+        instructionSuggestedByAI: { status: 'complete' },
+      });
+
+      expect(find('category').exists()).toBe(false);
+      expect(
+        wrapper
+          .find('[data-testid="new-instruction-drawer-ai-analysis"]')
+          .exists(),
+      ).toBe(true);
+    });
+  });
+
+  describe('Closing', () => {
     it('closes the drawer when the cancel button is clicked', async () => {
       await findComponent('cancelButton').trigger('click');
 
-      expect(wrapper.vm.modelValue).toBe(false);
-    });
-
-    it('keeps the drawer open when the save button is clicked', async () => {
-      await findComponent('saveButton').trigger('click');
-
-      expect(wrapper.vm.modelValue).toBe(true);
+      expect(store.closeInstructionDrawer).toHaveBeenCalled();
     });
   });
 });

--- a/src/components/Instructions/NewInstructionDrawer/index.vue
+++ b/src/components/Instructions/NewInstructionDrawer/index.vue
@@ -1,17 +1,32 @@
 <template>
   <UnnnicDrawerNext
-    v-model:open="modelValue"
+    :open="instructionsStore.isInstructionDrawerOpen"
     lazyMount
+    @update:open="onOpenChange"
   >
     <UnnnicDrawerContent size="large">
       <UnnnicDrawerHeader>
         <UnnnicDrawerTitle data-testid="new-instruction-drawer-title">
-          {{ $t('agents.instructions.new_instruction_drawer.title') }}
+          {{ title }}
         </UnnnicDrawerTitle>
       </UnnnicDrawerHeader>
 
       <section class="new-instruction-drawer">
         <NewInstructionDrawerForm data-testid="new-instruction-drawer-form" />
+
+        <section
+          v-if="showStandaloneCategory"
+          class="new-instruction-drawer__category"
+          data-testid="new-instruction-drawer-category"
+        >
+          <p class="new-instruction-drawer__category-label">
+            {{
+              $t('agents.instructions.new_instruction_drawer.category_label')
+            }}
+          </p>
+
+          <SuggestedCategory />
+        </section>
 
         <NewInstructionDrawerAIAnalysis
           v-if="instructionsStore.instructionSuggestedByAI.status"
@@ -43,37 +58,59 @@
 
 <script setup>
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import NewInstructionDrawerForm from './Form.vue';
 import NewInstructionDrawerAIAnalysis from './AIAnalysis.vue';
+import SuggestedCategory from './SuggestedCategory.vue';
 
 import { useInstructionsStore } from '@/store/Instructions';
 
+const { t } = useI18n();
+
 const instructionsStore = useInstructionsStore();
 
-const modelValue = defineModel({
-  type: Boolean,
-  required: true,
-});
-
-const saveDisabled = computed(
-  () =>
-    !instructionsStore.newInstruction.text.trim() ||
-    instructionsStore.instructionSuggestedByAI.status !== 'complete',
+const isEditing = computed(
+  () => instructionsStore.instructionDrawerMode === 'edit',
 );
 
+const showStandaloneCategory = computed(
+  () => isEditing.value && !instructionsStore.instructionSuggestedByAI.status,
+);
+
+const title = computed(() =>
+  t(
+    `agents.instructions.new_instruction_drawer.${
+      isEditing.value ? 'edit_title' : 'title'
+    }`,
+  ),
+);
+
+const saveDisabled = computed(() => {
+  if (!instructionsStore.newInstruction.text.trim()) return true;
+  if (isEditing.value) return false;
+  return instructionsStore.instructionSuggestedByAI.status !== 'complete';
+});
+
 function close() {
-  modelValue.value = false;
+  instructionsStore.closeInstructionDrawer();
+}
+
+function onOpenChange(open) {
+  if (!open) close();
 }
 
 async function save() {
   if (saveDisabled.value) return;
 
-  await instructionsStore.addInstruction();
+  if (isEditing.value) {
+    await instructionsStore.updateEditingInstruction();
+  } else {
+    await instructionsStore.addInstruction();
+  }
 
   if (instructionsStore.newInstruction.status === 'error') return;
 
-  instructionsStore.resetInstructionSuggestedByAI();
   close();
 }
 </script>
@@ -87,5 +124,16 @@ async function save() {
   display: flex;
   flex-direction: column;
   gap: $unnnic-space-6;
+
+  &__category {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-1;
+  }
+
+  &__category-label {
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
 }
 </style>

--- a/src/components/Instructions/__tests__/InstructionsHeaderActions.spec.js
+++ b/src/components/Instructions/__tests__/InstructionsHeaderActions.spec.js
@@ -1,11 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { shallowMount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
 
 import InstructionsHeaderActions from '../InstructionsHeaderActions.vue';
+import { useInstructionsStore } from '@/store/Instructions';
 import i18n from '@/utils/plugins/i18n';
 
 describe('InstructionsHeaderActions.vue', () => {
   let wrapper;
+  let store;
 
   const findExportButton = () =>
     wrapper.findComponent('[data-testid="export-instructions-button"]');
@@ -15,7 +18,11 @@ describe('InstructionsHeaderActions.vue', () => {
     wrapper.findComponent('[data-testid="new-instruction-drawer"]');
 
   const createWrapper = () => {
-    wrapper = shallowMount(InstructionsHeaderActions);
+    const pinia = createTestingPinia();
+    store = useInstructionsStore();
+    wrapper = shallowMount(InstructionsHeaderActions, {
+      global: { plugins: [pinia] },
+    });
   };
 
   afterEach(() => {
@@ -69,18 +76,12 @@ describe('InstructionsHeaderActions.vue', () => {
       expect(findDrawer().exists()).toBe(true);
     });
 
-    it('is closed by default', () => {
-      createWrapper();
-
-      expect(findDrawer().props('modelValue')).toBe(false);
-    });
-
-    it('opens when the new instruction button is clicked', async () => {
+    it('opens the new instruction drawer through the store when clicked', async () => {
       createWrapper();
 
       await findNewInstructionButton().trigger('click');
 
-      expect(findDrawer().props('modelValue')).toBe(true);
+      expect(store.openNewInstructionDrawer).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -366,6 +366,8 @@
       },
       "new_instruction_drawer": {
         "title": "New instruction",
+        "edit_title": "Edit instruction",
+        "category_label": "Category",
         "validate": "Validate",
         "save": "Save",
         "cancel": "Cancel",
@@ -394,6 +396,7 @@
             "create_title": "Create category",
             "name_label": "Category name",
             "name_placeholder": "Name",
+            "placeholder": "Select...",
             "cancel": "Cancel",
             "create": "Create",
             "validation": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -366,6 +366,8 @@
       },
       "new_instruction_drawer": {
         "title": "Nueva instrucción",
+        "edit_title": "Editar instrucción",
+        "category_label": "Categoría",
         "validate": "Validar",
         "save": "Guardar",
         "cancel": "Cancelar",
@@ -394,6 +396,7 @@
             "create_title": "Crear categoría",
             "name_label": "Nombre de la categoría",
             "name_placeholder": "Nombre",
+            "placeholder": "Seleccionar...",
             "cancel": "Cancelar",
             "create": "Crear",
             "validation": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -366,6 +366,8 @@
       },
       "new_instruction_drawer": {
         "title": "Nova instrução",
+        "edit_title": "Editar instrução",
+        "category_label": "Categoria",
         "validate": "Validar",
         "save": "Salvar",
         "cancel": "Cancelar",
@@ -394,6 +396,7 @@
             "create_title": "Criar categoria",
             "name_label": "Nome da categoria",
             "name_placeholder": "Nome",
+            "placeholder": "Selecionar...",
             "cancel": "Cancelar",
             "create": "Criar",
             "validation": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -365,6 +365,8 @@
       },
       "new_instruction_drawer": {
         "title": "Instrucțiune nouă",
+        "edit_title": "Editare instrucțiune",
+        "category_label": "Categorie",
         "validate": "Validează",
         "save": "Salvează",
         "cancel": "Anulează",
@@ -393,6 +395,7 @@
             "create_title": "Creează categorie",
             "name_label": "Numele categoriei",
             "name_placeholder": "Nume",
+            "placeholder": "Selectează...",
             "cancel": "Anulează",
             "create": "Creează",
             "validation": {

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -159,6 +159,10 @@ export const useInstructionsStore = defineStore('Instructions', () => {
   const activeInstructionsView = ref<'categories' | 'list'>('categories');
   const searchTerm = ref('');
 
+  const isInstructionDrawerOpen = ref(false);
+  const instructionDrawerMode = ref<'create' | 'edit'>('create');
+  const editingInstructionId = ref<number | string | null>(null);
+
   const isSearching = computed(() => searchTerm.value.trim().length > 0);
 
   const groupT = (key: string) =>
@@ -238,6 +242,74 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     } catch (error) {
       newInstruction.status = 'error';
       callAlert('error', 'new_instruction.error_alert');
+    }
+  }
+
+  function resetNewInstruction() {
+    newInstruction.text = '';
+    newInstruction.category = null;
+    newInstruction.status = null;
+  }
+
+  function openNewInstructionDrawer() {
+    resetNewInstruction();
+    resetInstructionSuggestedByAI();
+    instructionDrawerMode.value = 'create';
+    editingInstructionId.value = null;
+    isInstructionDrawerOpen.value = true;
+  }
+
+  function startEditingInstruction(instruction: { id: number | string }) {
+    const target = instructions.data.find((item) => item.id === instruction.id);
+    if (!target) return;
+
+    resetInstructionSuggestedByAI();
+    newInstruction.text = target.text;
+    newInstruction.category = target.category ?? null;
+    newInstruction.status = null;
+    instructionDrawerMode.value = 'edit';
+    editingInstructionId.value = target.id;
+    isInstructionDrawerOpen.value = true;
+  }
+
+  function closeInstructionDrawer() {
+    isInstructionDrawerOpen.value = false;
+    instructionDrawerMode.value = 'create';
+    editingInstructionId.value = null;
+    resetNewInstruction();
+    resetInstructionSuggestedByAI();
+  }
+
+  async function updateEditingInstruction() {
+    const target = instructions.data.find(
+      (item) => item.id === editingInstructionId.value,
+    );
+    if (!target) return;
+
+    newInstruction.status = 'loading';
+
+    const previousText = target.text;
+    const previousCategory = target.category;
+
+    try {
+      target.text = newInstruction.text;
+      target.category = newInstruction.category;
+
+      const response = await nexusaiAPI.agent_builder.instructions.update({
+        projectUuid: projectUuid.value,
+        ...toGroupedPayload(),
+      });
+
+      instructions.data = response.instructions;
+      categories.value = response.categories;
+
+      newInstruction.status = null;
+      callAlert('success', 'edit_instruction.success_alert');
+    } catch {
+      target.text = previousText;
+      target.category = previousCategory;
+      newInstruction.status = 'error';
+      callAlert('error', 'edit_instruction.error_alert');
     }
   }
 
@@ -413,10 +485,17 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     activeInstructionsView,
     searchTerm,
     isSearching,
+    isInstructionDrawerOpen,
+    instructionDrawerMode,
+    editingInstructionId,
     groupedInstructions,
     flatInstructions,
     createCategory,
     addInstruction,
+    openNewInstructionDrawer,
+    startEditingInstruction,
+    closeInstructionDrawer,
+    updateEditingInstruction,
     loadInstructions,
     editInstruction,
     removeInstruction,

--- a/src/store/__tests__/Instructions.unit.spec.js
+++ b/src/store/__tests__/Instructions.unit.spec.js
@@ -665,6 +665,105 @@ describe('Instructions Store', () => {
     });
   });
 
+  describe('Instruction drawer (create/edit)', () => {
+    it('opens the drawer in create mode and resets the new instruction', () => {
+      store.newInstruction.text = 'leftover';
+      store.newInstruction.category = { id: 1, name: 'X' };
+
+      store.openNewInstructionDrawer();
+
+      expect(store.isInstructionDrawerOpen).toBe(true);
+      expect(store.instructionDrawerMode).toBe('create');
+      expect(store.editingInstructionId).toBeNull();
+      expect(store.newInstruction.text).toBe('');
+      expect(store.newInstruction.category).toBeNull();
+    });
+
+    it('opens the drawer in edit mode prefilled from the instruction', () => {
+      store.instructions.data = [
+        { id: 7, text: 'Be concise', category: { id: 3, name: 'Tone' } },
+      ];
+
+      store.startEditingInstruction({ id: 7 });
+
+      expect(store.isInstructionDrawerOpen).toBe(true);
+      expect(store.instructionDrawerMode).toBe('edit');
+      expect(store.editingInstructionId).toBe(7);
+      expect(store.newInstruction.text).toBe('Be concise');
+      expect(store.newInstruction.category).toEqual({ id: 3, name: 'Tone' });
+    });
+
+    it('does not open the drawer for an unknown instruction', () => {
+      store.instructions.data = [];
+
+      store.startEditingInstruction({ id: 999 });
+
+      expect(store.isInstructionDrawerOpen).toBe(false);
+    });
+
+    it('closes the drawer and resets state', () => {
+      store.instructions.data = [{ id: 7, text: 'x', category: null }];
+      store.startEditingInstruction({ id: 7 });
+
+      store.closeInstructionDrawer();
+
+      expect(store.isInstructionDrawerOpen).toBe(false);
+      expect(store.instructionDrawerMode).toBe('create');
+      expect(store.editingInstructionId).toBeNull();
+      expect(store.newInstruction.text).toBe('');
+    });
+
+    it('updates the edited instruction (text + category) via the grouped update', async () => {
+      store.instructions.data = [
+        { id: 7, text: 'Old', category: { id: 3, name: 'Tone' } },
+        { id: 8, text: 'Other', category: null },
+      ];
+      const updated = {
+        instructions: [
+          { id: 7, text: 'New', category: { id: 5, name: 'Personality' } },
+          { id: 8, text: 'Other', category: null },
+        ],
+        categories: [{ id: 5, name: 'Personality' }],
+      };
+      nexusaiAPI.agent_builder.instructions.update.mockResolvedValue(updated);
+
+      store.startEditingInstruction({ id: 7 });
+      store.newInstruction.text = 'New';
+      store.newInstruction.category = { id: 5, name: 'Personality' };
+
+      await store.updateEditingInstruction();
+
+      expect(nexusaiAPI.agent_builder.instructions.update).toHaveBeenCalledWith(
+        expect.objectContaining({ projectUuid: 'test-project-uuid' }),
+      );
+      expect(store.instructions.data).toEqual(updated.instructions);
+      expect(store.categories).toEqual(updated.categories);
+      expect(store.newInstruction.status).toBeNull();
+    });
+
+    it('rolls back text and category when the grouped update fails', async () => {
+      const originalCategory = { id: 3, name: 'Tone' };
+      store.instructions.data = [
+        { id: 7, text: 'Old', category: originalCategory },
+        { id: 8, text: 'Other', category: null },
+      ];
+      nexusaiAPI.agent_builder.instructions.update.mockRejectedValue(
+        new Error('network'),
+      );
+
+      store.startEditingInstruction({ id: 7 });
+      store.newInstruction.text = 'New';
+      store.newInstruction.category = { id: 5, name: 'Personality' };
+
+      await store.updateEditingInstruction();
+
+      const target = store.instructions.data.find((item) => item.id === 7);
+      expect(target.text).toBe('Old');
+      expect(target.category).toEqual(originalCategory);
+      expect(store.newInstruction.status).toBe('error');
+    });
+  });
+
   describe('groupedInstructions getter', () => {
     const viewT = (key) => i18n.global.t(`agents.instructions.view.${key}`);
 


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The instruction drawer previously only supported creating new instructions. Users had no way to edit an existing instruction through the drawer UI, requiring a full create flow for any modification.

### Summary of Changes

- Added edit mode to the `NewInstructionDrawer`, which displays an "Edit instruction" title and a standalone category selector when no AI analysis is active.
- Introduced `openNewInstructionDrawer`, `startEditingInstruction`, `closeInstructionDrawer`, and `updateEditingInstruction` actions to the Instructions store, centralizing all drawer open/close and mode management.
- Drawer open state is now fully controlled by the store (`isInstructionDrawerOpen`, `instructionDrawerMode`, `editingInstructionId`) instead of local component state.
- `CategoriesView` and `ListView` now emit an `edit` event that triggers `startEditingInstruction`, pre-filling the drawer with the selected instruction's text and category.
- The "New Instruction" button in `InstructionsHeaderActions` now calls `instructionsStore.openNewInstructionDrawer` directly instead of managing a local `ref`.
- Save behavior is mode-aware: edit mode calls `updateEditingInstruction` (no AI validation required), while create mode still requires AI validation to be complete before saving.
- Added localization keys for `edit_title`, `category_label`, and category `placeholder` across all supported locales (en, es, pt_br, ro).
- Updated and expanded tests for the drawer (create vs. edit mode scenarios) and the Instructions store (drawer lifecycle, `updateEditingInstruction` flow).

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/46c3c14b-e9d9-4301-b76b-696e443babff.png)

