### PR TITLE
feat: Add export instructions modal with CSV download

### DIFF
--- a/src/api/nexus/Instructions.js
+++ b/src/api/nexus/Instructions.js
@@ -124,4 +124,12 @@ export const Instructions = {
     );
     return InstructionClassificationAdapter.fromApi(response.data);
   },
+
+  async export({ projectUuid }) {
+    const response = await request.$http.get(
+      `api/${projectUuid}/instructions/export/`,
+    );
+
+    return response.data;
+  },
 };

--- a/src/components/Instructions/ExportInstructionsModal.vue
+++ b/src/components/Instructions/ExportInstructionsModal.vue
@@ -1,0 +1,69 @@
+<template>
+  <UnnnicDialog
+    data-testid="export-instructions-modal"
+    :open="modelValue"
+    lazyMount
+    @update:open="close"
+  >
+    <UnnnicDialogContent>
+      <UnnnicDialogHeader>
+        <UnnnicDialogTitle>
+          {{ $t('agents.instructions.export_instructions.modal_title') }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+      <p
+        class="export-instructions-modal__description"
+        data-testid="description"
+      >
+        {{ $t('agents.instructions.export_instructions.modal_description') }}
+      </p>
+      <UnnnicDialogFooter>
+        <UnnnicDialogClose>
+          <UnnnicButton
+            data-testid="cancel-button"
+            :text="$t('agents.instructions.export_instructions.cancel_button')"
+            type="tertiary"
+          />
+        </UnnnicDialogClose>
+        <UnnnicButton
+          data-testid="export-button"
+          :text="$t('agents.instructions.export_instructions.export_button')"
+          type="primary"
+          :loading="instructionsStore.isExportingInstructionsLoading"
+          @click="exportInstructions"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup>
+import { useInstructionsStore } from '@/store/Instructions';
+
+const instructionsStore = useInstructionsStore();
+
+const modelValue = defineModel('modelValue', {
+  type: Boolean,
+  required: true,
+});
+
+async function exportInstructions() {
+  const response = await instructionsStore.exportInstructions();
+  if (response.status === 'success') close();
+}
+
+function close() {
+  modelValue.value = false;
+}
+</script>
+
+<style lang="scss" scoped>
+.export-instructions-modal {
+  &__description {
+    margin: $unnnic-space-6;
+
+    @include unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+}
+</style>

--- a/src/components/Instructions/InstructionsHeaderActions.vue
+++ b/src/components/Instructions/InstructionsHeaderActions.vue
@@ -2,7 +2,7 @@
   <UnnnicButton
     data-testid="export-instructions-button"
     type="secondary"
-    :text="$t('agents.instructions.export_instructions')"
+    :text="$t('agents.instructions.export_instructions.title')"
     @click="exportInstructions"
   />
 
@@ -14,16 +14,24 @@
   />
 
   <NewInstructionDrawer data-testid="new-instruction-drawer" />
+  <ExportInstructionsModal
+    v-model="isExportInstructionsModalOpen"
+    data-testid="export-instructions-modal"
+  />
 </template>
 
 <script setup lang="ts">
+import { ref } from 'vue';
 import { useInstructionsStore } from '@/store/Instructions';
 
 import NewInstructionDrawer from '@/components/Instructions/NewInstructionDrawer/index.vue';
+import ExportInstructionsModal from '@/components/Instructions/ExportInstructionsModal.vue';
 
 const instructionsStore = useInstructionsStore();
 
+const isExportInstructionsModalOpen = ref(false);
+
 function exportInstructions() {
-  // TODO: Implement export instructions
+  isExportInstructionsModalOpen.value = true;
 }
 </script>

--- a/src/components/Instructions/__tests__/ExportInstructionsModal.spec.js
+++ b/src/components/Instructions/__tests__/ExportInstructionsModal.spec.js
@@ -1,0 +1,111 @@
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { nextTick } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+
+import ExportInstructionsModal from '../ExportInstructionsModal.vue';
+import i18n from '@/utils/plugins/i18n';
+import { useInstructionsStore } from '@/store/Instructions';
+
+describe('ExportInstructionsModal.vue', () => {
+  let wrapper;
+  let instructionsStore;
+
+  const exportT = (key) =>
+    i18n.global.t(`agents.instructions.export_instructions.${key}`);
+
+  const SELECTORS = {
+    modal: '[data-testid="export-instructions-modal"]',
+    description: '[data-testid="description"]',
+    cancel: '[data-testid="cancel-button"]',
+    export: '[data-testid="export-button"]',
+  };
+  const find = (selector) => wrapper.find(SELECTORS[selector]);
+  const findComponent = (selector) =>
+    wrapper.findComponent(SELECTORS[selector]);
+
+  const createWrapper = () => {
+    const pinia = createTestingPinia();
+
+    instructionsStore = useInstructionsStore(pinia);
+    instructionsStore.exportInstructions = vi
+      .fn()
+      .mockResolvedValue({ status: 'success' });
+
+    return shallowMount(ExportInstructionsModal, {
+      props: { modelValue: true },
+      global: {
+        plugins: [pinia],
+        stubs: { UnnnicDialogClose: { template: '<div><slot /></div>' } },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    wrapper = createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders the dialog open with the title', () => {
+      expect(findComponent('modal').props('open')).toBe(true);
+      expect(wrapper.text()).toContain(exportT('modal_title'));
+    });
+
+    it('renders the description', () => {
+      expect(find('description').text()).toBe(exportT('modal_description'));
+    });
+
+    it('renders cancel and export buttons with the correct labels', () => {
+      expect(findComponent('cancel').props('text')).toBe(
+        exportT('cancel_button'),
+      );
+      expect(findComponent('export').props('text')).toBe(
+        exportT('export_button'),
+      );
+      expect(findComponent('export').props('type')).toBe('primary');
+    });
+  });
+
+  describe('Interactions', () => {
+    it('emits update:modelValue false when the dialog requests to close', async () => {
+      await findComponent('modal').vm.$emit('update:open', false);
+
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+    });
+
+    it('calls exportInstructions and closes on success', async () => {
+      await findComponent('export').vm.$emit('click');
+      await flushPromises();
+
+      expect(instructionsStore.exportInstructions).toHaveBeenCalledTimes(1);
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+    });
+
+    it('keeps the modal open on error', async () => {
+      instructionsStore.exportInstructions.mockResolvedValue({
+        status: 'error',
+      });
+
+      await findComponent('export').vm.$emit('click');
+      await flushPromises();
+
+      expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+    });
+
+    it('reflects the store loading state on the export button', async () => {
+      instructionsStore.isExportingInstructionsLoading = true;
+      await nextTick();
+
+      expect(findComponent('export').props('loading')).toBe(true);
+    });
+
+    it('does not show loading when the store is not exporting', () => {
+      expect(findComponent('export').props('loading')).toBe(false);
+    });
+  });
+});

--- a/src/components/Instructions/__tests__/InstructionsHeaderActions.spec.js
+++ b/src/components/Instructions/__tests__/InstructionsHeaderActions.spec.js
@@ -16,6 +16,8 @@ describe('InstructionsHeaderActions.vue', () => {
     wrapper.findComponent('[data-testid="new-instruction-button"]');
   const findDrawer = () =>
     wrapper.findComponent('[data-testid="new-instruction-drawer"]');
+  const findExportModal = () =>
+    wrapper.findComponent('[data-testid="export-instructions-modal"]');
 
   const createWrapper = () => {
     const pinia = createTestingPinia();
@@ -48,8 +50,26 @@ describe('InstructionsHeaderActions.vue', () => {
       createWrapper();
 
       expect(findExportButton().props('text')).toBe(
-        i18n.global.t('agents.instructions.export_instructions'),
+        i18n.global.t('agents.instructions.export_instructions.title'),
       );
+    });
+
+    it('opens the export modal when clicked', async () => {
+      createWrapper();
+
+      expect(findExportModal().props('modelValue')).toBe(false);
+
+      await findExportButton().trigger('click');
+
+      expect(findExportModal().props('modelValue')).toBe(true);
+    });
+  });
+
+  describe('ExportInstructionsModal', () => {
+    it('renders the export modal', () => {
+      createWrapper();
+
+      expect(findExportModal().exists()).toBe(true);
     });
   });
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -345,8 +345,16 @@
     "instructions": {
       "title": "Instructions",
       "description": "Define the rules that guide how Manager responds, communicates, and makes decisions",
-      "export_instructions": "Export instructions",
       "new_instruction": "New instruction",
+      "export_instructions": {
+        "title": "Export instructions",
+        "cancel_button": "Cancel",
+        "export_button": "Export",
+        "modal_description": "Instructions will be downloaded as a CSV file, compatible with Excel, Google Sheets, and similar tools",
+        "modal_title": "Export instructions",
+        "success_alert_description": "The CSV file is ready in the downloads folder",
+        "success_alert_title": "Instructions exported"
+      },
       "delete_category": {
         "modal_title": "Delete category",
         "modal_description": "{count} from {name} to Uncategorized. Nothing will be deleted, only the category label is removed.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -345,7 +345,15 @@
     "instructions": {
       "title": "Instrucciones",
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
-      "export_instructions": "Exportar instrucciones",
+      "export_instructions": {
+        "title": "Exportar instrucciones",
+        "cancel_button": "Cancelar",
+        "export_button": "Exportar",
+        "modal_description": "Las instrucciones se descargarán en un archivo CSV, compatible con Excel, Google Sheets y herramientas similares",
+        "modal_title": "Exportar instrucciones",
+        "success_alert_description": "El archivo CSV está listo en la carpeta de descargas",
+        "success_alert_title": "Instrucciones exportadas"
+      },
       "new_instruction": "Nueva instrucción",
       "delete_category": {
         "modal_title": "Eliminar categoría",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -345,7 +345,15 @@
     "instructions": {
       "title": "Instruções",
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
-      "export_instructions": "Exportar instruções",
+      "export_instructions": {
+        "title": "Exportar instruções",
+        "cancel_button": "Cancelar",
+        "export_button": "Exportar",
+        "modal_description": "As instruções serão baixadas em um arquivo CSV, compatível com Excel, Google Sheets e ferramentas similares",
+        "modal_title": "Exportar instruções",
+        "success_alert_description": "O arquivo CSV está pronto na pasta de downloads",
+        "success_alert_title": "Instruções exportadas"
+      },
       "new_instruction": "Nova instrução",
       "delete_category": {
         "modal_title": "Excluir categoria",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -344,7 +344,15 @@
     "instructions": {
       "title": "Instrucțiuni",
       "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
-      "export_instructions": "Exportă instrucțiuni",
+      "export_instructions": {
+        "title": "Exportă instrucțiuni",
+        "cancel_button": "Anulează",
+        "export_button": "Exportă",
+        "modal_description": "Instrucțiunile vor fi descărcate într-un fișier CSV, compatibil cu Excel, Google Sheets și instrumente similare",
+        "modal_title": "Exportă instrucțiuni",
+        "success_alert_description": "Fișierul CSV este gata în folderul de descărcări",
+        "success_alert_title": "Instrucțiuni exportate"
+      },
       "new_instruction": "Instrucțiune nouă",
       "delete_category": {
         "modal_title": "Șterge categoria",

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -520,6 +520,42 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     instructionSuggestedByAI.status = null;
   }
 
+  const isExportingInstructionsLoading = ref(false);
+  async function exportInstructions() {
+    try {
+      isExportingInstructionsLoading.value = true;
+
+      const response = await nexusaiAPI.agent_builder.instructions.export({
+        projectUuid: projectUuid.value,
+      });
+
+      const blob = new Blob([response], { type: 'text/csv' });
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'instructions.csv';
+      a.click();
+      window.URL.revokeObjectURL(url);
+
+      useAlertStore().add({
+        type: 'success',
+        text: i18n.global.t(
+          'agents.instructions.export_instructions.success_alert_title',
+        ),
+        description: i18n.global.t(
+          'agents.instructions.export_instructions.success_alert_description',
+        ),
+      });
+
+      return { status: 'success' };
+    } catch (error) {
+      console.error(error);
+      return { status: 'error' };
+    } finally {
+      isExportingInstructionsLoading.value = false;
+    }
+  }
+
   return {
     instructions,
     categories,
@@ -553,5 +589,8 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     getInstructionSuggestionByAI,
     updateValidateInstructionByAI,
     resetInstructionSuggestedByAI,
+
+    isExportingInstructionsLoading,
+    exportInstructions,
   };
 });

--- a/src/store/__tests__/Instructions.unit.spec.js
+++ b/src/store/__tests__/Instructions.unit.spec.js
@@ -1,5 +1,5 @@
 import { setActivePinia, createPinia } from 'pinia';
-import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { useInstructionsStore } from '@/store/Instructions';
 import { useAlertStore } from '@/store/Alert';
 import nexusaiAPI from '@/api/nexusaiAPI';
@@ -20,6 +20,7 @@ vi.mock('@/api/nexusaiAPI', () => ({
         deleteInstruction: vi.fn(),
         deleteCategory: vi.fn(),
         getSuggestionByAI: vi.fn(),
+        export: vi.fn(),
       },
     },
   },
@@ -415,6 +416,79 @@ describe('Instructions Store', () => {
           text: 'Instruction 3',
           status: 'complete',
         });
+      });
+    });
+
+    describe('exportInstructions', () => {
+      const mockClick = vi.fn();
+      let createElementSpy;
+
+      beforeEach(() => {
+        window.URL.createObjectURL = vi.fn(() => 'blob:mock-url');
+        window.URL.revokeObjectURL = vi.fn();
+        createElementSpy = vi.spyOn(document, 'createElement').mockReturnValue({
+          href: '',
+          download: '',
+          click: mockClick,
+        });
+      });
+
+      afterEach(() => {
+        createElementSpy.mockRestore();
+      });
+
+      it('downloads the CSV and shows a success alert', async () => {
+        const csvData = 'instruction,category\nHello,Sales';
+        nexusaiAPI.agent_builder.instructions.export.mockResolvedValue(csvData);
+
+        const result = await store.exportInstructions();
+
+        expect(
+          nexusaiAPI.agent_builder.instructions.export,
+        ).toHaveBeenCalledWith({ projectUuid: 'test-project-uuid' });
+        expect(window.URL.createObjectURL).toHaveBeenCalled();
+        expect(mockClick).toHaveBeenCalled();
+        expect(window.URL.revokeObjectURL).toHaveBeenCalledWith(
+          'blob:mock-url',
+        );
+        expect(alertStore.add).toHaveBeenCalledWith({
+          type: 'success',
+          text: i18n.global.t(
+            'agents.instructions.export_instructions.success_alert_title',
+          ),
+          description: i18n.global.t(
+            'agents.instructions.export_instructions.success_alert_description',
+          ),
+        });
+        expect(result).toEqual({ status: 'success' });
+      });
+
+      it('sets loading while exporting and clears it afterward', async () => {
+        nexusaiAPI.agent_builder.instructions.export.mockImplementation(() => {
+          expect(store.isExportingInstructionsLoading).toBe(true);
+          return Promise.resolve('csv');
+        });
+
+        await store.exportInstructions();
+
+        expect(store.isExportingInstructionsLoading).toBe(false);
+      });
+
+      it('returns error status when the export request fails', async () => {
+        const consoleErrorSpy = vi
+          .spyOn(console, 'error')
+          .mockImplementation(() => {});
+        nexusaiAPI.agent_builder.instructions.export.mockRejectedValue(
+          new Error('API Error'),
+        );
+
+        const result = await store.exportInstructions();
+
+        expect(alertStore.add).not.toHaveBeenCalled();
+        expect(result).toEqual({ status: 'error' });
+        expect(store.isExportingInstructionsLoading).toBe(false);
+
+        consoleErrorSpy.mockRestore();
       });
     });
 


### PR DESCRIPTION
## Description

### Type of Change

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other

### Motivation and Context

Users need the ability to export their instructions as a CSV file for use in external tools such as Excel and Google Sheets.

### Summary of Changes

- Added an `export` method to the `Instructions` API that calls the `instructions/export/` endpoint.
- Created the `ExportInstructionsModal` component, which presents a confirmation dialog before triggering the export.
- Wired the export button in `InstructionsHeaderActions` to open the `ExportInstructionsModal` instead of the previous unimplemented placeholder.
- Added `exportInstructions` and `isExportingInstructionsLoading` to the Instructions store, handling the CSV blob download and displaying a success alert upon completion.
- Expanded the `export_instructions` locale keys across all supported languages (en, es, pt_br, ro) to include modal title, description, cancel/export button labels, and success alert messages.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/8a0a9cfa-b9e5-4fad-9cc2-0d75e6321ae7.png)