### PR TITLE
feat: Add customizable API error message to tunings settings

### DIFF
--- a/src/api/adapters/tunings/__tests__/apiErrorMessage.unit.spec.js
+++ b/src/api/adapters/tunings/__tests__/apiErrorMessage.unit.spec.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+
+import { ApiErrorMessageAdapter } from '@/api/adapters/tunings/apiErrorMessage';
+
+describe('ApiErrorMessageAdapter', () => {
+  describe('fromApi', () => {
+    it('maps error_message to errorMessage', () => {
+      expect(
+        ApiErrorMessageAdapter.fromApi({
+          error_message: 'Custom error',
+        }),
+      ).toEqual({
+        errorMessage: 'Custom error',
+      });
+    });
+  });
+
+  describe('toApi', () => {
+    it('maps errorMessage to error_message', () => {
+      expect(
+        ApiErrorMessageAdapter.toApi({
+          errorMessage: 'Custom error',
+        }),
+      ).toEqual({
+        error_message: 'Custom error',
+      });
+    });
+
+    it('normalizes empty string to null', () => {
+      expect(
+        ApiErrorMessageAdapter.toApi({
+          errorMessage: '',
+        }),
+      ).toEqual({
+        error_message: null,
+      });
+    });
+
+    it('normalizes whitespace-only string to null', () => {
+      expect(
+        ApiErrorMessageAdapter.toApi({
+          errorMessage: '   ',
+        }),
+      ).toEqual({
+        error_message: null,
+      });
+    });
+
+    it('trims surrounding whitespace before saving', () => {
+      expect(
+        ApiErrorMessageAdapter.toApi({
+          errorMessage: '  Custom error  ',
+        }),
+      ).toEqual({
+        error_message: 'Custom error',
+      });
+    });
+  });
+});

--- a/src/api/adapters/tunings/apiErrorMessage.js
+++ b/src/api/adapters/tunings/apiErrorMessage.js
@@ -1,0 +1,21 @@
+export const ApiErrorMessageAdapter = {
+  fromApi(apiData) {
+    const { error_message, ...rest } = apiData;
+
+    return {
+      ...rest,
+      errorMessage: error_message,
+    };
+  },
+
+  toApi(storeData) {
+    const { errorMessage, ...rest } = storeData;
+    const trimmed =
+      typeof errorMessage === 'string' ? errorMessage.trim() : errorMessage;
+
+    return {
+      ...rest,
+      error_message: trimmed === '' || trimmed == null ? null : trimmed,
+    };
+  },
+};

--- a/src/api/nexusaiAPI.js
+++ b/src/api/nexusaiAPI.js
@@ -8,6 +8,7 @@ import { FeatureFlags } from './nexus/FeatureFlags';
 
 import { ProgressiveFeedbackAdapter } from './adapters/tunings/progressiveFeedback';
 import { ComponentsAdapter } from './adapters/tunings/components';
+import { ApiErrorMessageAdapter } from './adapters/tunings/apiErrorMessage';
 import { ProjectDetailsAdapter } from './adapters/tunings/projectDetails';
 import i18n from '@/utils/plugins/i18n';
 import env from '@/utils/env';
@@ -114,6 +115,27 @@ export default {
           ComponentsAdapter.toApi(data),
           requestOptions,
         );
+      },
+
+      apiErrorMessage: {
+        async read({ projectUuid }) {
+          const response = await request.$http.get(
+            `api/project/${projectUuid}/api-error-message`,
+            { hideGenericErrorAlert: true },
+          );
+
+          return ApiErrorMessageAdapter.fromApi(response.data);
+        },
+
+        async edit({ projectUuid, data, requestOptions = {} }) {
+          const response = await request.$http.patch(
+            `api/project/${projectUuid}/api-error-message`,
+            ApiErrorMessageAdapter.toApi(data),
+            { hideGenericErrorAlert: true, ...requestOptions },
+          );
+
+          return ApiErrorMessageAdapter.fromApi(response.data);
+        },
       },
 
       manager: {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -291,6 +291,14 @@
           "provider": "Select a provider",
           "model": "Select a model"
         }
+      },
+      "system_messages": {
+        "title": "System messages",
+        "error_message": {
+          "label": "Error message",
+          "save_error": "Error message couldn't be saved due to a technical issue",
+          "tooltip": "This message is displayed to the contact when the agent is unable to generate a response.\nFor example, in cases of technical instability, processing errors, or exceeded response times.\nCustomize it to maintain your brand’s tone of voice even in error situations."
+        }
       }
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -291,6 +291,14 @@
           "provider": "Selecciona un proveedor",
           "model": "Selecciona un modelo"
         }
+      },
+      "system_messages": {
+        "title": "Mensajes del sistema",
+        "error_message": {
+          "label": "Mensaje de error",
+          "save_error": "No se pudo guardar el mensaje de error debido a un problema técnico",
+          "tooltip": "Este mensaje se muestra al contacto cuando el agente no puede generar una respuesta.\nPor ejemplo, en casos de inestabilidad técnica, errores de procesamiento o tiempos de respuesta excedidos.\nPersonalízalo para mantener el tono de voz de tu marca incluso en situaciones de error."
+        }
       }
     }
   },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -291,6 +291,14 @@
           "provider": "Selecione um provedor",
           "model": "Selecione um modelo"
         }
+      },
+      "system_messages": {
+        "title": "Mensagens do sistema",
+        "error_message": {
+          "label": "Mensagem de erro",
+          "save_error": "Não foi possível salvar a mensagem de erro devido a um problema técnico",
+          "tooltip": "Esta mensagem é exibida para o contato quando o agente não consegue gerar uma resposta.\nPor exemplo, em casos de instabilidade técnica, erros de processamento ou tempo de resposta excedido.\nPersonalize-a para manter o tom de voz da sua marca mesmo em situações de erro."
+        }
       }
     }
   },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -290,6 +290,14 @@
           "provider": "Selectează un furnizor",
           "model": "Selectează un model"
         }
+      },
+      "system_messages": {
+        "title": "Mesaje de sistem",
+        "error_message": {
+          "label": "Mesaj de eroare",
+          "save_error": "Mesajul de eroare nu a putut fi salvat din cauza unei probleme tehnice",
+          "tooltip": "Acest mesaj este afișat contactului când agentul nu poate genera un răspuns.\nDe exemplu, în cazuri de instabilitate tehnică, erori de procesare sau timpi de răspuns depășiți.\nPersonalizează-l pentru a menține tonul vocii brandului tău chiar și în situații de eroare."
+        }
       }
     }
   },

--- a/src/store/Tunings.js
+++ b/src/store/Tunings.js
@@ -32,12 +32,14 @@ export const useTuningsStore = defineStore('Tunings', () => {
   });
 
   const initialSettings = ref(null);
+  const lastErrorMessageSaveFailed = ref(false);
   const settings = reactive({
     status: null,
     data: {
       components: false,
       progressiveFeedback: false,
       manager: '',
+      errorMessage: '',
     },
   });
 
@@ -183,6 +185,8 @@ export const useTuningsStore = defineStore('Tunings', () => {
 
   async function fetchSettings() {
     try {
+      settings.status = 'loading';
+
       const { progressiveFeedback } =
         await nexusaiAPI.router.tunings.getProgressiveFeedback({
           projectUuid: projectUuid.value,
@@ -192,10 +196,24 @@ export const useTuningsStore = defineStore('Tunings', () => {
         projectUuid: projectUuid.value,
       });
 
+      let errorMessage = '';
+
+      try {
+        const { errorMessage: savedErrorMessage } =
+          await nexusaiAPI.router.tunings.apiErrorMessage.read({
+            projectUuid: projectUuid.value,
+          });
+
+        errorMessage = savedErrorMessage ?? '';
+      } catch {
+        errorMessage = '';
+      }
+
       settings.data = {
         ...settings.data,
         components,
         progressiveFeedback,
+        errorMessage,
       };
       initialSettings.value = cloneDeep(settings.data);
 
@@ -206,6 +224,8 @@ export const useTuningsStore = defineStore('Tunings', () => {
   }
 
   async function saveSettings() {
+    lastErrorMessageSaveFailed.value = false;
+
     try {
       settings.status = 'loading';
 
@@ -257,10 +277,38 @@ export const useTuningsStore = defineStore('Tunings', () => {
         }
       }
 
-      initialSettings.value = cloneDeep(settings.data);
+      const hasErrorMessageChanges =
+        initialSettings.value.errorMessage !== settings.data.errorMessage;
+
+      if (hasErrorMessageChanges) {
+        try {
+          const { errorMessage: savedErrorMessage } =
+            await nexusaiAPI.router.tunings.apiErrorMessage.edit({
+              projectUuid: projectUuid.value,
+              data: {
+                errorMessage: settings.data.errorMessage,
+              },
+              requestOptions: {
+                hideGenericErrorAlert: true,
+              },
+            });
+
+          settings.data.errorMessage = savedErrorMessage ?? '';
+        } catch {
+          lastErrorMessageSaveFailed.value = true;
+        }
+      }
+
+      const nextInitialSettings = cloneDeep(settings.data);
+
+      if (lastErrorMessageSaveFailed.value) {
+        nextInitialSettings.errorMessage = initialSettings.value.errorMessage;
+      }
+
+      initialSettings.value = nextInitialSettings;
       settings.status = 'success';
 
-      return true;
+      return !lastErrorMessageSaveFailed.value;
     } catch (error) {
       settings.status = 'error';
       return false;
@@ -308,10 +356,21 @@ export const useTuningsStore = defineStore('Tunings', () => {
           text: i18n.global.t('router.tunings.settings.save_error'),
           type: 'error',
         });
+      } else if (lastErrorMessageSaveFailed.value) {
+        alertStore.add({
+          text: i18n.global.t(
+            'agent_builder.tunings.system_messages.error_message.save_error',
+          ),
+          type: 'error',
+        });
       }
     }
 
-    if (!hasCredentialsError && !hasSettingsError) {
+    if (
+      !hasCredentialsError &&
+      !hasSettingsError &&
+      !lastErrorMessageSaveFailed.value
+    ) {
       alertStore.add({
         text: i18n.global.t('router.tunings.save_success'),
         type: 'success',
@@ -327,6 +386,7 @@ export const useTuningsStore = defineStore('Tunings', () => {
     isSettingsValid,
     initialCredentials,
     initialSettings,
+    lastErrorMessageSaveFailed,
     getCredentialIndex,
     updateCredential,
     fetchCredentials,

--- a/src/store/__tests__/Tunings.unit.spec.js
+++ b/src/store/__tests__/Tunings.unit.spec.js
@@ -20,6 +20,10 @@ vi.mock('@/api/nexusaiAPI', () => ({
         editProgressiveFeedback: vi.fn(),
         editComponents: vi.fn(),
         createCredentials: vi.fn(),
+        apiErrorMessage: {
+          read: vi.fn(),
+          edit: vi.fn(),
+        },
         manager: {
           edit: vi.fn(),
         },
@@ -49,6 +53,9 @@ describe('Tunings Store', () => {
   let alertStore;
   let managerSelectorStore;
   let engineSourceStore;
+
+  const backendDefaultErrorMessage =
+    'Sorry, I was unable to process your request. Try again.';
 
   const mockCredentialsData = {
     my_agents_credentials: [
@@ -85,6 +92,7 @@ describe('Tunings Store', () => {
           components: false,
           progressiveFeedback: false,
           manager: '',
+          errorMessage: '',
         },
       });
       expect(store.initialCredentials).toBeNull();
@@ -170,11 +178,13 @@ describe('Tunings Store', () => {
           components: true,
           progressiveFeedback: false,
           manager: 'manager-2.6',
+          errorMessage: backendDefaultErrorMessage,
         };
         store.initialSettings = {
           components: false,
           progressiveFeedback: false,
           manager: 'manager-2.5',
+          errorMessage: backendDefaultErrorMessage,
         };
       });
 
@@ -371,6 +381,9 @@ describe('Tunings Store', () => {
         nexusaiAPI.router.tunings.getComponents.mockResolvedValue({
           components: true,
         });
+        nexusaiAPI.router.tunings.apiErrorMessage.read.mockResolvedValue({
+          errorMessage: backendDefaultErrorMessage,
+        });
 
         await store.fetchSettings();
 
@@ -379,8 +392,42 @@ describe('Tunings Store', () => {
           components: true,
           progressiveFeedback: true,
           manager: '',
+          errorMessage: backendDefaultErrorMessage,
         });
         expect(store.initialSettings).toEqual(store.settings.data);
+      });
+
+      it('should pre-fill saved custom error message', async () => {
+        nexusaiAPI.router.tunings.getProgressiveFeedback.mockResolvedValue({
+          progressiveFeedback: false,
+        });
+        nexusaiAPI.router.tunings.getComponents.mockResolvedValue({
+          components: false,
+        });
+        nexusaiAPI.router.tunings.apiErrorMessage.read.mockResolvedValue({
+          errorMessage: 'Custom API error',
+        });
+
+        await store.fetchSettings();
+
+        expect(store.settings.data.errorMessage).toBe('Custom API error');
+      });
+
+      it('should leave error message empty when api read fails', async () => {
+        nexusaiAPI.router.tunings.getProgressiveFeedback.mockResolvedValue({
+          progressiveFeedback: false,
+        });
+        nexusaiAPI.router.tunings.getComponents.mockResolvedValue({
+          components: false,
+        });
+        nexusaiAPI.router.tunings.apiErrorMessage.read.mockRejectedValue(
+          new Error('Read failed'),
+        );
+
+        await store.fetchSettings();
+
+        expect(store.settings.status).toBe('success');
+        expect(store.settings.data.errorMessage).toBe('');
       });
 
       it('should handle fetch settings error', async () => {
@@ -400,11 +447,13 @@ describe('Tunings Store', () => {
           components: true,
           progressiveFeedback: true,
           manager: 'manager-2.6',
+          errorMessage: backendDefaultErrorMessage,
         };
         store.initialSettings = {
           components: false,
           progressiveFeedback: false,
           manager: 'manager-2.5',
+          errorMessage: backendDefaultErrorMessage,
         };
       });
 
@@ -507,6 +556,62 @@ describe('Tunings Store', () => {
         await nextTick();
 
         expect(store.settings.data.manager).toBe('manager-2.7');
+      });
+
+      it('should save changed error message independently', async () => {
+        store.settings.data = cloneDeep(store.initialSettings);
+        store.settings.data.errorMessage = 'Updated error message';
+        nexusaiAPI.router.tunings.apiErrorMessage.edit.mockResolvedValue({
+          errorMessage: 'Updated error message',
+        });
+
+        const result = await store.saveSettings();
+
+        expect(
+          nexusaiAPI.router.tunings.apiErrorMessage.edit,
+        ).toHaveBeenCalledWith({
+          projectUuid: 'test-project-uuid',
+          data: { errorMessage: 'Updated error message' },
+          requestOptions: { hideGenericErrorAlert: true },
+        });
+        expect(result).toBe(true);
+        expect(store.settings.data.errorMessage).toBe('Updated error message');
+      });
+
+      it('should reset to default after clearing error message', async () => {
+        store.settings.data = cloneDeep(store.initialSettings);
+        store.initialSettings.errorMessage = 'Custom saved message';
+        store.settings.data.errorMessage = '';
+        nexusaiAPI.router.tunings.apiErrorMessage.edit.mockResolvedValue({
+          errorMessage: backendDefaultErrorMessage,
+        });
+
+        const result = await store.saveSettings();
+
+        expect(result).toBe(true);
+        expect(store.settings.data.errorMessage).toBe(
+          backendDefaultErrorMessage,
+        );
+      });
+
+      it('should keep other settings saved when only error message save fails', async () => {
+        store.settings.data.errorMessage = 'Updated error message';
+        nexusaiAPI.router.tunings.editProgressiveFeedback.mockResolvedValue();
+        nexusaiAPI.router.tunings.editComponents.mockResolvedValue();
+        nexusaiAPI.router.tunings.apiErrorMessage.edit.mockRejectedValue(
+          new Error('Save failed'),
+        );
+        vi.spyOn(managerSelectorStore, 'saveManager').mockResolvedValue(true);
+
+        const result = await store.saveSettings();
+
+        expect(result).toBe(false);
+        expect(store.lastErrorMessageSaveFailed).toBe(true);
+        expect(store.settings.status).toBe('success');
+        expect(store.initialSettings.components).toBe(true);
+        expect(store.initialSettings.errorMessage).toBe(
+          backendDefaultErrorMessage,
+        );
       });
     });
 


### PR DESCRIPTION
## Description

### Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other

### Motivation and Context

Agents need to display a customizable error message to contacts when they are unable to generate a response — for example, during technical instability, processing errors, or exceeded response times. This allows teams to maintain their brand's tone of voice even in failure scenarios.

### Summary of Changes

- Added `ApiErrorMessageAdapter` with `fromApi` and `toApi` methods that handle snake_case ↔ camelCase mapping, whitespace trimming, and normalization of empty/whitespace-only strings to `null`.
- Exposed `apiErrorMessage.read` and `apiErrorMessage.edit` endpoints in `nexusaiAPI` under `router.tunings`.
- Integrated the error message field into the Tunings store:
    - Fetched alongside other settings on `fetchSettings`, with graceful fallback to an empty string if the read fails.
    - Saved independently during `saveSettings`, tracking failures separately via `lastErrorMessageSaveFailed` so that other settings are not rolled back when only the error message save fails.
    - On save failure, the error message reverts to its previous value while other settings retain their saved state.
- Added a dedicated error alert using the `system_messages.error_message.save_error` locale key when the error message fails to save.
- Added localization strings for the system messages section (title, label, save error, and tooltip) in English, Spanish, Portuguese (BR), and Romanian.
- Added unit tests for `ApiErrorMessageAdapter` covering field mapping, trimming, and null normalization, as well as Tunings store tests covering fetch, save, failure isolation, and reset-to-default behavior.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/776d6623-8b0b-482b-9748-4cd5d771ceaa.png)

![image.png](https://app.graphite.com/user-attachments/assets/d11062de-f2a8-4890-ac3b-d44783fb06b0.png)

