### PR TITLE
feat: Redesign remove instruction modal with new dialog components, instruction snippet preview, and updated copy

### DIFF
--- a/src/components/Instructions/InstructionsCategorization/ListInstructionRow.vue
+++ b/src/components/Instructions/InstructionsCategorization/ListInstructionRow.vue
@@ -81,6 +81,7 @@ const status = computed(
 
 const removeTarget = computed(() => ({
   id: props.instruction.id,
+  text: props.instruction.text,
   status: status.value,
 }));
 

--- a/src/components/Instructions/ModalRemoveInstruction.vue
+++ b/src/components/Instructions/ModalRemoveInstruction.vue
@@ -1,43 +1,62 @@
 <template>
-  <UnnnicModalDialog
-    :modelValue="modelValue"
+  <UnnnicDialog
     data-testid="modal"
-    class="modal-remove-instruction"
-    showCloseIcon
-    icon="warning"
-    iconScheme="red-10"
-    :title="$t('agent_builder.instructions.remove_instruction.title')"
-    size="sm"
-    :secondaryButtonProps="{
-      text: $t('agent_builder.instructions.remove_instruction.cancel'),
-    }"
-    :primaryButtonProps="{
-      text: $t('agent_builder.instructions.remove_instruction.remove'),
-      loading: instruction.status === 'loading',
-      type: 'warning',
-    }"
-    @secondary-button-click="close"
-    @primary-button-click="removeInstruction"
-    @update:model-value="close"
+    :open="modelValue"
+    lazyMount
+    @update:open="onUpdateOpen"
   >
-    <p
-      class="modal-remove-instruction__description"
-      data-testid="description"
-    >
-      {{
-        $t('agent_builder.instructions.remove_instruction.modal_description')
-      }}
-    </p>
-  </UnnnicModalDialog>
+    <UnnnicDialogContent>
+      <UnnnicDialogHeader type="warning">
+        <UnnnicDialogTitle>
+          {{ $t('agent_builder.instructions.remove_instruction.title') }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+
+      <section class="modal-remove-instruction">
+        <p
+          class="modal-remove-instruction__description"
+          data-testid="description"
+        >
+          {{
+            $t(
+              'agent_builder.instructions.remove_instruction.modal_description',
+            )
+          }}
+        </p>
+
+        <p
+          class="modal-remove-instruction__snippet"
+          data-testid="instruction-snippet"
+        >
+          {{ instruction.text }}
+        </p>
+      </section>
+
+      <UnnnicDialogFooter>
+        <UnnnicDialogClose>
+          <UnnnicButton
+            data-testid="cancel-button"
+            :text="$t('agent_builder.instructions.remove_instruction.cancel')"
+            type="tertiary"
+            @click="close"
+          />
+        </UnnnicDialogClose>
+        <UnnnicButton
+          data-testid="remove-button"
+          :text="$t('agent_builder.instructions.remove_instruction.remove')"
+          :loading="instruction.status === 'loading'"
+          type="warning"
+          @click="removeInstruction"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
 </template>
 
 <script setup>
 import { useInstructionsStore } from '@/store/Instructions';
-import { ref } from 'vue';
 
 const instructionsStore = useInstructionsStore();
-
-const emit = defineEmits(['update:modelValue']);
 
 const props = defineProps({
   instruction: {
@@ -46,10 +65,17 @@ const props = defineProps({
   },
 });
 
-const modelValue = ref(false);
+const modelValue = defineModel('modelValue', {
+  type: Boolean,
+  required: true,
+});
 
 function close() {
-  emit('update:modelValue', false);
+  modelValue.value = false;
+}
+
+function onUpdateOpen(open) {
+  if (!open) close();
 }
 
 async function removeInstruction() {
@@ -57,23 +83,34 @@ async function removeInstruction() {
     props.instruction.id,
   );
 
-  if (status === 'complete') close();
+  if (status !== 'error') close();
 }
 </script>
 
 <style lang="scss" scoped>
 .modal-remove-instruction {
-  :deep(.unnnic-modal-dialog__container__content) {
-    padding-bottom: $unnnic-spacing-xs;
-  }
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-2;
+
+  padding: $unnnic-space-6;
 
   &__description {
-    color: $unnnic-color-neutral-cloudy;
+    margin: 0;
 
-    font-family: $unnnic-font-family-secondary;
-    font-size: $unnnic-font-size-body-gt;
-    font-weight: $unnnic-font-weight-regular;
-    line-height: $unnnic-font-size-body-gt + $unnnic-line-height-md;
+    color: $unnnic-color-fg-base;
+    font: $unnnic-font-body;
+  }
+
+  &__snippet {
+    margin: 0;
+    padding: $unnnic-space-3;
+
+    border-radius: $unnnic-radius-2;
+    background-color: $unnnic-color-bg-base-soft;
+
+    color: $unnnic-color-fg-base;
+    font: $unnnic-font-caption-2;
   }
 }
 </style>

--- a/src/components/Instructions/__tests__/ModalRemoveInstruction.spec.js
+++ b/src/components/Instructions/__tests__/ModalRemoveInstruction.spec.js
@@ -1,5 +1,6 @@
-import { mount } from '@vue/test-utils';
+import { shallowMount, flushPromises } from '@vue/test-utils';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { nextTick } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 
 import ModalRemoveInstruction from '../ModalRemoveInstruction.vue';
@@ -10,45 +11,47 @@ describe('ModalRemoveInstruction.vue', () => {
   let wrapper;
   let instructionsStore;
 
-  const pinia = createTestingPinia({
-    initialState: {
-      Instructions: {
-        instructions: {
-          data: [],
-        },
-      },
-    },
-  });
-
   const mockInstruction = {
     id: 'test-instruction-id',
     text: 'Test instruction text',
     status: null,
   };
 
+  const removeT = (key) =>
+    i18n.global.t(`agent_builder.instructions.remove_instruction.${key}`);
+
   const SELECTORS = {
     modal: '[data-testid="modal"]',
     description: '[data-testid="description"]',
+    snippet: '[data-testid="instruction-snippet"]',
+    cancel: '[data-testid="cancel-button"]',
+    remove: '[data-testid="remove-button"]',
   };
   const find = (selector) => wrapper.find(SELECTORS[selector]);
-  const findComponent = (component) =>
-    wrapper.findComponent(SELECTORS[component]);
+  const findComponent = (selector) =>
+    wrapper.findComponent(SELECTORS[selector]);
 
-  beforeEach(() => {
-    instructionsStore = useInstructionsStore(pinia);
-    instructionsStore.removeInstruction = vi.fn().mockResolvedValue({
-      status: 'complete',
+  const createWrapper = (instruction = mockInstruction) => {
+    const pinia = createTestingPinia({
+      initialState: { Instructions: { instructions: { data: [] } } },
     });
 
-    wrapper = mount(ModalRemoveInstruction, {
-      props: {
-        modelValue: true,
-        instruction: mockInstruction,
-      },
+    instructionsStore = useInstructionsStore(pinia);
+    instructionsStore.removeInstruction = vi
+      .fn()
+      .mockResolvedValue({ status: null });
+
+    return shallowMount(ModalRemoveInstruction, {
+      props: { modelValue: true, instruction },
       global: {
         plugins: [pinia],
+        stubs: { UnnnicDialogClose: { template: '<div><slot /></div>' } },
       },
     });
+  };
+
+  beforeEach(() => {
+    wrapper = createWrapper();
   });
 
   afterEach(() => {
@@ -57,110 +60,81 @@ describe('ModalRemoveInstruction.vue', () => {
   });
 
   describe('Component rendering', () => {
-    it('should match snapshot', () => {
-      expect(wrapper.html()).toMatchSnapshot();
+    it('renders the dialog open with the title', () => {
+      expect(findComponent('modal').exists()).toBe(true);
+      expect(findComponent('modal').props('open')).toBe(true);
+      expect(wrapper.text()).toContain(removeT('title'));
     });
 
-    it('renders the modal with correct props', () => {
-      const modal = findComponent('modal');
-      expect(modal.exists()).toBe(true);
-      expect(modal.props('modelValue')).toBe(true);
-      expect(modal.props('title')).toBe(
-        i18n.global.t('agent_builder.instructions.remove_instruction.title'),
-      );
-      expect(modal.props('showCloseIcon')).toBe(true);
-      expect(modal.props('icon')).toBe('warning');
-      expect(modal.props('iconScheme')).toBe('red-10');
-      expect(modal.props('size')).toBe('sm');
+    it('renders the description', () => {
+      expect(find('description').text()).toBe(removeT('modal_description'));
     });
 
-    it('renders the correct description', () => {
-      expect(find('description').exists()).toBe(true);
-      expect(find('description').text()).toBe(
-        i18n.global.t(
-          'agent_builder.instructions.remove_instruction.modal_description',
-        ),
-      );
+    it('renders the instruction text snippet', () => {
+      expect(find('snippet').text()).toBe(mockInstruction.text);
     });
 
-    it('renders the correct button props', () => {
-      const modal = findComponent('modal');
-      expect(modal.props('secondaryButtonProps')).toEqual({
-        text: i18n.global.t(
-          'agent_builder.instructions.remove_instruction.cancel',
-        ),
-      });
-
-      expect(modal.props('primaryButtonProps')).toEqual({
-        text: i18n.global.t(
-          'agent_builder.instructions.remove_instruction.remove',
-        ),
-        loading: false,
-        type: 'warning',
-      });
+    it('renders cancel and remove buttons with the correct labels', () => {
+      expect(findComponent('cancel').props('text')).toBe(removeT('cancel'));
+      expect(findComponent('remove').props('text')).toBe(removeT('remove'));
+      expect(findComponent('remove').props('type')).toBe('warning');
     });
   });
 
   describe('Modal interactions', () => {
-    it('emits update:modelValue when modal is closed via close icon', async () => {
-      await findComponent('modal').vm.$emit('update:model-value', false);
+    it('emits update:modelValue false when the dialog requests to close', async () => {
+      await findComponent('modal').vm.$emit('update:open', false);
 
-      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
-      expect(wrapper.emitted('update:modelValue')[0]).toEqual([false]);
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
     });
 
-    it('emits update:modelValue when secondary button is clicked', async () => {
-      await findComponent('modal').vm.$emit('secondary-button-click');
+    it('emits update:modelValue false when cancel is clicked', async () => {
+      await findComponent('cancel').vm.$emit('click');
 
-      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
-      expect(wrapper.emitted('update:modelValue')[0]).toEqual([false]);
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
     });
   });
 
   describe('Remove instruction functionality', () => {
-    it('calls removeInstruction with correct instruction id', async () => {
-      await findComponent('modal').vm.$emit('primary-button-click');
+    it('calls removeInstruction with the instruction id', async () => {
+      await findComponent('remove').vm.$emit('click');
 
       expect(instructionsStore.removeInstruction).toHaveBeenCalledWith(
         mockInstruction.id,
       );
     });
 
-    it('closes modal when removal is successful', async () => {
-      await findComponent('modal').vm.$emit('primary-button-click');
-      await wrapper.vm.$nextTick();
+    it('closes the modal on success', async () => {
+      await findComponent('remove').vm.$emit('click');
+      await flushPromises();
 
-      expect(wrapper.emitted('update:modelValue')).toBeTruthy();
-      expect(wrapper.emitted('update:modelValue')[0]).toEqual([false]);
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
     });
 
-    it('does not close modal when removal fails', async () => {
+    it('keeps the modal open on error', async () => {
       instructionsStore.removeInstruction.mockResolvedValue({
         status: 'error',
       });
 
-      await findComponent('modal').vm.$emit('primary-button-click');
-      await wrapper.vm.$nextTick();
+      await findComponent('remove').vm.$emit('click');
+      await flushPromises();
 
       expect(wrapper.emitted('update:modelValue')).toBeFalsy();
     });
   });
 
-  describe('Loading states', () => {
-    it('shows loading state on primary button when instruction status is loading', async () => {
+  describe('Loading state', () => {
+    it('shows loading on the remove button when status is loading', async () => {
       await wrapper.setProps({
         instruction: { ...mockInstruction, status: 'loading' },
       });
+      await nextTick();
 
-      expect(findComponent('modal').props('primaryButtonProps').loading).toBe(
-        true,
-      );
+      expect(findComponent('remove').props('loading')).toBe(true);
     });
 
-    it('does not show loading state when instruction status is not loading', () => {
-      expect(findComponent('modal').props('primaryButtonProps').loading).toBe(
-        false,
-      );
+    it('does not show loading when status is not loading', () => {
+      expect(findComponent('remove').props('loading')).toBe(false);
     });
   });
 });

--- a/src/components/Instructions/__tests__/__snapshots__/ModalRemoveInstruction.spec.js.snap
+++ b/src/components/Instructions/__tests__/__snapshots__/ModalRemoveInstruction.spec.js.snap
@@ -1,7 +1,0 @@
-// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
-
-exports[`ModalRemoveInstruction.vue > Component rendering > should match snapshot 1`] = `
-"<div data-v-25f17094="" data-testid="modal" class="modal-remove-instruction">
-  <p data-v-25f17094="" class="modal-remove-instruction__description" data-testid="description">Are you sure you want to delete this instruction?</p>
-</div>"
-`;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -107,11 +107,12 @@
       },
       "remove_instruction": {
         "title": "Delete instruction",
-        "modal_description": "Are you sure you want to delete this instruction?",
-        "remove": "Delete",
+        "modal_description": "This instruction will be permanently removed and the Manager agent will stop following it. This can't be undone.",
+        "remove": "Delete instruction",
         "cancel": "Cancel",
-        "success_alert": "Custom instruction deleted",
-        "error_alert": "Error deleting custom instruction"
+        "success_alert": "Instruction deleted",
+        "error_alert": "Couldn't delete instruction",
+        "error_alert_description": "Something went wrong and nothing was changed. Try again."
       }
     },
     "traces": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -107,11 +107,12 @@
       },
       "remove_instruction": {
         "title": "Eliminar instrucción",
-        "modal_description": "¿Realmente deseas eliminar esta instrucción?",
-        "remove": "Eliminar",
+        "modal_description": "Esta instrucción se eliminará de forma permanente y el agente Manager dejará de seguirla. Esta acción no se puede deshacer.",
+        "remove": "Eliminar instrucción",
         "cancel": "Cancelar",
-        "success_alert": "Instrucción personalizada eliminada",
-        "error_alert": "Error al eliminar la instrucción personalizada"
+        "success_alert": "Instrucción eliminada",
+        "error_alert": "No se pudo eliminar la instrucción",
+        "error_alert_description": "Algo salió mal y no se cambió nada. Inténtalo de nuevo."
       }
     },
     "traces": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -107,11 +107,12 @@
       },
       "remove_instruction": {
         "title": "Excluir instrução",
-        "modal_description": "Tem certeza de que deseja excluir a instrução?",
-        "remove": "Excluir",
+        "modal_description": "Esta instrução será removida permanentemente e o agente Manager deixará de segui-la. Essa ação não pode ser desfeita.",
+        "remove": "Excluir instrução",
         "cancel": "Cancelar",
-        "success_alert": "Instrução personalizada excluída",
-        "error_alert": "Erro ao excluir instrução personalizada"
+        "success_alert": "Instrução excluída",
+        "error_alert": "Não foi possível excluir a instrução",
+        "error_alert_description": "Algo deu errado e nada foi alterado. Tente novamente."
       }
     },
     "traces": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -107,11 +107,12 @@
       },
       "remove_instruction": {
         "title": "Șterge instrucțiunea",
-        "modal_description": "Ești sigur că vrei să ștergi această instrucțiune?",
-        "remove": "Ștergere",
+        "modal_description": "Această instrucțiune va fi eliminată definitiv, iar agentul Manager nu o va mai urma. Această acțiune nu poate fi anulată.",
+        "remove": "Șterge instrucțiunea",
         "cancel": "Anulează",
-        "success_alert": "Instrucțiune personalizată ștearsă",
-        "error_alert": "Eroare la ștergerea instrucțiunii personalizate"
+        "success_alert": "Instrucțiune ștearsă",
+        "error_alert": "Instrucțiunea nu a putut fi ștearsă",
+        "error_alert_description": "Ceva nu a funcționat și nimic nu a fost modificat. Încearcă din nou."
       }
     },
     "traces": {

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -24,10 +24,13 @@ import nexusaiAPI from '@/api/nexusaiAPI';
 import i18n from '@/utils/plugins/i18n';
 import { moduleStorage } from '@/utils/storage';
 
-function callAlert(type, alertText) {
+function callAlert(type, alertText, descriptionKey?: string) {
   const alertStore = useAlertStore();
   alertStore.add({
     text: i18n.global.t(`agent_builder.instructions.${alertText}`),
+    description: descriptionKey
+      ? i18n.global.t(`agent_builder.instructions.${descriptionKey}`)
+      : '',
     type,
   });
 }
@@ -401,11 +404,15 @@ export const useInstructionsStore = defineStore('Instructions', () => {
       instructions.data = instructions.data.filter(
         (instruction) => instruction.id !== id,
       );
-      callAlert('default', 'remove_instruction.success_alert');
+      callAlert('informational', 'remove_instruction.success_alert');
       return { status: null };
     } catch (error) {
       instruction.status = 'error';
-      callAlert('error', 'remove_instruction.error_alert');
+      callAlert(
+        'error',
+        'remove_instruction.error_alert',
+        'remove_instruction.error_alert_description',
+      );
     }
 
     return { status: instruction?.status };

--- a/src/store/__tests__/Instructions.unit.spec.js
+++ b/src/store/__tests__/Instructions.unit.spec.js
@@ -124,6 +124,7 @@ describe('Instructions Store', () => {
           text: i18n.global.t(
             'agent_builder.instructions.new_instruction.success_alert',
           ),
+          description: '',
           type: 'success',
         });
       });
@@ -162,6 +163,7 @@ describe('Instructions Store', () => {
           text: i18n.global.t(
             'agent_builder.instructions.new_instruction.error_alert',
           ),
+          description: '',
           type: 'error',
         });
         expect(store.instructions.data).toHaveLength(0);
@@ -265,6 +267,7 @@ describe('Instructions Store', () => {
           text: i18n.global.t(
             'agent_builder.instructions.edit_instruction.success_alert',
           ),
+          description: '',
           type: 'success',
         });
         expect(result).toEqual({ status: 'complete' });
@@ -290,6 +293,7 @@ describe('Instructions Store', () => {
           text: i18n.global.t(
             'agent_builder.instructions.edit_instruction.error_alert',
           ),
+          description: '',
           type: 'error',
         });
         expect(result).toEqual({ status: 'error' });
@@ -349,7 +353,8 @@ describe('Instructions Store', () => {
           text: i18n.global.t(
             'agent_builder.instructions.remove_instruction.success_alert',
           ),
-          type: 'default',
+          description: '',
+          type: 'informational',
         });
         expect(result).toEqual({ status: null });
       });
@@ -376,6 +381,9 @@ describe('Instructions Store', () => {
         expect(alertStore.add).toHaveBeenCalledWith({
           text: i18n.global.t(
             'agent_builder.instructions.remove_instruction.error_alert',
+          ),
+          description: i18n.global.t(
+            'agent_builder.instructions.remove_instruction.error_alert_description',
           ),
           type: 'error',
         });


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [x] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The remove instruction modal needed to be migrated to the newer `UnnnicDialog` component pattern and improved to give users clearer context about what they are deleting and the consequences of the action.

### Summary of Changes

- Migrated `ModalRemoveInstruction` from `UnnnicModalDialog` to the `UnnnicDialog` compound component pattern (`UnnnicDialogContent`, `UnnnicDialogHeader`, `UnnnicDialogFooter`, `UnnnicDialogClose`).
- Added a snippet block inside the modal that displays the actual instruction text being deleted, so users can confirm they are removing the correct item. The instruction `text` is now included in the `removeTarget` computed property in `ListInstructionRow`.
- Replaced the `ref`\-based `modelValue` with `defineModel` and updated the close logic accordingly.
- Fixed the modal close condition to trigger on any non-error status instead of only on `'complete'`.
- Updated the success alert type from `'default'` to `'informational'`.
- Added an `error_alert_description` locale key for all supported languages (en, es, pt_br, ro) and wired it into the error alert call so the error toast now includes a descriptive message.
- Updated modal description and button label copy across all locales to be more explicit about the permanence of the action.
- Refactored tests to use `shallowMount`, removed the snapshot test, and updated all assertions to target the new component structure and data-testid attributes.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/3d8f3811-94cf-4933-85e0-2621a2509a8b.png)

