### PR TITLE
feat: Refine instruction categorization with uncategorized group, duplicate validation, alphabetical ordering, and per-instruction update API

### DIFF
--- a/src/api/adapters/instructions/__tests__/grouped.spec.js
+++ b/src/api/adapters/instructions/__tests__/grouped.spec.js
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+
+import { InstructionsGroupedAdapter } from '../grouped';
+
+describe('InstructionsGroupedAdapter.toUpdateApi', () => {
+  it('builds a categories payload for an existing category', () => {
+    expect(
+      InstructionsGroupedAdapter.toUpdateApi({
+        id: 7,
+        text: 'New text',
+        category: { id: 5 },
+      }),
+    ).toEqual({
+      categories: [
+        {
+          id: 5,
+          instructions: [{ id: 7, instruction: 'New text' }],
+        },
+      ],
+    });
+  });
+
+  it('builds an uncategorized payload when category is omitted', () => {
+    expect(
+      InstructionsGroupedAdapter.toUpdateApi({
+        id: 7,
+        text: 'New text',
+      }),
+    ).toEqual({
+      uncategorized_instructions: [{ id: 7, instruction: 'New text' }],
+    });
+  });
+
+  it('builds a categories payload with name when assigning a new category', () => {
+    expect(
+      InstructionsGroupedAdapter.toUpdateApi({
+        id: 7,
+        text: 'New text',
+        category: { name: 'Marketing' },
+      }),
+    ).toEqual({
+      categories: [
+        {
+          name: 'Marketing',
+          instructions: [{ id: 7, instruction: 'New text' }],
+        },
+      ],
+    });
+  });
+
+  it('trims instruction text', () => {
+    expect(
+      InstructionsGroupedAdapter.toUpdateApi({
+        id: 7,
+        text: '  New text  ',
+        category: { id: 5 },
+      }),
+    ).toEqual({
+      categories: [
+        {
+          id: 5,
+          instructions: [{ id: 7, instruction: 'New text' }],
+        },
+      ],
+    });
+  });
+});

--- a/src/api/adapters/instructions/grouped.js
+++ b/src/api/adapters/instructions/grouped.js
@@ -33,20 +33,36 @@ export const InstructionsGroupedAdapter = {
     return body;
   },
 
-  toUpdateApi({ categories = [], uncategorizedInstructions = [] } = {}) {
-    const toApiInstruction = ({ id, text }) => ({
+  toUpdateApi({ id, text, category }) {
+    const instructionItem = {
       id,
-      instruction: text,
-    });
+      instruction: text.trim(),
+    };
+
+    if (!category) {
+      return {
+        uncategorized_instructions: [instructionItem],
+      };
+    }
+
+    if (category.id != null) {
+      return {
+        categories: [
+          {
+            id: category.id,
+            instructions: [instructionItem],
+          },
+        ],
+      };
+    }
 
     return {
-      categories: categories.map((category) => ({
-        id: category.id,
-        name: category.name,
-        instructions: (category.instructions || []).map(toApiInstruction),
-      })),
-      uncategorized_instructions:
-        uncategorizedInstructions.map(toApiInstruction),
+      categories: [
+        {
+          name: category.name,
+          instructions: [instructionItem],
+        },
+      ],
     };
   },
 };

--- a/src/api/nexus/Instructions.js
+++ b/src/api/nexus/Instructions.js
@@ -29,10 +29,14 @@ export const Instructions = {
     return InstructionsGroupedAdapter.fromApi(response.data);
   },
 
-  async update({ projectUuid, ...groupedPayload }) {
+  async update({ projectUuid, id, instruction, category }) {
     const response = await request.$http.patch(
       `api/${projectUuid}/instructions/`,
-      InstructionsGroupedAdapter.toUpdateApi(groupedPayload),
+      InstructionsGroupedAdapter.toUpdateApi({
+        id,
+        text: instruction,
+        category,
+      }),
     );
 
     return InstructionsGroupedAdapter.fromApi(response.data);
@@ -127,9 +131,25 @@ export const Instructions = {
     return InstructionClassificationAdapter.fromApi(response.data);
   },
 
-  async export({ projectUuid }) {
-    const response = await request.$http.get(
+  async export({
+    projectUuid,
+    columns,
+    categoryLabels,
+    defaultInstructions = [],
+  }) {
+    const response = await request.$http.post(
       `api/${projectUuid}/instructions/export/`,
+      {
+        columns,
+        category_labels: categoryLabels,
+        default_instructions: defaultInstructions,
+      },
+      {
+        headers: {
+          Accept: 'text/csv',
+        },
+        responseType: 'text',
+      },
     );
 
     return response.data;

--- a/src/components/Instructions/InstructionsCategorization/CategoryAccordion.vue
+++ b/src/components/Instructions/InstructionsCategorization/CategoryAccordion.vue
@@ -84,6 +84,7 @@ import { useI18n } from 'vue-i18n';
 
 import ContentItemActions from '@/components/ContentItemActions.vue';
 import Instruction from '@/components/Instructions/Instruction.vue';
+import { INSTRUCTION_GROUP_KEYS } from '@/store/helpers/instructionViewModels';
 
 const props = defineProps({
   group: {
@@ -115,7 +116,14 @@ watch(
   { immediate: true },
 );
 
-const lockedTooltip = computed(() => viewT('locked_tooltip'));
+const lockedTooltip = computed(() => {
+  const tooltips = {
+    [INSTRUCTION_GROUP_KEYS.uncategorized]: viewT('uncategorized_tooltip'),
+    [INSTRUCTION_GROUP_KEYS.default]: viewT('locked_tooltip'),
+  };
+
+  return tooltips[props.group.key];
+});
 const emptyText = computed(() => viewT('empty_category'));
 
 const actions = computed(() => [

--- a/src/components/Instructions/InstructionsCategorization/ListInstructionRow.vue
+++ b/src/components/Instructions/InstructionsCategorization/ListInstructionRow.vue
@@ -56,6 +56,7 @@ import { useInstructionsStore } from '@/store/Instructions';
 
 import ContentItemActions from '@/components/ContentItemActions.vue';
 import ModalRemoveInstruction from '@/components/Instructions/ModalRemoveInstruction.vue';
+import { INSTRUCTION_GROUP_KEYS } from '@/store/helpers/instructionViewModels';
 
 const props = defineProps({
   instruction: {
@@ -67,6 +68,7 @@ const props = defineProps({
 const emit = defineEmits(['edit']);
 
 const { t } = useI18n();
+const viewT = (key) => t(`agents.instructions.view.${key}`);
 
 const instructionsStore = useInstructionsStore();
 
@@ -85,9 +87,18 @@ const removeTarget = computed(() => ({
   status: status.value,
 }));
 
-const lockedTooltip = computed(() =>
-  t('agents.instructions.view.locked_tooltip'),
-);
+const lockedTooltip = computed(() => {
+  const tooltips = {
+    [INSTRUCTION_GROUP_KEYS.uncategorized]: viewT('uncategorized_tooltip'),
+    [INSTRUCTION_GROUP_KEYS.default]: viewT('locked_tooltip'),
+  };
+
+  const key = props.instruction.locked
+    ? INSTRUCTION_GROUP_KEYS.default
+    : INSTRUCTION_GROUP_KEYS.uncategorized;
+
+  return tooltips[key];
+});
 
 const actions = computed(() => [
   {

--- a/src/components/Instructions/InstructionsCategorization/__tests__/CategoryAccordion.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/CategoryAccordion.spec.js
@@ -26,6 +26,14 @@ const lockedGroup = (overrides = {}) => ({
   ...overrides,
 });
 
+const uncategorizedGroup = (overrides = {}) => ({
+  key: 'uncategorized',
+  label: viewT('uncategorized'),
+  locked: true,
+  instructions: [{ id: 1, text: 'Loose instruction' }],
+  ...overrides,
+});
+
 describe('CategoryAccordion.vue', () => {
   let wrapper;
 
@@ -95,15 +103,29 @@ describe('CategoryAccordion.vue', () => {
     expect(wrapper.emitted('delete-category')).toEqual([[group]]);
   });
 
-  it('renders a locked tag with tooltip and no menu for locked groups', () => {
+  it('renders a locked tag with tooltip and no menu for default groups', () => {
     wrapper = createWrapper(lockedGroup());
 
     expect(find('tag').attributes('lefticon')).toBe('lock');
     expect(find('lockedTooltip').exists()).toBe(true);
+    expect(find('lockedTooltip').attributes('enabled')).toBe('true');
     expect(find('lockedTooltip').attributes('text')).toBe(
       viewT('locked_tooltip'),
     );
     expect(find('actions').exists()).toBe(false);
+  });
+
+  it('renders a locked tag with uncategorized tooltip and keeps instruction actions for uncategorized groups', () => {
+    wrapper = createWrapper(uncategorizedGroup());
+
+    expect(find('tag').attributes('lefticon')).toBe('lock');
+    expect(find('lockedTooltip').exists()).toBe(true);
+    expect(find('lockedTooltip').attributes('enabled')).toBe('true');
+    expect(find('lockedTooltip').attributes('text')).toBe(
+      viewT('uncategorized_tooltip'),
+    );
+    expect(find('actions').exists()).toBe(false);
+    expect(wrapper.findComponent(Instruction).props('showActions')).toBe(true);
   });
 
   it('disables instruction actions for locked items', () => {

--- a/src/components/Instructions/InstructionsCategorization/__tests__/ListInstructionRow.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/ListInstructionRow.spec.js
@@ -88,18 +88,24 @@ describe('ListInstructionRow.vue', () => {
 
     expect(find('tag').attributes('lefticon')).toBe('lock');
     expect(find('lockedTooltip').exists()).toBe(true);
+    expect(find('lockedTooltip').attributes('enabled')).toBe('true');
     expect(find('lockedTooltip').attributes('text')).toBe(
       i18n.global.t('agents.instructions.view.locked_tooltip'),
     );
     expect(find('actions').exists()).toBe(false);
   });
 
-  it('keeps the actions menu for an uncategorized row with a locked tag', () => {
+  it('renders a locked tag with uncategorized tooltip and keeps the actions menu', () => {
     wrapper = createWrapper(
       customItem({ categoryLabel: 'Uncategorized', categoryLocked: true }),
     );
 
     expect(find('tag').attributes('lefticon')).toBe('lock');
+    expect(find('lockedTooltip').exists()).toBe(true);
+    expect(find('lockedTooltip').attributes('enabled')).toBe('true');
+    expect(find('lockedTooltip').attributes('text')).toBe(
+      i18n.global.t('agents.instructions.view.uncategorized_tooltip'),
+    );
     expect(find('actions').exists()).toBe(true);
   });
 

--- a/src/components/Instructions/ModalRemoveCategory.vue
+++ b/src/components/Instructions/ModalRemoveCategory.vue
@@ -15,10 +15,13 @@
       <i18n-t
         tag="p"
         class="modal-remove-category__description"
-        keypath="agents.instructions.delete_category.modal_description"
+        :keypath="modalDescriptionKey"
         data-testid="description"
       >
-        <template #count>
+        <template
+          v-if="instructionsCount > 0"
+          #count
+        >
           {{
             t('agents.instructions.delete_category.instructions_count', {
               count: instructionsCount,
@@ -85,6 +88,12 @@ const instructionsCount = computed(
     instructionsStore.instructions.data.filter(
       (instruction) => instruction.category?.id === props.category.id,
     ).length,
+);
+
+const modalDescriptionKey = computed(() =>
+  instructionsCount.value > 0
+    ? 'agents.instructions.delete_category.modal_description'
+    : 'agents.instructions.delete_category.modal_description_empty',
 );
 
 function close() {

--- a/src/components/Instructions/NewInstructionDrawer/CategoryCreateForm.vue
+++ b/src/components/Instructions/NewInstructionDrawer/CategoryCreateForm.vue
@@ -58,6 +58,8 @@ import { useI18n } from 'vue-i18n';
 
 import { UnnnicPopoverFooter } from '@weni/unnnic-system';
 
+import { useInstructionsStore } from '@/store/Instructions';
+
 import { useCategoryValidation } from './useCategoryValidation';
 
 const MAX_LENGTH = 50;
@@ -71,10 +73,16 @@ const { t } = useI18n();
 const categoryT = (key: string) =>
   t(`agents.instructions.new_instruction_drawer.ai_analysis.category.${key}`);
 
+const instructionsStore = useInstructionsStore();
+
 const name = ref('');
 const touched = ref(false);
 
-const { error, isValid } = useCategoryValidation(name);
+const existingNames = computed(() =>
+  instructionsStore.categoryOptions.map((category) => category.name),
+);
+
+const { error, isValid } = useCategoryValidation(name, existingNames);
 
 const displayedErrors = computed(() =>
   touched.value && error.value ? [error.value] : [],

--- a/src/components/Instructions/NewInstructionDrawer/SuggestedCategory.vue
+++ b/src/components/Instructions/NewInstructionDrawer/SuggestedCategory.vue
@@ -120,6 +120,7 @@ import { UnnnicPopoverOption } from '@weni/unnnic-system';
 const { t } = useI18n();
 const categoryT = (key: string) =>
   t(`agents.instructions.new_instruction_drawer.ai_analysis.category.${key}`);
+const viewT = (key: string) => t(`agents.instructions.view.${key}`);
 
 const instructionsStore = useInstructionsStore();
 
@@ -139,23 +140,47 @@ const suggestedCategoryIsNew = computed(
 );
 
 const selectedLabel = computed(
-  () => selectedCategory.value?.name ?? categoryT('placeholder'),
+  () => selectedCategory.value?.name ?? viewT('uncategorized'),
 );
 
-const otherCategories = computed(() =>
-  categoryOptions.value.filter(
-    (option) => option.name !== suggestedCategory.value?.name,
-  ),
-);
+const uncategorizedOption = computed<InstructionCategory>(() => ({
+  id: null,
+  name: viewT('uncategorized'),
+}));
+
+const otherCategories = computed(() => {
+  const uncategorizedName = uncategorizedOption.value.name;
+
+  const filtered = categoryOptions.value.filter(
+    (option) =>
+      option.name !== suggestedCategory.value?.name &&
+      option.name !== uncategorizedName,
+  );
+
+  return [uncategorizedOption.value, ...filtered];
+});
+
+function isUncategorizedOption(option: InstructionCategory) {
+  return option.name === uncategorizedOption.value.name;
+}
 
 function isActive(option: InstructionCategory | null) {
+  if (!option) return false;
+
+  if (isUncategorizedOption(option)) {
+    return selectedCategory.value === null;
+  }
+
   const selected = selectedCategory.value;
-  return !!selected && !!option && selected.name === option.name;
+  return !!selected && selected.name === option.name;
 }
 
 function selectCategory(option: InstructionCategory | null) {
   if (!option) return;
-  instructionsStore.newInstruction.category = { ...option };
+
+  instructionsStore.newInstruction.category = isUncategorizedOption(option)
+    ? null
+    : { ...option };
   isOpen.value = false;
 }
 
@@ -175,7 +200,7 @@ function handleOpenChange(open: boolean) {
   padding: 0;
 
   width: 320px;
-  height: 300px;
+  height: 240px;
 }
 </style>
 
@@ -223,6 +248,9 @@ function handleOpenChange(open: boolean) {
     gap: $unnnic-space-4;
 
     padding: $unnnic-space-4;
+
+    overflow: auto;
+    height: 100%;
   }
 
   &__category-section {

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/SuggestedCategory.spec.js
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/SuggestedCategory.spec.js
@@ -47,6 +47,8 @@ const categoryT = (key) =>
     `agents.instructions.new_instruction_drawer.ai_analysis.category.${key}`,
   );
 
+const viewT = (key) => i18n.global.t(`agents.instructions.view.${key}`);
+
 describe('NewInstructionDrawer/SuggestedCategory.vue', () => {
   let wrapper;
   let store;
@@ -148,7 +150,7 @@ describe('NewInstructionDrawer/SuggestedCategory.vue', () => {
       expect(find('newTag').text()).toBe(categoryT('new_badge'));
     });
 
-    it('falls back to the placeholder when no category is selected', () => {
+    it('shows uncategorized when no category is selected', () => {
       wrapper = createWrapper({
         newInstruction: {
           text: 'My instruction',
@@ -157,7 +159,7 @@ describe('NewInstructionDrawer/SuggestedCategory.vue', () => {
         },
       });
 
-      expect(find('value').text()).toBe(categoryT('placeholder'));
+      expect(find('value').text()).toBe(viewT('uncategorized'));
     });
   });
 
@@ -229,15 +231,39 @@ describe('NewInstructionDrawer/SuggestedCategory.vue', () => {
   });
 
   describe('Other categories section', () => {
-    it('renders the categories excluding the suggested one', () => {
+    it('renders uncategorized and the categories excluding the suggested one', () => {
       const options = wrapper.findAll(
         '[data-testid^="suggested-category-option-"]',
       );
 
       expect(options.map((option) => option.text())).toEqual([
+        viewT('uncategorized'),
         'Sales',
         'Support',
       ]);
+    });
+
+    it('marks uncategorized as active when no category is selected', () => {
+      wrapper = createWrapper({
+        newInstruction: {
+          text: 'My instruction',
+          category: null,
+          status: null,
+        },
+      });
+
+      expect(findOption(viewT('uncategorized')).attributes('data-active')).toBe(
+        'true',
+      );
+    });
+
+    it('sets category to null when uncategorized is selected', async () => {
+      await findOption('Support').trigger('click');
+      expect(store.newInstruction.category).toEqual({ id: 2, name: 'Support' });
+
+      await findOption(viewT('uncategorized')).trigger('click');
+
+      expect(store.newInstruction.category).toBeNull();
     });
 
     it('marks an option as active when it is the selected category', () => {

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/index.spec.js
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/index.spec.js
@@ -110,7 +110,16 @@ describe('NewInstructionDrawer/index.vue', () => {
     const editState = {
       instructionDrawerMode: 'edit',
       editingInstructionId: 1,
+      instructions: {
+        data: [{ id: 1, text: 'Be concise', category: null }],
+        status: 'complete',
+      },
       newInstruction: { text: 'Be concise', category: null, status: null },
+    };
+
+    const editStateWithChanges = {
+      ...editState,
+      newInstruction: { text: 'Updated rule', category: null, status: null },
     };
 
     it('renders the edit title and the standalone category section', () => {
@@ -120,8 +129,14 @@ describe('NewInstructionDrawer/index.vue', () => {
       expect(find('category').exists()).toBe(true);
     });
 
-    it('enables save without requiring AI validation', () => {
+    it('disables save when no edits were made', () => {
       wrapper = createWrapper(editState);
+
+      expect(findComponent('saveButton').props('disabled')).toBe(true);
+    });
+
+    it('enables save without requiring AI validation when edits were made', () => {
+      wrapper = createWrapper(editStateWithChanges);
 
       expect(findComponent('saveButton').props('disabled')).toBe(false);
     });
@@ -145,7 +160,7 @@ describe('NewInstructionDrawer/index.vue', () => {
     });
 
     it('updates the instruction when saving', async () => {
-      wrapper = createWrapper(editState);
+      wrapper = createWrapper(editStateWithChanges);
 
       await findComponent('saveButton').trigger('click');
 

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/useCategoryValidation.spec.ts
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/useCategoryValidation.spec.ts
@@ -13,19 +13,23 @@ const validationT = (key: string) =>
 
 type ValidationResult = ReturnType<typeof useCategoryValidation>;
 
-const setup = (initialName = '') => {
+const setup = (initialName = '', existingNames: string[] = []) => {
   const name = ref(initialName);
+  const existing = ref(existingNames);
   let validation: ValidationResult;
 
   const wrapper = mount({
     template: '<div />',
     setup() {
-      validation = useCategoryValidation(name as Ref<string>);
+      validation = useCategoryValidation(
+        name as Ref<string>,
+        existing as Ref<string[]>,
+      );
       return {};
     },
   });
 
-  return { name, validation: validation!, wrapper };
+  return { name, existing, validation: validation!, wrapper };
 };
 
 describe('useCategoryValidation', () => {
@@ -73,5 +77,61 @@ describe('useCategoryValidation', () => {
 
     expect(validation.isValid.value).toBe(true);
     expect(validation.error.value).toBeNull();
+  });
+
+  it('returns the already exists message when the name matches an existing category', () => {
+    const { validation } = setup('Sales', ['Sales', 'Support']);
+
+    expect(validation.error.value).toBe(validationT('already_exists'));
+    expect(validation.isValid.value).toBe(false);
+  });
+
+  it('treats duplicate names as case-insensitive', () => {
+    const { validation } = setup('sales', ['Sales']);
+
+    expect(validation.error.value).toBe(validationT('already_exists'));
+    expect(validation.isValid.value).toBe(false);
+  });
+
+  it('is valid when the name does not match any existing category', () => {
+    const { validation } = setup('Logistics', ['Sales', 'Support']);
+
+    expect(validation.error.value).toBeNull();
+    expect(validation.isValid.value).toBe(true);
+  });
+
+  it('blocks the fixed uncategorized name in every locale', () => {
+    const reservedNames = i18n.global.availableLocales.map((locale) =>
+      String(
+        i18n.global.t('agents.instructions.view.uncategorized', {}, { locale }),
+      ),
+    );
+
+    expect(reservedNames).toEqual(
+      expect.arrayContaining([
+        'Uncategorized',
+        'Sem categoria',
+        'Sin categoría',
+        'Fără categorie',
+      ]),
+    );
+
+    reservedNames.forEach((reservedName) => {
+      const { validation } = setup(reservedName);
+
+      expect(validation.error.value).toBe(validationT('already_exists'));
+      expect(validation.isValid.value).toBe(false);
+    });
+  });
+
+  it('reacts when the existing names list changes', () => {
+    const { existing, validation } = setup('Sales', []);
+
+    expect(validation.isValid.value).toBe(true);
+
+    existing.value = ['Sales'];
+
+    expect(validation.error.value).toBe(validationT('already_exists'));
+    expect(validation.isValid.value).toBe(false);
   });
 });

--- a/src/components/Instructions/NewInstructionDrawer/index.vue
+++ b/src/components/Instructions/NewInstructionDrawer/index.vue
@@ -92,7 +92,11 @@ const saveDisabled = computed(() => {
   const aiStatus = instructionsStore.instructionSuggestedByAI.status;
 
   if (isEditing.value) {
-    return aiStatus === 'loading' || aiStatus === 'error';
+    return (
+      !instructionsStore.hasEditingInstructionChanges ||
+      aiStatus === 'loading' ||
+      aiStatus === 'error'
+    );
   }
 
   return aiStatus !== 'complete';
@@ -130,6 +134,8 @@ async function save() {
   display: flex;
   flex-direction: column;
   gap: $unnnic-space-6;
+
+  overflow-y: auto;
 
   &__category {
     display: flex;

--- a/src/components/Instructions/NewInstructionDrawer/useCategoryValidation.ts
+++ b/src/components/Instructions/NewInstructionDrawer/useCategoryValidation.ts
@@ -2,9 +2,25 @@ import { computed, unref } from 'vue';
 import type { Ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
-const ALLOWED_CHARS = /^[\p{L}\p{N}\s-]+$/u;
+import i18n from '@/utils/plugins/i18n';
 
-export function useCategoryValidation(name: Ref<string> | string) {
+const ALLOWED_CHARS = /^[\p{L}\p{N}\s-]+$/u;
+const UNCATEGORIZED_KEY = 'agents.instructions.view.uncategorized';
+
+function namesMatch(a: string, b: string) {
+  return a.localeCompare(b, undefined, { sensitivity: 'base' }) === 0;
+}
+
+function getReservedCategoryNames(): string[] {
+  return i18n.global.availableLocales.map((locale) =>
+    String(i18n.global.t(UNCATEGORIZED_KEY, {}, { locale })),
+  );
+}
+
+export function useCategoryValidation(
+  name: Ref<string> | string,
+  existingNames: Ref<string[]> | string[] = [],
+) {
   const { t } = useI18n();
 
   const validationT = (key: string) =>
@@ -19,6 +35,15 @@ export function useCategoryValidation(name: Ref<string> | string) {
 
     if (!value) return validationT('required');
     if (!ALLOWED_CHARS.test(value)) return validationT('invalid_chars');
+
+    const blockedNames = [
+      ...getReservedCategoryNames(),
+      ...unref(existingNames),
+    ];
+    const alreadyExists = blockedNames.some((existing) =>
+      namesMatch(existing, value),
+    );
+    if (alreadyExists) return validationT('already_exists');
 
     return null;
   });

--- a/src/components/Instructions/__tests__/ModalRemoveCategory.spec.js
+++ b/src/components/Instructions/__tests__/ModalRemoveCategory.spec.js
@@ -89,6 +89,18 @@ describe('ModalRemoveCategory.vue', () => {
       );
     });
 
+    it('renders the empty category description when the category has no instructions', () => {
+      wrapper.unmount();
+      wrapper = createWrapper([
+        { id: 3, text: 'C', category: { id: 20, name: 'Support' } },
+      ]);
+
+      expect(find('description').attributes('keypath')).toBe(
+        'agents.instructions.delete_category.modal_description_empty',
+      );
+      expect(find('name').text()).toBe(category.name);
+    });
+
     it('renders cancel and confirm buttons with the correct labels', () => {
       expect(findComponent('cancel').props('text')).toBe(categoryT('cancel'));
       expect(findComponent('confirm').props('text')).toBe(categoryT('confirm'));

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -358,11 +358,13 @@
       "delete_category": {
         "modal_title": "Delete category",
         "modal_description": "{count} from {name} to Uncategorized. Nothing will be deleted, only the category label is removed.",
+        "modal_description_empty": "{name} has no instructions. Deleting it will only remove it from your list",
         "instructions_count": "{count, plural, one {{count} instruction will be moved} other {{count} instructions will be moved}}",
         "cancel": "Cancel",
         "confirm": "Delete category",
         "success_title": "Category deleted",
         "success_description": "{count, plural, one {{count} instruction moved to Uncategorized} other {{count} instructions moved to Uncategorized}}",
+        "success_description_empty": "Removed from your list",
         "error_title": "Couldn't delete category",
         "error_description": "Something went wrong and nothing was changed. Try again."
       },
@@ -382,7 +384,8 @@
           "categories": "Categories",
           "list": "List"
         },
-        "uncategorized": "Uncategorized"
+        "uncategorized": "Uncategorized",
+        "uncategorized_tooltip": "Instructions without a category appear here\nThis group can't be removed"
       },
       "new_instruction_drawer": {
         "title": "New instruction",
@@ -417,12 +420,12 @@
             "create_title": "Create category",
             "name_label": "Category name",
             "name_placeholder": "Name",
-            "placeholder": "Select...",
             "cancel": "Cancel",
             "create": "Create",
             "validation": {
-              "required": "Complete this field",
-              "invalid_chars": "Use only letters, numbers, spaces, and hyphens"
+              "already_exists": "Enter a category name that doesn't already exist",
+              "invalid_chars": "Use only letters, numbers, spaces, and hyphens",
+              "required": "Complete this field"
             }
           }
         }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -358,11 +358,13 @@
       "delete_category": {
         "modal_title": "Eliminar categoría",
         "modal_description": "{count} de {name} a Sin categoría. No se eliminará nada, solo se quita la etiqueta de la categoría.",
+        "modal_description_empty": "{name} no tiene instrucciones. Eliminarla solo la quitará de tu lista",
         "instructions_count": "{count, plural, one {{count} instrucción se moverá} other {{count} instrucciones se moverán}}",
         "cancel": "Cancelar",
         "confirm": "Eliminar categoría",
         "success_title": "Categoría eliminada",
         "success_description": "{count, plural, one {{count} instrucción movida a Sin categoría} other {{count} instrucciones movidas a Sin categoría}}",
+        "success_description_empty": "Eliminada de tu lista",
         "error_title": "No se pudo eliminar la categoría",
         "error_description": "Algo salió mal y no se cambió nada. Inténtalo de nuevo."
       },
@@ -382,7 +384,8 @@
           "categories": "Categorías",
           "list": "Lista"
         },
-        "uncategorized": "Sin categoría"
+        "uncategorized": "Sin categoría",
+        "uncategorized_tooltip": "Las instrucciones sin categoría aparecen aquí\nEste grupo no se puede eliminar"
       },
       "new_instruction_drawer": {
         "title": "Nueva instrucción",
@@ -417,12 +420,12 @@
             "create_title": "Crear categoría",
             "name_label": "Nombre de la categoría",
             "name_placeholder": "Nombre",
-            "placeholder": "Seleccionar...",
             "cancel": "Cancelar",
             "create": "Crear",
             "validation": {
-              "required": "Completa este campo",
-              "invalid_chars": "Usa solo letras, números, espacios y guiones"
+              "already_exists": "Ingresa un nombre de categoría que no exista",
+              "invalid_chars": "Usa solo letras, números, espacios y guiones",
+              "required": "Completa este campo"
             }
           }
         }

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -358,11 +358,13 @@
       "delete_category": {
         "modal_title": "Excluir categoria",
         "modal_description": "{count} de {name} para Sem categoria. Nada será excluído, apenas o rótulo da categoria é removido.",
+        "modal_description_empty": "{name} não tem instruções. Excluí-la só a removerá da sua lista",
         "instructions_count": "{count, plural, one {{count} instrução será movida} other {{count} instruções serão movidas}}",
         "cancel": "Cancelar",
         "confirm": "Excluir categoria",
         "success_title": "Categoria excluída",
         "success_description": "{count, plural, one {{count} instrução movida para Sem categoria} other {{count} instruções movidas para Sem categoria}}",
+        "success_description_empty": "Removida da sua lista",
         "error_title": "Não foi possível excluir a categoria",
         "error_description": "Algo deu errado e nada foi alterado. Tente novamente."
       },
@@ -382,7 +384,8 @@
           "categories": "Categorias",
           "list": "Lista"
         },
-        "uncategorized": "Sem categoria"
+        "uncategorized": "Sem categoria",
+        "uncategorized_tooltip": "Instruções sem categoria aparecem aqui\nEste grupo não pode ser removido"
       },
       "new_instruction_drawer": {
         "title": "Nova instrução",
@@ -417,12 +420,12 @@
             "create_title": "Criar categoria",
             "name_label": "Nome da categoria",
             "name_placeholder": "Nome",
-            "placeholder": "Selecionar...",
             "cancel": "Cancelar",
             "create": "Criar",
             "validation": {
-              "required": "Preencha este campo",
-              "invalid_chars": "Use apenas letras, números, espaços e hifens"
+              "already_exists": "Insira um nome de categoria que não exista",
+              "invalid_chars": "Use apenas letras, números, espaços e hifens",
+              "required": "Preencha este campo"
             }
           }
         }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -357,11 +357,13 @@
       "delete_category": {
         "modal_title": "Șterge categoria",
         "modal_description": "{count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
+        "modal_description_empty": "{name} nu are instrucțiuni. Ștergerea o va elimina doar din listă",
         "instructions_count": "{count, plural, one {{count} instrucțiune va fi mutată} other {{count} instrucțiuni vor fi mutate}}",
         "cancel": "Anulează",
         "confirm": "Șterge categoria",
         "success_title": "Categorie ștearsă",
         "success_description": "{count, plural, one {{count} instrucțiune mutată în Fără categorie} other {{count} instrucțiuni mutate în Fără categorie}}",
+        "success_description_empty": "Eliminată din listă",
         "error_title": "Categoria nu a putut fi ștearsă",
         "error_description": "Ceva nu a funcționat și nimic nu a fost modificat. Încearcă din nou."
       },
@@ -381,7 +383,8 @@
           "categories": "Categorii",
           "list": "Listă"
         },
-        "uncategorized": "Fără categorie"
+        "uncategorized": "Fără categorie",
+        "uncategorized_tooltip": "Instrucțiunile fără categorie apar aici\nAcest grup nu poate fi eliminat"
       },
       "new_instruction_drawer": {
         "title": "Instrucțiune nouă",
@@ -416,12 +419,12 @@
             "create_title": "Creează categorie",
             "name_label": "Numele categoriei",
             "name_placeholder": "Nume",
-            "placeholder": "Selectează...",
             "cancel": "Anulează",
             "create": "Creează",
             "validation": {
-              "required": "Completează acest câmp",
-              "invalid_chars": "Folosește doar litere, cifre, spații și cratime"
+              "already_exists": "Introdu un nume de categorie care nu există deja",
+              "invalid_chars": "Folosește doar litere, cifre, spații și cratime",
+              "required": "Completează acest câmp"
             }
           }
         }

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -35,6 +35,19 @@ function callAlert(type, alertText, descriptionKey?: string) {
   });
 }
 
+function categoriesEqual(
+  current: InstructionCategory | null,
+  original: InstructionCategory | null,
+) {
+  if (current === original) return true;
+  if (!current || !original) return false;
+  if (current.id !== null && original.id !== null) {
+    return current.id === original.id;
+  }
+
+  return current.name === original.name;
+}
+
 export const useInstructionsStore = defineStore('Instructions', () => {
   const projectUuid = computed(() => useProjectStore().uuid);
   const featureFlags = useFeatureFlagsStore();
@@ -106,41 +119,9 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     newInstruction.category = { id: null, name: trimmedName };
   }
 
-  function toCategoryPayload() {
-    const category = newInstruction.category;
+  function toCategoryPayload(category = newInstruction.category) {
     if (!category) return undefined;
     return category.id !== null ? { id: category.id } : { name: category.name };
-  }
-
-  function toGroupedPayload() {
-    type GroupedItem = { id: number; text: string };
-    const categoriesById = new Map<
-      number,
-      { id: number; name: string; instructions: GroupedItem[] }
-    >();
-    const uncategorizedInstructions: GroupedItem[] = [];
-
-    instructions.data.forEach((instruction) => {
-      const item = { id: instruction.id, text: instruction.text };
-
-      if (instruction.category) {
-        const { id, name } = instruction.category;
-        const group = categoriesById.get(id) ?? {
-          id,
-          name,
-          instructions: [],
-        };
-        group.instructions.push(item);
-        categoriesById.set(id, group);
-      } else {
-        uncategorizedInstructions.push(item);
-      }
-    });
-
-    return {
-      categories: [...categoriesById.values()],
-      uncategorizedInstructions,
-    };
   }
 
   const storedValidation = moduleStorage.getItem('validateInstructionByAI');
@@ -165,6 +146,23 @@ export const useInstructionsStore = defineStore('Instructions', () => {
   const isInstructionDrawerOpen = ref(false);
   const instructionDrawerMode = ref<'create' | 'edit'>('create');
   const editingInstructionId = ref<number | string | null>(null);
+
+  const editingInstruction = computed<Instruction | null>(
+    () =>
+      instructions.data.find(
+        (item) => item.id === editingInstructionId.value,
+      ) ?? null,
+  );
+
+  const hasEditingInstructionChanges = computed(() => {
+    const original = editingInstruction.value;
+    if (instructionDrawerMode.value !== 'edit' || !original) return false;
+
+    return (
+      newInstruction.text !== original.text ||
+      !categoriesEqual(newInstruction.category, original.category ?? null)
+    );
+  });
 
   const isSearching = computed(() => searchTerm.value.trim().length > 0);
 
@@ -295,12 +293,11 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     const previousCategory = target.category;
 
     try {
-      target.text = newInstruction.text;
-      target.category = newInstruction.category;
-
       const response = await nexusaiAPI.agent_builder.instructions.update({
         projectUuid: projectUuid.value,
-        ...toGroupedPayload(),
+        id: editingInstructionId.value,
+        instruction: newInstruction.text,
+        category: toCategoryPayload(),
       });
 
       instructions.data = response.instructions;
@@ -351,17 +348,15 @@ export const useInstructionsStore = defineStore('Instructions', () => {
       instruction.status = 'loading';
 
       if (useV2()) {
-        const previousText = instruction.text;
-        try {
-          await nexusaiAPI.agent_builder.instructions.update({
-            projectUuid: projectUuid.value,
-            ...toGroupedPayload(),
-          });
-          instruction.text = text;
-        } catch (error) {
-          instruction.text = previousText;
-          throw error;
-        }
+        const response = await nexusaiAPI.agent_builder.instructions.update({
+          projectUuid: projectUuid.value,
+          id,
+          instruction: text,
+          category: toCategoryPayload(instruction.category ?? null),
+        });
+
+        instructions.data = response.instructions;
+        categories.value = response.categories;
       } else {
         await nexusaiAPI.agent_builder.instructions.edit({
           projectUuid: projectUuid.value,
@@ -446,7 +441,10 @@ export const useInstructionsStore = defineStore('Instructions', () => {
       alertStore.add({
         type: 'informational',
         text: categoryT('success_title'),
-        description: categoryT('success_description', { count: movedCount }),
+        description:
+          movedCount === 0
+            ? categoryT('success_description_empty')
+            : categoryT('success_description', { count: movedCount }),
       });
 
       return { status: null };
@@ -489,7 +487,7 @@ export const useInstructionsStore = defineStore('Instructions', () => {
       instructionSuggestedByAI.suggestionApplied = '';
       instructionSuggestedByAI.status = 'complete';
 
-      if (suggestedCategory && instructionDrawerMode.value !== 'edit') {
+      if (suggestedCategory) {
         const existing = categories.value.find(
           (category) => category.name === suggestedCategory,
         );
@@ -531,6 +529,21 @@ export const useInstructionsStore = defineStore('Instructions', () => {
 
       const response = await nexusaiAPI.agent_builder.instructions.export({
         projectUuid: projectUuid.value,
+        columns: {
+          category: i18n.global.t(
+            'agents.instructions.view.list_columns.category',
+          ),
+          instruction: i18n.global.t(
+            'agents.instructions.view.list_columns.instruction',
+          ),
+        },
+        categoryLabels: {
+          uncategorized: groupT('uncategorized'),
+          default: groupT('default_instructions'),
+        },
+        defaultInstructions: defaultInstructionsMock.value.map(
+          (instruction) => instruction.text,
+        ),
       });
 
       const blob = new Blob([response], { type: 'text/csv' });
@@ -578,6 +591,7 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     isInstructionDrawerOpen,
     instructionDrawerMode,
     editingInstructionId,
+    hasEditingInstructionChanges,
     groupedInstructions,
     flatInstructions,
     createCategory,

--- a/src/store/__tests__/Instructions.unit.spec.js
+++ b/src/store/__tests__/Instructions.unit.spec.js
@@ -327,6 +327,48 @@ describe('Instructions Store', () => {
         expect(store.instructions.data[1].text).toBe('Old text 2');
         expect(store.instructions.data[1].status).toBe('complete');
       });
+
+      it('updates a single instruction via the grouped endpoint when V2 is enabled', async () => {
+        featureFlagsState.categorizationOfInstructions = true;
+        store.instructions.data = [
+          {
+            id: 1,
+            text: 'Old text 1',
+            status: 'complete',
+            category: { id: 10, name: 'Sales' },
+          },
+          { id: 2, text: 'Old text 2', status: 'complete', category: null },
+        ];
+        const updated = {
+          instructions: [
+            {
+              id: 1,
+              text: 'Updated text',
+              category: { id: 10, name: 'Sales' },
+            },
+            { id: 2, text: 'Old text 2', category: null },
+          ],
+          categories: [{ id: 10, name: 'Sales' }],
+        };
+        nexusaiAPI.agent_builder.instructions.update.mockResolvedValue(updated);
+
+        const result = await store.editInstruction(1, 'Updated text');
+
+        expect(
+          nexusaiAPI.agent_builder.instructions.update,
+        ).toHaveBeenCalledWith({
+          projectUuid: 'test-project-uuid',
+          id: 1,
+          instruction: 'Updated text',
+          category: { id: 10 },
+        });
+        expect(
+          nexusaiAPI.agent_builder.instructions.edit,
+        ).not.toHaveBeenCalled();
+        expect(store.instructions.data).toEqual(updated.instructions);
+        expect(store.categories).toEqual(updated.categories);
+        expect(result).toEqual({ status: 'complete' });
+      });
     });
 
     describe('removeInstruction', () => {
@@ -445,7 +487,30 @@ describe('Instructions Store', () => {
 
         expect(
           nexusaiAPI.agent_builder.instructions.export,
-        ).toHaveBeenCalledWith({ projectUuid: 'test-project-uuid' });
+        ).toHaveBeenCalledWith({
+          projectUuid: 'test-project-uuid',
+          columns: {
+            category: i18n.global.t(
+              'agents.instructions.view.list_columns.category',
+            ),
+            instruction: i18n.global.t(
+              'agents.instructions.view.list_columns.instruction',
+            ),
+          },
+          categoryLabels: {
+            uncategorized: i18n.global.t(
+              'agents.instructions.view.uncategorized',
+            ),
+            default: i18n.global.t(
+              'agents.instructions.view.default_instructions',
+            ),
+          },
+          defaultInstructions: i18n.global
+            .tm(
+              'agent_builder.instructions.instructions_list.default_instructions',
+            )
+            .map(String),
+        });
         expect(window.URL.createObjectURL).toHaveBeenCalled();
         expect(mockClick).toHaveBeenCalled();
         expect(window.URL.revokeObjectURL).toHaveBeenCalledWith(
@@ -542,6 +607,25 @@ describe('Instructions Store', () => {
           description: i18n.global.t(
             'agents.instructions.delete_category.success_description',
             { count: 2 },
+          ),
+        });
+      });
+
+      it('shows a success toast without moved count when the category is empty', async () => {
+        store.instructions.data = [
+          { id: 3, text: 'C', category: { id: 20, name: 'Support' } },
+        ];
+        nexusaiAPI.agent_builder.instructions.deleteCategory.mockResolvedValue();
+
+        await store.deleteCategory(10);
+
+        expect(alertStore.add).toHaveBeenCalledWith({
+          type: 'informational',
+          text: i18n.global.t(
+            'agents.instructions.delete_category.success_title',
+          ),
+          description: i18n.global.t(
+            'agents.instructions.delete_category.success_description_empty',
           ),
         });
       });
@@ -827,7 +911,7 @@ describe('Instructions Store', () => {
         });
       });
 
-      it('does not overwrite the current category when revalidating in edit mode', async () => {
+      it('overwrites the current category when revalidating in edit mode', async () => {
         store.instructionDrawerMode = 'edit';
         store.newInstruction.category = { id: 3, name: 'Tone' };
         store.categories = [
@@ -844,7 +928,10 @@ describe('Instructions Store', () => {
 
         await store.getInstructionSuggestionByAI('Some instruction');
 
-        expect(store.newInstruction.category).toEqual({ id: 3, name: 'Tone' });
+        expect(store.newInstruction.category).toEqual({
+          id: 10,
+          name: 'Sales',
+        });
         expect(store.instructionSuggestedByAI.data.suggestedCategory).toBe(
           'Sales',
         );
@@ -878,6 +965,19 @@ describe('Instructions Store', () => {
       expect(store.editingInstructionId).toBe(7);
       expect(store.newInstruction.text).toBe('Be concise');
       expect(store.newInstruction.category).toEqual({ id: 3, name: 'Tone' });
+      expect(store.hasEditingInstructionChanges).toBe(false);
+    });
+
+    it('flags edits once the instruction text or category changes', () => {
+      store.instructions.data = [
+        { id: 7, text: 'Be concise', category: { id: 3, name: 'Tone' } },
+      ];
+
+      store.startEditingInstruction({ id: 7 });
+      expect(store.hasEditingInstructionChanges).toBe(false);
+
+      store.newInstruction.text = 'Be very concise';
+      expect(store.hasEditingInstructionChanges).toBe(true);
     });
 
     it('does not open the drawer for an unknown instruction', () => {
@@ -897,6 +997,7 @@ describe('Instructions Store', () => {
       expect(store.isInstructionDrawerOpen).toBe(false);
       expect(store.instructionDrawerMode).toBe('create');
       expect(store.editingInstructionId).toBeNull();
+      expect(store.hasEditingInstructionChanges).toBe(false);
       expect(store.newInstruction.text).toBe('');
     });
 
@@ -921,7 +1022,12 @@ describe('Instructions Store', () => {
       await store.updateEditingInstruction();
 
       expect(nexusaiAPI.agent_builder.instructions.update).toHaveBeenCalledWith(
-        expect.objectContaining({ projectUuid: 'test-project-uuid' }),
+        {
+          projectUuid: 'test-project-uuid',
+          id: 7,
+          instruction: 'New',
+          category: { id: 5 },
+        },
       );
       expect(store.instructions.data).toEqual(updated.instructions);
       expect(store.categories).toEqual(updated.categories);
@@ -975,6 +1081,14 @@ describe('Instructions Store', () => {
 
       await store.updateEditingInstruction();
 
+      expect(nexusaiAPI.agent_builder.instructions.update).toHaveBeenCalledWith(
+        {
+          projectUuid: 'test-project-uuid',
+          id: 7,
+          instruction: 'Be concise',
+          category: { id: 5 },
+        },
+      );
       expect(store.instructions.data[0]).toEqual({
         id: 7,
         text: 'Be concise',
@@ -991,6 +1105,66 @@ describe('Instructions Store', () => {
         category: { id: 5, name: 'Personality' },
       });
     });
+
+    it('creates a new category when editing an instruction with a custom category', async () => {
+      store.instructions.data = [
+        { id: 7, text: 'Be concise', category: { id: 3, name: 'Tone' } },
+      ];
+      const updated = {
+        instructions: [
+          {
+            id: 7,
+            text: 'Be concise',
+            category: { id: 9, name: 'Marketing' },
+          },
+        ],
+        categories: [
+          { id: 3, name: 'Tone' },
+          { id: 9, name: 'Marketing' },
+        ],
+      };
+      nexusaiAPI.agent_builder.instructions.update.mockResolvedValue(updated);
+
+      store.startEditingInstruction({ id: 7 });
+      store.newInstruction.category = { id: null, name: 'Marketing' };
+
+      await store.updateEditingInstruction();
+
+      expect(nexusaiAPI.agent_builder.instructions.update).toHaveBeenCalledWith(
+        {
+          projectUuid: 'test-project-uuid',
+          id: 7,
+          instruction: 'Be concise',
+          category: { name: 'Marketing' },
+        },
+      );
+      expect(store.instructions.data[0]).toEqual({
+        id: 7,
+        text: 'Be concise',
+        category: { id: 9, name: 'Marketing' },
+      });
+    });
+
+    it('preserves instruction state when the grouped update fails', async () => {
+      const originalInstruction = {
+        id: 7,
+        text: 'Old',
+        category: { id: 3, name: 'Tone' },
+      };
+      store.instructions.data = [originalInstruction];
+      nexusaiAPI.agent_builder.instructions.update.mockRejectedValue(
+        new Error('API Error'),
+      );
+
+      store.startEditingInstruction({ id: 7 });
+      store.newInstruction.text = 'New';
+      store.newInstruction.category = { id: 5, name: 'Personality' };
+
+      await store.updateEditingInstruction();
+
+      expect(store.instructions.data[0]).toEqual(originalInstruction);
+      expect(store.newInstruction.status).toBe('error');
+    });
   });
 
   describe('groupedInstructions getter', () => {
@@ -1000,7 +1174,7 @@ describe('Instructions Store', () => {
     const groupByKey = (key) =>
       store.groupedInstructions.find((group) => group.key === key);
 
-    it('groups custom categories ordered by the last added instruction', () => {
+    it('groups custom categories in alphabetical order', () => {
       store.categories = [
         { id: 10, name: 'Sales' },
         { id: 20, name: 'Support' },
@@ -1011,7 +1185,7 @@ describe('Instructions Store', () => {
         { id: 3, text: 'Sales B', category: { id: 10, name: 'Sales' } },
       ];
 
-      expect(keysOf()).toEqual(['category-20', 'category-10', 'default']);
+      expect(keysOf()).toEqual(['category-10', 'category-20', 'default']);
     });
 
     it('orders instructions within a group by the last inserted first', () => {

--- a/src/store/helpers/__tests__/instructionViewModels.spec.js
+++ b/src/store/helpers/__tests__/instructionViewModels.spec.js
@@ -25,7 +25,7 @@ const keysOf = (groups) => groups.map((group) => group.key);
 const byKey = (groups, key) => groups.find((group) => group.key === key);
 
 describe('buildInstructionGroups', () => {
-  it('orders custom categories by the last added instruction', () => {
+  it('orders custom categories alphabetically by name', () => {
     const groups = build({
       categories: [
         { id: 10, name: 'Sales' },
@@ -38,7 +38,7 @@ describe('buildInstructionGroups', () => {
       ],
     });
 
-    expect(keysOf(groups)).toEqual(['category-20', 'category-10', 'default']);
+    expect(keysOf(groups)).toEqual(['category-10', 'category-20', 'default']);
   });
 
   it('orders instructions within a group with the last inserted first', () => {

--- a/src/store/helpers/instructionViewModels.ts
+++ b/src/store/helpers/instructionViewModels.ts
@@ -37,8 +37,8 @@ const recencyOf = (item: Instruction) => Number(item.id) || 0;
 const newestFirst = (items: Instruction[]) =>
   [...items].sort((a, b) => recencyOf(b) - recencyOf(a));
 
-const lastAddedId = (items: Instruction[]) =>
-  items.reduce((newest, item) => Math.max(newest, recencyOf(item)), -Infinity);
+const alphabetically = (a: string, b: string) =>
+  a.localeCompare(b, undefined, { sensitivity: 'base' });
 
 const createCategoryGroup = (category: InstructionCategory) => ({
   id: category.id,
@@ -80,7 +80,7 @@ function partitionByCategory(
   return { categorized: [...byCategory.values()], uncategorized };
 }
 
-// Custom groups are ordered by their most recently added instruction.
+// Custom groups are ordered alphabetically by category name.
 function toCustomGroups(
   categorized: CategoryWithInstructions[],
 ): InstructionGroup[] {
@@ -92,7 +92,7 @@ function toCustomGroups(
       locked: false,
       instructions: newestFirst(category.instructions),
     }))
-    .sort((a, b) => lastAddedId(b.instructions) - lastAddedId(a.instructions));
+    .sort((a, b) => alphabetically(a.label, b.label));
 }
 
 // System groups are mocked and are always read-only.


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Several gaps existed in the instructions categorization flow: the uncategorized group lacked its own tooltip and identity, category creation allowed duplicate or reserved names, the edit drawer could be saved without any actual changes, the export endpoint was a GET with no payload, and category groups were ordered by recency rather than alphabetically.

### Summary of Changes

**Uncategorized group improvements**
- Added a dedicated `uncategorized_tooltip` translation (EN, ES, PT-BR, RO) that explains the group cannot be removed, distinct from the `locked_tooltip` used for default instructions.
- `CategoryAccordion` and `ListInstructionRow` now resolve the correct tooltip based on the group key (`uncategorized` vs `default`), and instruction-level actions remain available inside the uncategorized group.

**Category name validation**
- `useCategoryValidation` now accepts an `existingNames` ref and blocks names that already exist (case-insensitive) or match the reserved "Uncategorized" label in any supported locale.
- `CategoryCreateForm` passes the current category list into the validator so duplicates are caught before submission.
- Added an `already_exists` validation message in all four locales.

**Edit drawer save guard**
- Introduced `hasEditingInstructionChanges` in the Instructions store, which compares the current draft text and category against the original instruction.
- The save button in the edit drawer is disabled until at least one field differs from the stored value.

**Instruction update API refactor**
- `InstructionsGroupedAdapter.toUpdateApi` now accepts a single `{ id, text, category }` object and produces a minimal payload targeting only that instruction, either under `categories` or `uncategorized_instructions`.
- `Instructions.update` and the store's `updateEditingInstruction` / `editInstruction` actions pass individual instruction fields instead of rebuilding the full grouped payload.
- `editInstruction` (inline toggle) now refreshes `instructions.data` and `categories` from the API response.

**Export endpoint change**
- `Instructions.export` switched from GET to POST, sending `columns`, `category_labels`, and `default_instructions` in the request body with `Accept: text/csv` and `responseType: text`.
- The store populates these fields with translated column headers, localized group labels, and the default instructions list.

**Category deletion UX**
- `ModalRemoveCategory` shows a different description key (`modal_description_empty`) when the category being deleted has no instructions.
- The store's `deleteCategory` action shows a `success_description_empty` toast instead of the count-based message when no instructions were moved.

**Category ordering**
- Custom instruction groups are now sorted alphabetically by category name instead of by the most recently added instruction ID.

**AI suggestion in edit mode**
- The AI-suggested category is now applied even when the drawer is in edit mode, replacing the previous guard that skipped the assignment.