### PR TITLE
feat: Add SystemMessages component with error message field to tunings settings

### DIFF
--- a/src/components/AgentsTeam/MyAgents/EditManagerProfileDrawer.vue
+++ b/src/components/AgentsTeam/MyAgents/EditManagerProfileDrawer.vue
@@ -123,8 +123,16 @@ async function save() {
     const settingsSaved = await tuningsStore.saveSettings();
     if (!settingsSaved) {
       hasError = true;
+      let errorText = i18n.global.t('router.tunings.settings.save_error');
+
+      if (tuningsStore.lastErrorMessageSaveFailed) {
+        errorText = i18n.global.t(
+          'agent_builder.tunings.system_messages.error_message.save_error',
+        );
+      }
+
       alertStore.add({
-        text: i18n.global.t('router.tunings.settings.save_error'),
+        text: errorText,
         type: 'error',
       });
     }

--- a/src/components/AgentsTeam/MyAgents/__tests__/EditManagerProfileDrawer.spec.js
+++ b/src/components/AgentsTeam/MyAgents/__tests__/EditManagerProfileDrawer.spec.js
@@ -14,6 +14,7 @@ const defaultSettingsData = {
   components: false,
   progressiveFeedback: false,
   manager: '',
+  errorMessage: '',
 };
 
 const pinia = createTestingPinia({
@@ -305,11 +306,42 @@ describe('EditManagerProfileDrawer.vue', () => {
       tuningsStore.initialSettings = { ...defaultSettingsData };
       tuningsStore.settings.data = { ...defaultSettingsData, manager: 'other' };
       tuningsStore.saveSettings.mockResolvedValue(false);
+      tuningsStore.lastErrorMessageSaveFailed = false;
       const alertSpy = vi.spyOn(alertStore, 'add');
 
       await wrapper.vm.save();
 
       expect(alertSpy).toHaveBeenCalledWith({
+        text: i18n.global.t('router.tunings.settings.save_error'),
+        type: 'error',
+      });
+      expect(wrapper.vm.modelValue).toBe(true);
+    });
+
+    it('shows dedicated error alert when only error message save fails', async () => {
+      profileStore.name.current = profileStore.name.old;
+      profileStore.role.current = profileStore.role.old;
+      profileStore.personality.current = profileStore.personality.old;
+      profileStore.goal.current = profileStore.goal.old;
+
+      tuningsStore.initialSettings = { ...defaultSettingsData };
+      tuningsStore.settings.data = {
+        ...defaultSettingsData,
+        errorMessage: 'Updated error message',
+      };
+      tuningsStore.saveSettings.mockResolvedValue(false);
+      tuningsStore.lastErrorMessageSaveFailed = true;
+      const alertSpy = vi.spyOn(alertStore, 'add');
+
+      await wrapper.vm.save();
+
+      expect(alertSpy).toHaveBeenCalledWith({
+        text: i18n.global.t(
+          'agent_builder.tunings.system_messages.error_message.save_error',
+        ),
+        type: 'error',
+      });
+      expect(alertSpy).not.toHaveBeenCalledWith({
         text: i18n.global.t('router.tunings.settings.save_error'),
         type: 'error',
       });

--- a/src/components/Tunings/SettingsAgentsTeam/AgentsPreview.vue
+++ b/src/components/Tunings/SettingsAgentsTeam/AgentsPreview.vue
@@ -101,7 +101,7 @@ watch(isComponentsDisabled, (disabled) => {
   gap: $unnnic-space-3;
 
   &__title {
-    @include unnnic-font-body;
+    @include unnnic-font-action;
     color: $unnnic-color-fg-base;
   }
 

--- a/src/components/Tunings/SettingsAgentsTeam/EngineSource/index.vue
+++ b/src/components/Tunings/SettingsAgentsTeam/EngineSource/index.vue
@@ -1,6 +1,7 @@
 <template>
   <UnnnicRadioGroup
     state="vertical"
+    class="engine-source__radio-group"
     :label="$t('agent_builder.tunings.engine_source.title')"
     :modelValue="engineSourceStore.engineType"
     data-testid="engine-source-radio-group"
@@ -25,3 +26,11 @@ import { useEngineSourceStore } from '@/store/EngineSource';
 
 const engineSourceStore = useEngineSourceStore();
 </script>
+
+<style lang="scss" scoped>
+.engine-source__radio-group {
+  :deep(.unnnic-label__label) {
+    @include unnnic-font-action;
+  }
+}
+</style>

--- a/src/components/Tunings/SettingsAgentsTeam/ManagerSelector/index.vue
+++ b/src/components/Tunings/SettingsAgentsTeam/ManagerSelector/index.vue
@@ -95,7 +95,7 @@ const updateSelectedManager = (managerId) => {
   gap: $unnnic-space-3;
 
   &__title {
-    @include unnnic-font-body;
+    @include unnnic-font-action;
     color: $unnnic-color-fg-base;
   }
 

--- a/src/components/Tunings/SettingsAgentsTeam/SystemMessages.vue
+++ b/src/components/Tunings/SettingsAgentsTeam/SystemMessages.vue
@@ -1,0 +1,66 @@
+<template>
+  <section
+    class="system-messages"
+    data-testid="system-messages"
+  >
+    <h2
+      class="system-messages__title"
+      data-testid="system-messages-title"
+    >
+      {{ $t('agent_builder.tunings.system_messages.title') }}
+    </h2>
+
+    <UnnnicSkeletonLoading
+      v-if="isLoading"
+      tag="div"
+      width="100%"
+      height="120px"
+      data-testid="system-messages-skeleton"
+    />
+
+    <UnnnicFormElement
+      v-else
+      class="system-messages__field"
+      data-testid="system-messages-field"
+      :label="$t('agent_builder.tunings.system_messages.error_message.label')"
+      :tooltip="{
+        text: $t('agent_builder.tunings.system_messages.error_message.tooltip'),
+        side: 'top',
+        maxWidth: '550px',
+      }"
+    >
+      <UnnnicTextArea
+        v-model="tuningsStore.settings.data.errorMessage"
+        data-testid="system-messages-error-message"
+        :maxLength="1000"
+      />
+    </UnnnicFormElement>
+  </section>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+
+import { useTuningsStore } from '@/store/Tunings';
+
+const tuningsStore = useTuningsStore();
+
+const isLoading = computed(() => tuningsStore.settings.status === 'loading');
+</script>
+
+<style lang="scss" scoped>
+.system-messages {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-4;
+
+  &__title {
+    @include unnnic-font-action;
+    color: $unnnic-color-fg-base;
+  }
+
+  &__field {
+    width: 100%;
+  }
+}
+</style>

--- a/src/components/Tunings/SettingsAgentsTeam/__tests__/SystemMessages.spec.js
+++ b/src/components/Tunings/SettingsAgentsTeam/__tests__/SystemMessages.spec.js
@@ -1,0 +1,86 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { nextTick } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+
+import SystemMessages from '../SystemMessages.vue';
+import { useTuningsStore } from '@/store/Tunings';
+import i18n from '@/utils/plugins/i18n';
+
+describe('SystemMessages.vue', () => {
+  let wrapper;
+  let store;
+
+  const title = () => wrapper.find('[data-testid="system-messages-title"]');
+  const field = () =>
+    wrapper.findComponent('[data-testid="system-messages-field"]');
+  const textarea = () =>
+    wrapper.findComponent('[data-testid="system-messages-error-message"]');
+  const skeleton = () =>
+    wrapper.find('[data-testid="system-messages-skeleton"]');
+
+  beforeEach(() => {
+    wrapper = mount(SystemMessages, {
+      global: {
+        plugins: [createTestingPinia({ stubActions: false }), i18n],
+      },
+    });
+
+    store = useTuningsStore();
+    store.settings.data.errorMessage = 'Custom error message';
+    store.settings.status = 'success';
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+  });
+
+  it('renders the section title', () => {
+    expect(title().text()).toBe(
+      i18n.global.t('agent_builder.tunings.system_messages.title'),
+    );
+  });
+
+  it('renders the error message field with label and tooltip', () => {
+    expect(field().exists()).toBe(true);
+    expect(field().props('label')).toBe(
+      i18n.global.t(
+        'agent_builder.tunings.system_messages.error_message.label',
+      ),
+    );
+    expect(field().props('tooltip')).toEqual({
+      text: i18n.global.t(
+        'agent_builder.tunings.system_messages.error_message.tooltip',
+      ),
+      side: 'top',
+      maxWidth: '550px',
+    });
+  });
+
+  it('binds the textarea to the store errorMessage', () => {
+    expect(textarea().props('modelValue')).toBe('Custom error message');
+    expect(textarea().props('maxLength')).toBe(1000);
+  });
+
+  it('updates the store when the textarea changes', async () => {
+    await textarea().vm.$emit('update:modelValue', 'Updated error message');
+
+    expect(store.settings.data.errorMessage).toBe('Updated error message');
+  });
+
+  it('shows loading skeleton while settings are loading', async () => {
+    store.settings.status = 'loading';
+    await nextTick();
+
+    expect(skeleton().exists()).toBe(true);
+    expect(field().exists()).toBe(false);
+  });
+
+  it('hides loading skeleton when settings are loaded', async () => {
+    store.settings.status = 'success';
+    await nextTick();
+
+    expect(skeleton().exists()).toBe(false);
+    expect(field().exists()).toBe(true);
+  });
+});

--- a/src/components/Tunings/SettingsAgentsTeam/__tests__/index.spec.js
+++ b/src/components/Tunings/SettingsAgentsTeam/__tests__/index.spec.js
@@ -31,6 +31,8 @@ describe('SettingsAgentsTeam/index.vue', () => {
     wrapper.findComponent('[data-testid="custom-model-config"]');
   const agentsPreview = () =>
     wrapper.findComponent('[data-testid="agents-preview"]');
+  const systemMessages = () =>
+    wrapper.findComponent('[data-testid="system-messages"]');
   const voiceSettings = () =>
     wrapper.findComponent('[data-testid="voice-settings"]');
 
@@ -52,10 +54,11 @@ describe('SettingsAgentsTeam/index.vue', () => {
     vi.clearAllMocks();
   });
 
-  it('renders ManagerDisclaimers, EngineSource, and AgentsPreview', () => {
+  it('renders ManagerDisclaimers, EngineSource, AgentsPreview, and SystemMessages', () => {
     expect(managerDisclaimers().exists()).toBe(true);
     expect(engineSource().exists()).toBe(true);
     expect(agentsPreview().exists()).toBe(true);
+    expect(systemMessages().exists()).toBe(true);
   });
 
   it('renders ManagerSelector when engine type is native', () => {
@@ -82,6 +85,7 @@ describe('SettingsAgentsTeam/index.vue', () => {
     expect(children[1].getAttribute('data-testid')).toBe('engine-source');
     expect(children[2].getAttribute('data-testid')).toBe('manager-selector');
     expect(children[3].getAttribute('data-testid')).toBe('agents-preview');
-    expect(children[4].getAttribute('data-testid')).toBe('voice-settings');
+    expect(children[4].getAttribute('data-testid')).toBe('system-messages');
+    expect(children[5].getAttribute('data-testid')).toBe('voice-settings');
   });
 });

--- a/src/components/Tunings/SettingsAgentsTeam/index.vue
+++ b/src/components/Tunings/SettingsAgentsTeam/index.vue
@@ -21,9 +21,14 @@
 
     <AgentsPreview
       data-testid="agents-preview"
+      class="settings-agents-team__section--with-divider"
+    />
+
+    <SystemMessages
       :class="{
         'settings-agents-team__section--with-divider': hasAgentVoice,
       }"
+      data-testid="system-messages"
     />
 
     <VoiceSettings
@@ -37,6 +42,7 @@
 import { computed } from 'vue';
 
 import AgentsPreview from './AgentsPreview.vue';
+import SystemMessages from './SystemMessages.vue';
 import VoiceSettings from './VoiceSettings.vue';
 import ManagerSelector from './ManagerSelector/index.vue';
 import ManagerDisclaimers from './ManagerDisclaimers.vue';


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Agents need a way to display a customizable error message to users when something goes wrong. This requires a dedicated UI section in the tunings settings and proper error handling when saving this specific field fails.

### Summary of Changes
- Added a new `SystemMessages` component to the `SettingsAgentsTeam` section, which provides a textarea field (with a 1000-character limit) for configuring a custom error message, including a loading skeleton state while settings are being fetched.
- Integrated `SystemMessages` into the `SettingsAgentsTeam` layout, positioned between `AgentsPreview` and `VoiceSettings`, with appropriate divider styling.
- Updated the save error handling in `EditManagerProfileDrawer` to show a dedicated, context-specific error alert when only the error message field fails to save, using `tuningsStore.lastErrorMessageSaveFailed` to distinguish this case from a general settings save failure.
- Updated section title font styles in `AgentsPreview`, `ManagerSelector`, and `EngineSource` from `unnnic-font-body` to `unnnic-font-action` for visual consistency.
- Added unit tests for the new `SystemMessages` component covering rendering, data binding, store updates, and loading states.
- Updated existing `EditManagerProfileDrawer` and `SettingsAgentsTeam` tests to cover the new error alert behavior and the presence of the `SystemMessages` component.