### PR TITLE
feat: Add delete category modal

### DIFF
--- a/src/components/Instructions/InstructionsCategorization/__tests__/index.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/index.spec.js
@@ -4,6 +4,7 @@ import { createTestingPinia } from '@pinia/testing';
 
 import InstructionsCategorization from '../index.vue';
 import InstructionsResultsCount from '../InstructionsResultsCount.vue';
+import ModalRemoveCategory from '@/components/Instructions/ModalRemoveCategory.vue';
 import { useInstructionsStore } from '@/store/Instructions';
 import i18n from '@/utils/plugins/i18n';
 
@@ -105,6 +106,42 @@ describe('InstructionsCategorization/index.vue', () => {
 
       expect(find('listView').exists()).toBe(true);
       expect(find('categoriesView').exists()).toBe(false);
+    });
+  });
+
+  describe('Delete category', () => {
+    const removeModal = () => wrapper.findComponent(ModalRemoveCategory);
+
+    it('does not render the remove category modal by default', () => {
+      expect(removeModal().exists()).toBe(false);
+    });
+
+    it('opens the remove category modal with the selected category', async () => {
+      await findComponent('categoriesView').vm.$emit('delete-category', {
+        key: 'category-10',
+        categoryId: 10,
+        label: 'Sales',
+      });
+
+      expect(removeModal().exists()).toBe(true);
+      expect(removeModal().props('category')).toEqual({
+        id: 10,
+        name: 'Sales',
+      });
+    });
+
+    it('unmounts the remove category modal when it closes', async () => {
+      await findComponent('categoriesView').vm.$emit('delete-category', {
+        key: 'category-10',
+        categoryId: 10,
+        label: 'Sales',
+      });
+
+      expect(removeModal().exists()).toBe(true);
+
+      await removeModal().vm.$emit('update:model-value', false);
+
+      expect(removeModal().exists()).toBe(false);
     });
   });
 

--- a/src/components/Instructions/InstructionsCategorization/index.vue
+++ b/src/components/Instructions/InstructionsCategorization/index.vue
@@ -44,6 +44,7 @@
       <CategoriesView
         v-if="showCategoriesView"
         data-testid="instructions-categories-view"
+        @delete-category="onDeleteCategory"
         @edit="instructionsStore.startEditingInstruction"
       />
 
@@ -53,17 +54,26 @@
         @edit="instructionsStore.startEditingInstruction"
       />
     </template>
+
+    <ModalRemoveCategory
+      v-if="categoryToDelete"
+      v-model="isRemoveCategoryModalOpen"
+      :category="categoryToDelete"
+      data-testid="instructions-remove-category-modal"
+      @update:model-value="onRemoveCategoryModalOpenChange"
+    />
   </section>
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 
 import { useInstructionsStore } from '@/store/Instructions';
 
 import InstructionsResultsCount from './InstructionsResultsCount.vue';
 import CategoriesView from './CategoriesView.vue';
 import ListView from './ListView.vue';
+import ModalRemoveCategory from '@/components/Instructions/ModalRemoveCategory.vue';
 
 const views = ['categories', 'list'];
 
@@ -72,6 +82,9 @@ const instructionsStore = useInstructionsStore();
 if (instructionsStore.instructions.status === null) {
   instructionsStore.loadInstructions();
 }
+
+const categoryToDelete = ref(null);
+const isRemoveCategoryModalOpen = ref(false);
 
 const isLoading = computed(
   () => instructionsStore.instructions.status === 'loading',
@@ -90,6 +103,17 @@ const showListView = computed(
     instructionsStore.flatInstructions.length > 0 &&
     instructionsStore.activeInstructionsView === 'list',
 );
+
+function onDeleteCategory(group) {
+  categoryToDelete.value = { id: group.categoryId, name: group.label };
+  isRemoveCategoryModalOpen.value = true;
+}
+
+function onRemoveCategoryModalOpenChange(open) {
+  if (!open) {
+    categoryToDelete.value = null;
+  }
+}
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Instructions/ModalRemoveCategory.vue
+++ b/src/components/Instructions/ModalRemoveCategory.vue
@@ -1,0 +1,123 @@
+<template>
+  <UnnnicDialog
+    data-testid="modal"
+    :open="modelValue"
+    lazyMount
+    @update:open="onUpdateOpen"
+  >
+    <UnnnicDialogContent>
+      <UnnnicDialogHeader type="warning">
+        <UnnnicDialogTitle>
+          {{ t('agents.instructions.delete_category.modal_title') }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+
+      <i18n-t
+        tag="p"
+        class="modal-remove-category__description"
+        keypath="agents.instructions.delete_category.modal_description"
+        data-testid="description"
+      >
+        <template #count>
+          {{
+            t('agents.instructions.delete_category.instructions_count', {
+              count: instructionsCount,
+            })
+          }}
+        </template>
+        <template #name>
+          <b
+            class="modal-remove-category__description-category-name"
+            data-testid="category-name"
+            >{{ category.name }}</b
+          >
+        </template>
+      </i18n-t>
+
+      <UnnnicDialogFooter>
+        <UnnnicDialogClose>
+          <UnnnicButton
+            data-testid="cancel-button"
+            :text="t('agents.instructions.delete_category.cancel')"
+            type="tertiary"
+            :disabled="isDeleting"
+            @click="close"
+          />
+        </UnnnicDialogClose>
+        <UnnnicButton
+          data-testid="confirm-button"
+          :text="t('agents.instructions.delete_category.confirm')"
+          :loading="isDeleting"
+          type="warning"
+          @click="confirm"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup>
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { useInstructionsStore } from '@/store/Instructions';
+
+const props = defineProps({
+  category: {
+    type: Object,
+    required: true,
+  },
+});
+
+const modelValue = defineModel('modelValue', {
+  type: Boolean,
+  required: true,
+});
+
+const { t } = useI18n();
+
+const instructionsStore = useInstructionsStore();
+
+const isDeleting = ref(false);
+
+const instructionsCount = computed(
+  () =>
+    instructionsStore.instructions.data.filter(
+      (instruction) => instruction.category?.id === props.category.id,
+    ).length,
+);
+
+function close() {
+  modelValue.value = false;
+}
+
+function onUpdateOpen(open) {
+  if (isDeleting.value) return;
+  if (!open) close();
+}
+
+async function confirm() {
+  if (isDeleting.value) return;
+
+  isDeleting.value = true;
+  const { status } = await instructionsStore.deleteCategory(props.category.id);
+  isDeleting.value = false;
+
+  if (status !== 'error') close();
+}
+</script>
+
+<style lang="scss" scoped>
+.modal-remove-category {
+  &__description {
+    margin: $unnnic-space-6;
+
+    color: $unnnic-color-fg-base;
+    font: $unnnic-font-body;
+
+    &-category-name {
+      font-weight: $unnnic-font-weight-bold;
+    }
+  }
+}
+</style>

--- a/src/components/Instructions/__tests__/ModalRemoveCategory.spec.js
+++ b/src/components/Instructions/__tests__/ModalRemoveCategory.spec.js
@@ -1,0 +1,142 @@
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { nextTick } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+
+import ModalRemoveCategory from '../ModalRemoveCategory.vue';
+import i18n from '@/utils/plugins/i18n';
+import { useInstructionsStore } from '@/store/Instructions';
+
+describe('ModalRemoveCategory.vue', () => {
+  let wrapper;
+  let instructionsStore;
+
+  const category = { id: 10, name: 'Sales' };
+
+  const categoryT = (key, params) =>
+    i18n.global.t(`agents.instructions.delete_category.${key}`, params ?? {});
+
+  const SELECTORS = {
+    modal: '[data-testid="modal"]',
+    description: '[data-testid="description"]',
+    name: '[data-testid="category-name"]',
+    cancel: '[data-testid="cancel-button"]',
+    confirm: '[data-testid="confirm-button"]',
+  };
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+  const findComponent = (selector) =>
+    wrapper.findComponent(SELECTORS[selector]);
+
+  const createWrapper = (instructionsData = []) => {
+    const pinia = createTestingPinia({
+      initialState: {
+        Instructions: { instructions: { data: instructionsData } },
+      },
+    });
+
+    instructionsStore = useInstructionsStore(pinia);
+    instructionsStore.deleteCategory = vi
+      .fn()
+      .mockResolvedValue({ status: null });
+
+    return shallowMount(ModalRemoveCategory, {
+      props: { modelValue: true, category },
+      global: {
+        plugins: [pinia],
+        stubs: {
+          UnnnicDialogClose: { template: '<div><slot /></div>' },
+          'i18n-t': {
+            inheritAttrs: false,
+            template:
+              '<p v-bind="$attrs"><slot name="count" /><slot name="name" /></p>',
+          },
+        },
+      },
+    });
+  };
+
+  const threeInstructions = [
+    { id: 1, text: 'A', category: { id: 10, name: 'Sales' } },
+    { id: 2, text: 'B', category: { id: 10, name: 'Sales' } },
+    { id: 3, text: 'C', category: { id: 20, name: 'Support' } },
+  ];
+
+  beforeEach(() => {
+    wrapper = createWrapper(threeInstructions);
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders the dialog open with the title', () => {
+      expect(findComponent('modal').props('open')).toBe(true);
+      expect(wrapper.text()).toContain(categoryT('modal_title'));
+    });
+
+    it('renders the category name in a bold tag', () => {
+      const boldName = find('name');
+      expect(boldName.exists()).toBe(true);
+      expect(boldName.element.tagName).toBe('B');
+      expect(boldName.text()).toBe(category.name);
+    });
+
+    it('renders the count phrase using the real category count, ignoring search', () => {
+      expect(find('description').text()).toContain(
+        categoryT('instructions_count', { count: 2 }),
+      );
+    });
+
+    it('renders cancel and confirm buttons with the correct labels', () => {
+      expect(findComponent('cancel').props('text')).toBe(categoryT('cancel'));
+      expect(findComponent('confirm').props('text')).toBe(categoryT('confirm'));
+      expect(findComponent('confirm').props('type')).toBe('warning');
+    });
+  });
+
+  describe('Interactions', () => {
+    it('emits update:modelValue false when cancel is clicked', async () => {
+      await findComponent('cancel').vm.$emit('click');
+
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+    });
+
+    it('calls deleteCategory with the category id and closes on success', async () => {
+      await findComponent('confirm').vm.$emit('click');
+      await flushPromises();
+
+      expect(instructionsStore.deleteCategory).toHaveBeenCalledWith(
+        category.id,
+      );
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+    });
+
+    it('keeps the modal open on error', async () => {
+      instructionsStore.deleteCategory.mockResolvedValue({ status: 'error' });
+
+      await findComponent('confirm').vm.$emit('click');
+      await flushPromises();
+
+      expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+    });
+
+    it('shows loading on the confirm button while deleting', async () => {
+      let resolveDelete;
+      instructionsStore.deleteCategory.mockImplementation(
+        () => new Promise((resolve) => (resolveDelete = resolve)),
+      );
+
+      findComponent('confirm').vm.$emit('click');
+      await nextTick();
+
+      expect(findComponent('confirm').props('loading')).toBe(true);
+
+      resolveDelete({ status: null });
+      await flushPromises();
+
+      expect(findComponent('confirm').props('loading')).toBe(false);
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -347,6 +347,17 @@
       "description": "Define the rules that guide how Manager responds, communicates, and makes decisions",
       "export_instructions": "Export instructions",
       "new_instruction": "New instruction",
+      "delete_category": {
+        "modal_title": "Delete category",
+        "modal_description": "{count} from {name} to Uncategorized. Nothing will be deleted, only the category label is removed.",
+        "instructions_count": "{count, plural, one {{count} instruction will be moved} other {{count} instructions will be moved}}",
+        "cancel": "Cancel",
+        "confirm": "Delete category",
+        "success_title": "Category deleted",
+        "success_description": "{count, plural, one {{count} instruction moved to Uncategorized} other {{count} instructions moved to Uncategorized}}",
+        "error_title": "Couldn't delete category",
+        "error_description": "Something went wrong and nothing was changed. Try again."
+      },
       "view": {
         "default_instruction": "Default instruction",
         "default_instructions": "Default instructions",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -347,6 +347,17 @@
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
       "export_instructions": "Exportar instrucciones",
       "new_instruction": "Nueva instrucción",
+      "delete_category": {
+        "modal_title": "Eliminar categoría",
+        "modal_description": "{count} de {name} a Sin categoría. No se eliminará nada, solo se quita la etiqueta de la categoría.",
+        "instructions_count": "{count, plural, one {{count} instrucción se moverá} other {{count} instrucciones se moverán}}",
+        "cancel": "Cancelar",
+        "confirm": "Eliminar categoría",
+        "success_title": "Categoría eliminada",
+        "success_description": "{count, plural, one {{count} instrucción movida a Sin categoría} other {{count} instrucciones movidas a Sin categoría}}",
+        "error_title": "No se pudo eliminar la categoría",
+        "error_description": "Algo salió mal y no se cambió nada. Inténtalo de nuevo."
+      },
       "view": {
         "default_instruction": "Instrucción predeterminada",
         "default_instructions": "Instrucciones predeterminadas",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -347,6 +347,17 @@
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
       "export_instructions": "Exportar instruções",
       "new_instruction": "Nova instrução",
+      "delete_category": {
+        "modal_title": "Excluir categoria",
+        "modal_description": "{count} de {name} para Sem categoria. Nada será excluído, apenas o rótulo da categoria é removido.",
+        "instructions_count": "{count, plural, one {{count} instrução será movida} other {{count} instruções serão movidas}}",
+        "cancel": "Cancelar",
+        "confirm": "Excluir categoria",
+        "success_title": "Categoria excluída",
+        "success_description": "{count, plural, one {{count} instrução movida para Sem categoria} other {{count} instruções movidas para Sem categoria}}",
+        "error_title": "Não foi possível excluir a categoria",
+        "error_description": "Algo deu errado e nada foi alterado. Tente novamente."
+      },
       "view": {
         "default_instruction": "Instrução padrão",
         "default_instructions": "Instruções padrão",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -346,6 +346,17 @@
       "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
       "export_instructions": "Exportă instrucțiuni",
       "new_instruction": "Instrucțiune nouă",
+      "delete_category": {
+        "modal_title": "Șterge categoria",
+        "modal_description": "{count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
+        "instructions_count": "{count, plural, one {{count} instrucțiune va fi mutată} other {{count} instrucțiuni vor fi mutate}}",
+        "cancel": "Anulează",
+        "confirm": "Șterge categoria",
+        "success_title": "Categorie ștearsă",
+        "success_description": "{count, plural, one {{count} instrucțiune mutată în Fără categorie} other {{count} instrucțiuni mutate în Fără categorie}}",
+        "error_title": "Categoria nu a putut fi ștearsă",
+        "error_description": "Ceva nu a funcționat și nimic nu a fost modificat. Încearcă din nou."
+      },
       "view": {
         "default_instruction": "Instrucțiune implicită",
         "default_instructions": "Instrucțiuni implicite",

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -418,6 +418,49 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     return { status: instruction?.status };
   }
 
+  async function deleteCategory(id: number) {
+    const movedCount = instructions.data.filter(
+      (instruction) => instruction.category?.id === id,
+    ).length;
+
+    const alertStore = useAlertStore();
+    const categoryT = (key: string, params?: Record<string, unknown>) =>
+      i18n.global.t(`agents.instructions.delete_category.${key}`, params ?? {});
+
+    try {
+      await nexusaiAPI.agent_builder.instructions.deleteCategory({
+        projectUuid: projectUuid.value,
+        id,
+      });
+
+      // Instructions are preserved and reassigned to Uncategorized.
+      instructions.data = instructions.data.map((instruction) =>
+        instruction.category?.id === id
+          ? { ...instruction, category: null }
+          : instruction,
+      );
+      categories.value = categories.value.filter(
+        (category) => category.id !== id,
+      );
+
+      alertStore.add({
+        type: 'informational',
+        text: categoryT('success_title'),
+        description: categoryT('success_description', { count: movedCount }),
+      });
+
+      return { status: null };
+    } catch {
+      alertStore.add({
+        type: 'error',
+        text: categoryT('error_title'),
+        description: categoryT('error_description'),
+      });
+
+      return { status: 'error' };
+    }
+  }
+
   async function getInstructionSuggestionByAI(instruction: string) {
     instructionSuggestedByAI.status = 'loading';
 
@@ -506,6 +549,7 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     loadInstructions,
     editInstruction,
     removeInstruction,
+    deleteCategory,
     getInstructionSuggestionByAI,
     updateValidateInstructionByAI,
     resetInstructionSuggestedByAI,

--- a/src/store/__tests__/Instructions.unit.spec.js
+++ b/src/store/__tests__/Instructions.unit.spec.js
@@ -18,6 +18,7 @@ vi.mock('@/api/nexusaiAPI', () => ({
         listGrouped: vi.fn(),
         update: vi.fn(),
         deleteInstruction: vi.fn(),
+        deleteCategory: vi.fn(),
         getSuggestionByAI: vi.fn(),
       },
     },
@@ -414,6 +415,87 @@ describe('Instructions Store', () => {
           text: 'Instruction 3',
           status: 'complete',
         });
+      });
+    });
+
+    describe('deleteCategory', () => {
+      beforeEach(() => {
+        store.categories = [
+          { id: 10, name: 'Sales' },
+          { id: 20, name: 'Support' },
+        ];
+        store.instructions.data = [
+          { id: 1, text: 'A', category: { id: 10, name: 'Sales' } },
+          { id: 2, text: 'B', category: { id: 10, name: 'Sales' } },
+          { id: 3, text: 'C', category: { id: 20, name: 'Support' } },
+        ];
+      });
+
+      it('moves the category instructions to uncategorized and removes the category', async () => {
+        nexusaiAPI.agent_builder.instructions.deleteCategory.mockResolvedValue();
+
+        const result = await store.deleteCategory(10);
+
+        expect(
+          nexusaiAPI.agent_builder.instructions.deleteCategory,
+        ).toHaveBeenCalledWith({ projectUuid: 'test-project-uuid', id: 10 });
+        expect(
+          store.instructions.data.find((i) => i.id === 1).category,
+        ).toBeNull();
+        expect(
+          store.instructions.data.find((i) => i.id === 2).category,
+        ).toBeNull();
+        expect(
+          store.instructions.data.find((i) => i.id === 3).category,
+        ).toEqual({
+          id: 20,
+          name: 'Support',
+        });
+        expect(store.categories).toEqual([{ id: 20, name: 'Support' }]);
+        expect(result).toEqual({ status: null });
+      });
+
+      it('shows a success toast with the moved instructions count', async () => {
+        nexusaiAPI.agent_builder.instructions.deleteCategory.mockResolvedValue();
+
+        await store.deleteCategory(10);
+
+        expect(alertStore.add).toHaveBeenCalledWith({
+          type: 'informational',
+          text: i18n.global.t(
+            'agents.instructions.delete_category.success_title',
+          ),
+          description: i18n.global.t(
+            'agents.instructions.delete_category.success_description',
+            { count: 2 },
+          ),
+        });
+      });
+
+      it('keeps state and shows an error toast on failure', async () => {
+        nexusaiAPI.agent_builder.instructions.deleteCategory.mockRejectedValue(
+          new Error('API Error'),
+        );
+
+        const result = await store.deleteCategory(10);
+
+        expect(store.categories).toHaveLength(2);
+        expect(
+          store.instructions.data.find((i) => i.id === 1).category,
+        ).toEqual({
+          id: 10,
+          name: 'Sales',
+        });
+        expect(alertStore.add).toHaveBeenCalledWith({
+          type: 'error',
+          text: i18n.global.t(
+            'agents.instructions.delete_category.error_title',
+          ),
+          description: i18n.global.t(
+            'agents.instructions.delete_category.error_description',
+          ),
+        });
+        expect(result).toEqual({ status: 'error' });
       });
     });
 

--- a/src/store/helpers/__tests__/instructionViewModels.spec.js
+++ b/src/store/helpers/__tests__/instructionViewModels.spec.js
@@ -55,6 +55,17 @@ describe('buildInstructionGroups', () => {
     ).toEqual(['Sales B', 'Sales A']);
   });
 
+  it('exposes the category id on custom groups', () => {
+    const groups = build({
+      categories: [{ id: 10, name: 'Sales' }],
+      instructions: [
+        { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+      ],
+    });
+
+    expect(byKey(groups, 'category-10').categoryId).toBe(10);
+  });
+
   it('keeps custom categories without instructions for the empty state', () => {
     const groups = build({ categories: [{ id: 10, name: 'Empty' }] });
 

--- a/src/store/helpers/instructionViewModels.ts
+++ b/src/store/helpers/instructionViewModels.ts
@@ -87,6 +87,7 @@ function toCustomGroups(
   return categorized
     .map((category) => ({
       key: `category-${category.id}`,
+      categoryId: category.id,
       label: category.name,
       locked: false,
       instructions: newestFirst(category.instructions),

--- a/src/store/types/Instructions.types.ts
+++ b/src/store/types/Instructions.types.ts
@@ -37,6 +37,7 @@ export interface InstructionGroup {
   label: string;
   locked: boolean;
   instructions: Instruction[];
+  categoryId?: number | null;
 }
 
 export interface FlatInstruction {


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

Users needed a way to delete instruction categories. When a category is deleted, its instructions should not be lost — they are instead moved to "Uncategorized", preserving all content while removing only the category label.

### Summary of Changes

- Added a `ModalRemoveCategory` component that presents a warning dialog before deleting a category. The modal displays the category name and the number of instructions that will be moved to Uncategorized, shows a loading state on the confirm button during deletion, and closes automatically on success while staying open on error.
- Wired the modal into `InstructionsCategorization` by listening to the `delete-category` event emitted by `CategoriesView` and opening the modal with the selected category.
- Added a `deleteCategory` action to the Instructions store that calls the API, reassigns affected instructions to `null` (Uncategorized), removes the category from the local list, and shows a success or error toast with a pluralized moved-instructions count.
- Exposed `categoryId` on custom instruction groups in `buildInstructionGroups` so the delete flow can pass the numeric category ID to the store.
- Added localization strings for all delete-category UI text (modal title, description, pluralized instruction count, cancel/confirm labels, and success/error toast messages) in English, Spanish, Portuguese, and Romanian.
- Added unit tests covering the modal rendering and interactions, the store `deleteCategory` action, and the `categoryId` exposure on custom groups.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/6282b78c-ebd4-4821-a84d-aa6ac6486410.png)

