### PR TITLE
feat: Add re-validate flow for instruction editing with category preservation and save button state fixes

### DIFF
--- a/src/api/nexus/Instructions.js
+++ b/src/api/nexus/Instructions.js
@@ -105,6 +105,7 @@ export const Instructions = {
     projectUuid,
     instruction,
     instructionsCategories = [],
+    id = null,
   }) {
     const languageMap = {
       en: 'English',
@@ -120,6 +121,7 @@ export const Instructions = {
         instruction,
         instructions_categories: instructionsCategories,
         language,
+        ...(Boolean(id) && { id }),
       },
     );
     return InstructionClassificationAdapter.fromApi(response.data);

--- a/src/components/Instructions/NewInstructionDrawer/Form.vue
+++ b/src/components/Instructions/NewInstructionDrawer/Form.vue
@@ -15,7 +15,7 @@
     <UnnnicButton
       data-testid="new-instruction-drawer-validate-button"
       type="secondary"
-      :text="$t('agents.instructions.new_instruction_drawer.validate')"
+      :text="validateButtonText"
       :disabled="validateButtonDisabled"
     />
   </form>
@@ -23,22 +23,48 @@
 
 <script setup lang="ts">
 import { computed, onMounted, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import { useInstructionsStore } from '@/store/Instructions';
 
+const { t } = useI18n();
 const instructionsStore = useInstructionsStore();
 
 const textareaRef = ref<HTMLTextAreaElement | null>(null);
+
+const drawerT = (key: string) =>
+  t(`agents.instructions.new_instruction_drawer.${key}`);
+
+const validateButtonText = computed(() => {
+  const { status } = instructionsStore.instructionSuggestedByAI;
+  const isEditing = instructionsStore.instructionDrawerMode === 'edit';
+
+  if (isEditing || status === 'complete') {
+    return drawerT('re_validate');
+  }
+
+  return drawerT('validate');
+});
 
 const validateButtonDisabled = computed(() => {
   const instructionSuggestionStatus =
     instructionsStore.instructionSuggestedByAI.status;
   const newInstructionText = instructionsStore.newInstruction.text.trim();
-  return (
-    !newInstructionText ||
-    instructionSuggestionStatus === 'complete' ||
-    instructionSuggestionStatus === 'loading'
-  );
+  const validatedInstructionText =
+    instructionsStore.instructionSuggestedByAI.data.instruction.trim();
+
+  if (!newInstructionText || instructionSuggestionStatus === 'loading') {
+    return true;
+  }
+
+  if (
+    instructionSuggestionStatus === 'complete' &&
+    newInstructionText === validatedInstructionText
+  ) {
+    return true;
+  }
+
+  return false;
 });
 
 function validate() {

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/Form.spec.js
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/Form.spec.js
@@ -27,12 +27,16 @@ describe('NewInstructionDrawer/Form.vue', () => {
     const pinia = createTestingPinia({
       initialState: {
         Instructions: {
+          instructionDrawerMode: 'create',
           newInstruction: {
             text: '',
             status: null,
           },
           instructionSuggestedByAI: {
             status: null,
+            data: {
+              instruction: '',
+            },
           },
           ...initialState,
         },
@@ -67,6 +71,31 @@ describe('NewInstructionDrawer/Form.vue', () => {
     it('renders the validate button with the correct text', () => {
       expect(findComponent('validateButton').props('text')).toBe(
         translation('validate'),
+      );
+    });
+
+    it('renders Re-validate in edit mode before any validation', () => {
+      wrapper = createWrapper({
+        instructionDrawerMode: 'edit',
+        newInstruction: { text: 'Existing instruction', status: null },
+      });
+
+      expect(findComponent('validateButton').props('text')).toBe(
+        translation('re_validate'),
+      );
+    });
+
+    it('renders Re-validate after a completed validation in create mode', () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'Valid text', status: null },
+        instructionSuggestedByAI: {
+          status: 'complete',
+          data: { instruction: 'Valid text' },
+        },
+      });
+
+      expect(findComponent('validateButton').props('text')).toBe(
+        translation('re_validate'),
       );
     });
 
@@ -105,12 +134,26 @@ describe('NewInstructionDrawer/Form.vue', () => {
       expect(findComponent('validateButton').props('disabled')).toBe(true);
     });
 
-    it('disables the validate button when the suggestion status is complete', () => {
+    it('disables the validate button when the suggestion status is complete and the text matches the validated text', () => {
       wrapper = createWrapper({
         newInstruction: { text: 'Valid text', status: null },
-        instructionSuggestedByAI: { status: 'complete' },
+        instructionSuggestedByAI: {
+          status: 'complete',
+          data: { instruction: 'Valid text' },
+        },
       });
       expect(findComponent('validateButton').props('disabled')).toBe(true);
+    });
+
+    it('enables the validate button when the suggestion status is complete but the text changed', () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'Updated text', status: null },
+        instructionSuggestedByAI: {
+          status: 'complete',
+          data: { instruction: 'Valid text' },
+        },
+      });
+      expect(findComponent('validateButton').props('disabled')).toBe(false);
     });
 
     it('enables the validate button when the suggestion status is error and the text has content', () => {

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/index.spec.js
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/index.spec.js
@@ -76,6 +76,24 @@ describe('NewInstructionDrawer/index.vue', () => {
       expect(findComponent('saveButton').props('disabled')).toBe(true);
     });
 
+    it('disables save while AI validation is loading', () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'New rule', category: null, status: null },
+        instructionSuggestedByAI: { status: 'loading' },
+      });
+
+      expect(findComponent('saveButton').props('disabled')).toBe(true);
+    });
+
+    it('disables save when AI validation fails', () => {
+      wrapper = createWrapper({
+        newInstruction: { text: 'New rule', category: null, status: null },
+        instructionSuggestedByAI: { status: 'error' },
+      });
+
+      expect(findComponent('saveButton').props('disabled')).toBe(true);
+    });
+
     it('adds the instruction when saving a validated instruction', async () => {
       wrapper = createWrapper({
         newInstruction: { text: 'New rule', category: null, status: null },
@@ -106,6 +124,24 @@ describe('NewInstructionDrawer/index.vue', () => {
       wrapper = createWrapper(editState);
 
       expect(findComponent('saveButton').props('disabled')).toBe(false);
+    });
+
+    it('disables save while AI validation is loading', () => {
+      wrapper = createWrapper({
+        ...editState,
+        instructionSuggestedByAI: { status: 'loading' },
+      });
+
+      expect(findComponent('saveButton').props('disabled')).toBe(true);
+    });
+
+    it('disables save when AI validation fails', () => {
+      wrapper = createWrapper({
+        ...editState,
+        instructionSuggestedByAI: { status: 'error' },
+      });
+
+      expect(findComponent('saveButton').props('disabled')).toBe(true);
     });
 
     it('updates the instruction when saving', async () => {

--- a/src/components/Instructions/NewInstructionDrawer/index.vue
+++ b/src/components/Instructions/NewInstructionDrawer/index.vue
@@ -88,8 +88,14 @@ const title = computed(() =>
 
 const saveDisabled = computed(() => {
   if (!instructionsStore.newInstruction.text.trim()) return true;
-  if (isEditing.value) return false;
-  return instructionsStore.instructionSuggestedByAI.status !== 'complete';
+
+  const aiStatus = instructionsStore.instructionSuggestedByAI.status;
+
+  if (isEditing.value) {
+    return aiStatus === 'loading' || aiStatus === 'error';
+  }
+
+  return aiStatus !== 'complete';
 });
 
 function close() {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -388,6 +388,7 @@
         "title": "New instruction",
         "edit_title": "Edit instruction",
         "category_label": "Category",
+        "re_validate": "Re-validate",
         "validate": "Validate",
         "save": "Save",
         "cancel": "Cancel",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -388,6 +388,7 @@
         "title": "Nueva instrucción",
         "edit_title": "Editar instrucción",
         "category_label": "Categoría",
+        "re_validate": "Revalidar",
         "validate": "Validar",
         "save": "Guardar",
         "cancel": "Cancelar",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -388,6 +388,7 @@
         "title": "Nova instrução",
         "edit_title": "Editar instrução",
         "category_label": "Categoria",
+        "re_validate": "Revalidar",
         "validate": "Validar",
         "save": "Salvar",
         "cancel": "Cancelar",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -387,6 +387,7 @@
         "title": "Instrucțiune nouă",
         "edit_title": "Editare instrucțiune",
         "category_label": "Categorie",
+        "re_validate": "Revalidează",
         "validate": "Validează",
         "save": "Salvează",
         "cancel": "Anulează",

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -472,6 +472,10 @@ export const useInstructionsStore = defineStore('Instructions', () => {
           instructionsCategories: categories.value.map(
             (category) => category.name,
           ),
+          id:
+            instructionDrawerMode.value === 'edit'
+              ? editingInstructionId.value
+              : null,
         });
 
       const suggestedCategory = data.suggestedCategory ?? '';
@@ -485,7 +489,7 @@ export const useInstructionsStore = defineStore('Instructions', () => {
       instructionSuggestedByAI.suggestionApplied = '';
       instructionSuggestedByAI.status = 'complete';
 
-      if (suggestedCategory) {
+      if (suggestedCategory && instructionDrawerMode.value !== 'edit') {
         const existing = categories.value.find(
           (category) => category.name === suggestedCategory,
         );

--- a/src/store/__tests__/Instructions.unit.spec.js
+++ b/src/store/__tests__/Instructions.unit.spec.js
@@ -826,6 +826,29 @@ describe('Instructions Store', () => {
           name: 'Logistics',
         });
       });
+
+      it('does not overwrite the current category when revalidating in edit mode', async () => {
+        store.instructionDrawerMode = 'edit';
+        store.newInstruction.category = { id: 3, name: 'Tone' };
+        store.categories = [
+          { id: 3, name: 'Tone' },
+          { id: 10, name: 'Sales' },
+        ];
+        nexusaiAPI.agent_builder.instructions.getSuggestionByAI.mockResolvedValue(
+          {
+            classification: [],
+            suggestion: '',
+            suggestedCategory: 'Sales',
+          },
+        );
+
+        await store.getInstructionSuggestionByAI('Some instruction');
+
+        expect(store.newInstruction.category).toEqual({ id: 3, name: 'Tone' });
+        expect(store.instructionSuggestedByAI.data.suggestedCategory).toBe(
+          'Sales',
+        );
+      });
     });
   });
 
@@ -925,6 +948,48 @@ describe('Instructions Store', () => {
       expect(target.text).toBe('Old');
       expect(target.category).toEqual(originalCategory);
       expect(store.newInstruction.status).toBe('error');
+    });
+
+    it('updates only the category when the instruction text is unchanged', async () => {
+      featureFlagsState.categorizationOfInstructions = true;
+      store.instructions.data = [
+        { id: 7, text: 'Be concise', category: { id: 3, name: 'Tone' } },
+      ];
+      const updated = {
+        instructions: [
+          {
+            id: 7,
+            text: 'Be concise',
+            category: { id: 5, name: 'Personality' },
+          },
+        ],
+        categories: [
+          { id: 3, name: 'Tone' },
+          { id: 5, name: 'Personality' },
+        ],
+      };
+      nexusaiAPI.agent_builder.instructions.update.mockResolvedValue(updated);
+
+      store.startEditingInstruction({ id: 7 });
+      store.newInstruction.category = { id: 5, name: 'Personality' };
+
+      await store.updateEditingInstruction();
+
+      expect(store.instructions.data[0]).toEqual({
+        id: 7,
+        text: 'Be concise',
+        category: { id: 5, name: 'Personality' },
+      });
+
+      store.newInstruction.category = { id: 5, name: 'Personality' };
+
+      await store.updateEditingInstruction();
+
+      expect(store.instructions.data[0]).toEqual({
+        id: 7,
+        text: 'Be concise',
+        category: { id: 5, name: 'Personality' },
+      });
     });
   });
 


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other
```

### Motivation and Context

When editing an existing instruction, users needed the ability to re-run AI validation without losing their current category selection or being blocked from saving. Previously, the validate button was permanently disabled after a completed validation, and the save button had no loading/error guards in edit mode.

### Summary of Changes

- The validate button now displays "Re-validate" when in edit mode or after a completed validation, and reverts to "Validate" otherwise. The button is re-enabled when the instruction text has changed since the last validation, allowing users to trigger a new AI suggestion.
- The save button in edit mode is now disabled while AI validation is loading or has errored, preventing saves in an invalid state.
- When re-validating in edit mode, the AI-suggested category no longer overwrites the user's currently selected category. The suggested category is still stored in the AI suggestion data for reference.
- The instruction's `id` is passed to the AI suggestion API when re-validating in edit mode, enabling the backend to use the correct context.
- Added "Re-validate" translations for all supported locales (English, Spanish, Portuguese, and Romanian).

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/27ac1a92-7014-4f70-bd6f-9a32c822c23a.png)

