### PR TITLE
refactor: Move SupervisorHeader to use UnnnicPageHeader instead of AgentBuilderHeader

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -22,8 +22,6 @@
         data-testid="agent-builder-header-description"
       >
         {{ currentView?.description }}
-
-        <SupervisorHeaderDetails v-if="currentView.page === 'conversations'" />
       </h2>
     </section>
 
@@ -42,8 +40,6 @@ import { computed } from 'vue';
 import { useRoute } from 'vue-router';
 
 import useBuildViews from '@/composables/useBuildViews';
-
-import SupervisorHeaderDetails from './Supervisor/SupervisorHeaderDetails.vue';
 
 import i18n from '@/utils/plugins/i18n';
 
@@ -74,11 +70,6 @@ const currentView = computed(() => {
 
   const views = [
     ...useBuildViews().value,
-    {
-      title: t('agent_builder.tabs.conversations.title'),
-      description: t('agent_builder.tabs.conversations.description'),
-      page: 'conversations',
-    },
     {
       title: t('agent_builder.tabs.agents.title'),
       description: t('agent_builder.tabs.agents.description'),

--- a/src/views/Supervisor/SupervisorHeader.vue
+++ b/src/views/Supervisor/SupervisorHeader.vue
@@ -1,12 +1,31 @@
 <template>
-  <AgentBuilderHeader
-    :withDivider="false"
-    :actionsSize="showExport ? 'md' : 'none'"
-  >
-    <template #actions>
+  <UnnnicPageHeader hideDivider>
+    <template #infos>
+      <section class="supervisor-header__infos">
+        <h1
+          class="supervisor-header__title"
+          data-testid="page-title"
+        >
+          {{ headerTitle }}
+        </h1>
+
+        <p
+          class="supervisor-header__description"
+          data-testid="page-description"
+        >
+          {{ headerDescription }}
+
+          <SupervisorHeaderDetails />
+        </p>
+      </section>
+    </template>
+
+    <template
+      v-if="showExport"
+      #actions
+    >
       <section class="supervisor-header__actions">
         <UnnnicButton
-          v-if="showExport"
           iconCenter="open_in_new"
           type="secondary"
           data-testid="export-button"
@@ -15,23 +34,32 @@
       </section>
 
       <SupervisorExportModal
-        v-if="showExport"
         v-model="isExportModalOpen"
         data-testid="export-modal"
       />
     </template>
-  </AgentBuilderHeader>
+  </UnnnicPageHeader>
 </template>
 
 <script setup>
-import AgentBuilderHeader from '@/components/Header.vue';
 import SupervisorExportModal from '@/components/Supervisor/SupervisorExportModal.vue';
+import SupervisorHeaderDetails from '@/components/Supervisor/SupervisorHeaderDetails.vue';
 
 import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 
+import i18n from '@/utils/plugins/i18n';
+
 import { computed, ref } from 'vue';
 
+const { t } = i18n.global;
+
 const featureFlagsStore = useFeatureFlagsStore();
+
+const headerTitle = computed(() => t('agent_builder.tabs.conversations.title'));
+
+const headerDescription = computed(() =>
+  t('agent_builder.tabs.conversations.description'),
+);
 
 const showExport = computed(() => featureFlagsStore.flags.supervisorExport);
 
@@ -44,10 +72,26 @@ function openExportModal() {
 
 <style lang="scss" scoped>
 .supervisor-header {
+  &__infos {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+  }
+
+  &__title {
+    @include unnnic-font-display-1;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__description {
+    @include unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+
   &__actions {
     display: flex;
     align-items: center;
-    gap: $unnnic-spacing-xs;
+    gap: $unnnic-space-2;
     justify-content: flex-end;
   }
 }

--- a/src/views/Supervisor/__tests__/SupervisorHeader.spec.js
+++ b/src/views/Supervisor/__tests__/SupervisorHeader.spec.js
@@ -1,56 +1,17 @@
 import { mount } from '@vue/test-utils';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import SupervisorHeader from '../SupervisorHeader.vue';
-import { useSupervisorStore } from '@/store/Supervisor';
 import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 import { createTestingPinia } from '@pinia/testing';
 
 const pinia = createTestingPinia({
   initialState: {
-    supervisor: {
-      filters: {
-        start: '',
-        end: '',
-      },
-    },
     featureFlags: {
       flags: {
         supervisorExport: false,
       },
     },
   },
-});
-
-vi.mock('@/composables/useAgentBuilderViews', () => {
-  return {
-    default: vi.fn(() => {
-      return {
-        value: [
-          {
-            title: 'Test Route',
-            description: 'Test Description',
-            page: 'test-page',
-            icon: 'test-icon',
-          },
-        ],
-      };
-    }),
-  };
-});
-
-vi.mock('vue-router', () => {
-  return {
-    useRoute: vi.fn(() => ({
-      name: 'test-page',
-      query: {
-        start: '2025-01-01',
-        end: '2025-01-31',
-        search: '',
-        type: '',
-        conversationId: '',
-      },
-    })),
-  };
 });
 
 describe('SupervisorHeader', () => {
@@ -67,7 +28,13 @@ describe('SupervisorHeader', () => {
     featureFlagsStore = useFeatureFlagsStore();
   });
 
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
   it('should render the component correctly', () => {
+    expect(wrapper.find('[data-testid="page-title"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="page-description"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="export-button"]').exists()).toBe(false);
     expect(wrapper.find('[data-testid="export-modal"]').exists()).toBe(false);
   });


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [ ] Feature
    - [ ] Code style update (formatting, local variables)
    - [x] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The `SupervisorHeader` was relying on the shared `AgentBuilderHeader` component and injecting its title, description, and details through that component's slot system.

### Summary of Changes

- Replaced `AgentBuilderHeader` usage in `SupervisorHeader.vue` with `UnnnicPageHeader`, giving the Supervisor its own self-contained header layout with dedicated title, description, and `SupervisorHeaderDetails` rendering.
- Removed the `conversations` page entry from the `currentView` computed list in `Header.vue`, along with the conditional `SupervisorHeaderDetails` rendering that was embedded inside the shared header description.
- Moved `SupervisorHeaderDetails` into `SupervisorHeader.vue` where it is rendered directly within the description section.
- Cleaned up `SupervisorHeader.spec.js` by removing mocks for `vue-router` and `useAgentBuilderViews` that are no longer needed, added assertions for the new `page-title` and `page-description` test IDs, and added an `afterEach` cleanup to unmount the wrapper.