### PR TITLE
feat: Add Shopping Assistant availability note to progressive feedback title

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -559,7 +559,7 @@
         "agents_preview": {
           "title": "Agent preview",
           "agents_progressive_feedback": {
-            "title": "Agent progressive feedback",
+            "title": "Agent progressive feedback (Only available for Shopping Assistant)",
             "description": "The agent can provide brief updates while formulating the final response, helping the contact follow the process in real time."
           },
           "multiple_message_format": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -559,7 +559,7 @@
         "agents_preview": {
           "title": "Vista previa de los agentes",
           "agents_progressive_feedback": {
-            "title": "Feedback progresivo de los agentes",
+            "title": "Feedback progresivo de los agentes (Solo disponible para el Shopping Assistant)",
             "description": "El agente puede proporcionar actualizaciones breves mientras formula la respuesta final. Esto ayuda al contacto a seguir el proceso en tiempo real."
           },
           "multiple_message_format": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -559,7 +559,7 @@
         "agents_preview": {
           "title": "Prévia dos agentes",
           "agents_progressive_feedback": {
-            "title": "Feedback progressivo dos agentes",
+            "title": "Feedback progressivo dos agentes (Apenas disponível para o Assistente de Compras)",
             "description": "O agente pode fornecer atualizações breves enquanto formula a resposta final, ajudando o contato a acompanhar o processo em tempo real."
           },
           "multiple_message_format": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -558,7 +558,7 @@
         "agents_preview": {
           "title": "Previzualizare agent",
           "agents_progressive_feedback": {
-            "title": "Feedback progresiv agent",
+            "title": "Feedback progresiv agent (Disponibil doar pentru Shopping Assistant)",
             "description": "Agentul poate oferi actualizări sumare în timp ce formulează răspunsul final, ajutând contactul să urmărească procesul în timp real."
           },
           "multiple_message_format": {


### PR DESCRIPTION
## Description

### Type of Change

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other

### Motivation and Context

The "Agent progressive feedback" feature is only supported by the Shopping Assistant, but this was not communicated to users in the UI. Adding a clarification to the label helps prevent confusion when users enable this setting for other agent types.

### Summary of Changes

Updated the "Agent progressive feedback" feature title across all supported locales (English, Spanish, Portuguese, and Romanian) to include a note indicating that the feature is only available for the Shopping Assistant.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/3b3f381b-6f3e-42b8-9686-664f2459eb2c.png)

