### PR TITLE
refactor: Move supervisor i18n keys from `agent_builder.supervisor` to `audit.conversations`

### DIFF
--- a/src/components/Supervisor/SupervisorExportModal.vue
+++ b/src/components/Supervisor/SupervisorExportModal.vue
@@ -4,13 +4,13 @@
     showCloseIcon
     showActionsDivider
     size="md"
-    :title="$t('agent_builder.supervisor.export.title')"
+    :title="$t('audit.conversations.export.title')"
     :secondaryButtonProps="{
       text: $t('cancel'),
       'data-test': 'cancel-button',
     }"
     :primaryButtonProps="{
-      text: $t('agent_builder.supervisor.export.send'),
+      text: $t('audit.conversations.export.send'),
       loading: isSending,
       disabled: !token,
       'data-test': 'send-export-button',
@@ -28,7 +28,7 @@
       size="body-gt"
       weight="regular"
     >
-      {{ $t('agent_builder.supervisor.export.description') }}
+      {{ $t('audit.conversations.export.description') }}
     </UnnnicIntelligenceText>
 
     <ul class="supervisor-export-modal__email-list">
@@ -52,12 +52,12 @@
     <UnnnicDivider ySpacing="sm" />
 
     <UnnnicFormElement
-      :label="$t('agent_builder.supervisor.export.token_label')"
+      :label="$t('audit.conversations.export.token_label')"
       class="supervisor-export-modal__form-element"
     >
       <UnnnicInput
         v-model="token"
-        :placeholder="$t('agent_builder.supervisor.export.token_placeholder')"
+        :placeholder="$t('audit.conversations.export.token_placeholder')"
         data-test="token-input"
       />
     </UnnnicFormElement>
@@ -70,15 +70,15 @@
       weight="regular"
       class="supervisor-export-modal__help-text"
     >
-      {{ $t('agent_builder.supervisor.export.token_help') }}
+      {{ $t('audit.conversations.export.token_help') }}
       <a
         :href="`${env('CONNECT_URL')}/projects/${projectStore.uuid}/settings`"
         class="help-text__link"
         target="_blank"
       >
-        {{ $t('agent_builder.supervisor.export.project_settings') }}
+        {{ $t('audit.conversations.export.project_settings') }}
       </a>
-      {{ $t('agent_builder.supervisor.export.and_paste') }}
+      {{ $t('audit.conversations.export.and_paste') }}
     </UnnnicIntelligenceText>
   </UnnnicModalDialog>
 </template>

--- a/src/components/Supervisor/SupervisorHeaderDetails.vue
+++ b/src/components/Supervisor/SupervisorHeaderDetails.vue
@@ -3,7 +3,7 @@
     class="supervisor-header-details"
     @click="handleDetailsModal"
   >
-    {{ $t('agent_builder.supervisor.learn_details_conversations') }}
+    {{ $t('audit.conversations.learn_details_conversations') }}
   </p>
 
   <UnnnicModalDialog
@@ -11,7 +11,7 @@
     showCloseIcon
     showActionsDivider
     size="md"
-    :title="$t('agent_builder.supervisor.conversation_details.title')"
+    :title="$t('audit.conversations.conversation_details.title')"
     class="supervisor-header-details__modal"
     @update:model-value="handleDetailsModal"
   >
@@ -21,13 +21,11 @@
       class="modal__topic"
     >
       <p class="topic__title">
-        {{ $t(`agent_builder.supervisor.conversation_details.${topic}`) }}
+        {{ $t(`audit.conversations.conversation_details.${topic}`) }}
       </p>
       <p class="topic__description">
         {{
-          $t(
-            `agent_builder.supervisor.conversation_details.${topic}_description`,
-          )
+          $t(`audit.conversations.conversation_details.${topic}_description`)
         }}
       </p>
     </section>

--- a/src/components/Supervisor/SupervisorUsername.vue
+++ b/src/components/Supervisor/SupervisorUsername.vue
@@ -21,7 +21,7 @@ const props = withDefaults(
   }>(),
   {
     username: '',
-    fallbackKey: 'agent_builder.supervisor.unnamed_contact',
+    fallbackKey: 'audit.conversations.unnamed_contact',
     font: 'action',
   },
 );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,10 +13,6 @@
   "unexpected_error": "An unexpected error occurred",
   "agent_builder": {
     "tabs": {
-      "conversations": {
-        "title": "Conversations",
-        "description": "Review and analyze conversations between agents and customers."
-      },
       "knowledge": {
         "title": "Knowledge",
         "description": "Add knowledge through files, links, or text so the agent can reply accurately"
@@ -24,95 +20,6 @@
       "tunings": {
         "title": "Settings",
         "description": "Manage the settings and track the changes made"
-      }
-    },
-    "supervisor": {
-      "learn_details_conversations": "Learn about the details of a conversation.",
-      "conversation_details": {
-        "title": "About conversation",
-        "what_is_a_conversation": "What is a conversation?",
-        "what_is_a_conversation_description": "We consider all messages exchanged within 24 hours (resetting at midnight) as a single conversation.",
-        "optimized_resolution": "AI-assisted",
-        "optimized_resolution_description": "Conversations ended with a clear, effective resolution for the contact.",
-        "other_conclusion": "Not assisted",
-        "other_conclusion_description": "Conversations that ended in other ways, such as brief interactions, greetings, abandonment, or cases that followed a different flow without a direct resolution.",
-        "transferred_to_human_support": "Transferred to human support",
-        "transferred_to_human_support_description": "Includes conversations (AI-assisted and not assisted) transferred to a human representative."
-      },
-      "conversations_count": "{count} conversations found",
-      "unnamed_contact": "Unnamed contact",
-      "attended_by_agent": {
-        "title": "Assisted by an agent",
-        "tooltip": "Conversations completed by an agent"
-      },
-      "forwarded_human_support": {
-        "title": "Transferred to human support",
-        "tooltip": "Conversations transferred to human support"
-      },
-      "conversation_start_finish": {
-        "start": "Conversation started: {datetime}",
-        "finish": "Conversation ended: {datetime}"
-      },
-      "contact_urn": "Contact URN",
-      "topic": "Topic",
-      "conversation_details_collapse": "Conversation details",
-      "view_full_history": "View full history",
-      "view_logs": "Show logs",
-      "hide_logs": "Hide logs",
-      "search": "Search",
-      "conversations_empty": "No conversations found",
-      "conversations_separator": "Conversations below were classified using the legacy system",
-      "conversations_v2_disclaimer": "Starting on March {day}, conversations are organized into 24-hour windows (resetting at midnight) powered by our new classification system",
-      "no_messages_found": {
-        "title": "No messages found in this conversation",
-        "description": "If the message was sent by human support or triggered an automatic action, you can find it in {studio_link}.",
-        "studio_link": "Studio"
-      },
-      "unclassified_status_tooltip": "Conversations closed before September 8, 2025 can't be classified",
-      "export": {
-        "title": "Export to email",
-        "description": "We'll prepare the file with the AI information and send it to the following emails:",
-        "token_label": "Project API token",
-        "token_placeholder": "86d2ba6397cabd4b22f7da925ef89d78bfb2d90dd",
-        "token_help": "You can find this token in the",
-        "project_settings": "project settings",
-        "and_paste": "and paste it here",
-        "send": "Send export",
-        "success": "The export will be sent to all listed emails soon",
-        "error": "Error sending export. Try again later."
-      },
-      "filters": {
-        "filter_conversations": "Filter conversations",
-        "count_applied_filters": "{count, plural, one {(1 filter applied)} other {({count} filters applied)}}",
-        "filter_conversations_drawer": "Filter conversations",
-        "apply_filters": "Apply filters",
-        "clear_filters": "Clear filters",
-        "period": {
-          "label": "Period"
-        },
-        "status": {
-          "conversations": "Conversations",
-          "in_progress": "In progress",
-          "optimized_resolution": "AI-Assisted",
-          "other_conclusion": "Not Assisted",
-          "unclassified": "Not classified",
-          "transferred_to_human_support": "Transferred to human support"
-        },
-        "csat": {
-          "csat": "CSAT",
-          "very_satisfied": "🤩 Very satisfied",
-          "satisfied": "😃 Satisfied",
-          "neutral": "😐 Neutral",
-          "dissatisfied": "😔 Dissatisfied",
-          "very_dissatisfied": "😡 Very dissatisfied"
-        },
-        "topic": {
-          "topic": "Topic",
-          "unclassified": "Not classified"
-        }
-      },
-      "load_conversations": {
-        "error": "Error loading conversations"
       }
     },
     "instructions": {
@@ -463,6 +370,100 @@
           }
 
         }
+      }
+    }
+  },
+  "audit": {
+    "title": "Audit",
+    "description": "Review and analyze conversations between agents and customers.",
+    "conversations": {
+      "title": "Conversations",
+      "learn_details_conversations": "Learn about the details of a conversation.",
+      "conversation_details": {
+        "title": "About conversation",
+        "what_is_a_conversation": "What is a conversation?",
+        "what_is_a_conversation_description": "We consider all messages exchanged within 24 hours (resetting at midnight) as a single conversation.",
+        "optimized_resolution": "AI-assisted",
+        "optimized_resolution_description": "Conversations ended with a clear, effective resolution for the contact.",
+        "other_conclusion": "Not assisted",
+        "other_conclusion_description": "Conversations that ended in other ways, such as brief interactions, greetings, abandonment, or cases that followed a different flow without a direct resolution.",
+        "transferred_to_human_support": "Transferred to human support",
+        "transferred_to_human_support_description": "Includes conversations (AI-assisted and not assisted) transferred to a human representative."
+      },
+      "conversations_count": "{count} conversations found",
+      "unnamed_contact": "Unnamed contact",
+      "attended_by_agent": {
+        "title": "Assisted by an agent",
+        "tooltip": "Conversations completed by an agent"
+      },
+      "forwarded_human_support": {
+        "title": "Transferred to human support",
+        "tooltip": "Conversations transferred to human support"
+      },
+      "conversation_start_finish": {
+        "start": "Conversation started: {datetime}",
+        "finish": "Conversation ended: {datetime}"
+      },
+      "contact_urn": "Contact URN",
+      "topic": "Topic",
+      "conversation_details_collapse": "Conversation details",
+      "view_full_history": "View full history",
+      "view_logs": "Show logs",
+      "hide_logs": "Hide logs",
+      "search": "Search",
+      "conversations_empty": "No conversations found",
+      "conversations_separator": "Conversations below were classified using the legacy system",
+      "conversations_v2_disclaimer": "Starting on March {day}, conversations are organized into 24-hour windows (resetting at midnight) powered by our new classification system",
+      "no_messages_found": {
+        "title": "No messages found in this conversation",
+        "description": "If the message was sent by human support or triggered an automatic action, you can find it in {studio_link}.",
+        "studio_link": "Studio"
+      },
+      "unclassified_status_tooltip": "Conversations closed before September 8, 2025 can't be classified",
+      "export": {
+        "title": "Export to email",
+        "description": "We'll prepare the file with the AI information and send it to the following emails:",
+        "token_label": "Project API token",
+        "token_placeholder": "86d2ba6397cabd4b22f7da925ef89d78bfb2d90dd",
+        "token_help": "You can find this token in the",
+        "project_settings": "project settings",
+        "and_paste": "and paste it here",
+        "send": "Send export",
+        "success": "The export will be sent to all listed emails soon",
+        "error": "Error sending export. Try again later."
+      },
+      "filters": {
+        "filter_conversations": "Filter conversations",
+        "count_applied_filters": "{count, plural, one {(1 filter applied)} other {({count} filters applied)}}",
+        "filter_conversations_drawer": "Filter conversations",
+        "apply_filters": "Apply filters",
+        "clear_filters": "Clear filters",
+        "period": {
+          "label": "Period"
+        },
+        "status": {
+          "conversations": "Conversations",
+          "in_progress": "In progress",
+          "optimized_resolution": "AI-Assisted",
+          "other_conclusion": "Not Assisted",
+          "unclassified": "Not classified",
+          "transferred_to_human_support": "Transferred to human support"
+        },
+        "csat": {
+          "csat": "CSAT",
+          "very_satisfied": "🤩 Very satisfied",
+          "satisfied": "😃 Satisfied",
+          "neutral": "😐 Neutral",
+          "dissatisfied": "😔 Dissatisfied",
+          "very_dissatisfied": "😡 Very dissatisfied"
+        },
+        "topic": {
+          "topic": "Topic",
+          "unclassified": "Not classified"
+        }
+      },
+      "load_conversations": {
+        "error": "Error loading conversations"
       }
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -13,10 +13,6 @@
   "unexpected_error": "Se produjo un error inesperado",
   "agent_builder": {
     "tabs": {
-      "conversations": {
-        "title": "Conversaciones",
-        "description": "Analiza y revisa conversaciones entre agentes y clientes."
-      },
       "knowledge": {
         "title": "Conocimientos",
         "description": "Agrega conocimiento mediante archivos, links o texto para que el agente pueda responder con precisión"
@@ -24,95 +20,6 @@
       "tunings": {
         "title": "Ajustes",
         "description": "Gestiona la configuración y consulta los cambios realizados"
-      }
-    },
-    "supervisor": {
-      "learn_details_conversations": "Aprende sobre los detalles de una conversación.",
-      "conversation_details": {
-        "title": "Sobre conversación",
-        "what_is_a_conversation": "¿Qué es una conversación?",
-        "what_is_a_conversation_description": "Consideramos todas las conversaciones dentro de 24 horas (reseteando a medianoche) como una única conversación.",
-        "optimized_resolution": "Atendido por IA",
-        "optimized_resolution_description": "Conversaciones finalizadas con una resolución clara y efectiva para el contacto.",
-        "other_conclusion": "No atendido",
-        "other_conclusion_description": "Conversaciones que finalizaron de otras maneras, como interacciones breves, saludos, abandono o casos que siguieron un flujo diferente sin una resolución directa.",
-        "transferred_to_human_support": "Transferidas a soporte humano",
-        "transferred_to_human_support_description": "Incluye conversaciones (Atendido por IA y No atendido) transferidas a un representante humano."
-      },
-      "conversations_count": "{count} conversaciones encontradas",
-      "unnamed_contact": "Contacto sin nombre",
-      "attended_by_agent": {
-        "title": "Atendido por el agente",
-        "tooltip": "Conversaciones resueltas por el agente"
-      },
-      "forwarded_human_support": {
-        "title": "Enviado a soporte humano",
-        "tooltip": "Conversaciones transferidas a soporte humano"
-      },
-      "conversation_start_finish": {
-        "start": "Conversación iniciada: {datetime}",
-        "finish": "Conversación finalizada: {datetime}"
-      },
-      "contact_urn": "URN del contacto",
-      "topic": "Tópico",
-      "conversation_details_collapse": "Detalles de la conversación",
-      "view_full_history": "Ver historico completo",
-      "view_logs": "Mostrar logs",
-      "hide_logs": "Ocultar logs",
-      "search": "Buscar",
-      "conversations_empty": "No se encontraron conversaciones",
-      "conversations_separator": "Las conversaciones a continuación se clasificaron utilizando el sistema heredado",
-      "conversations_v2_disclaimer": "Comenzando el {day} de marzo, las conversas se organizan en ventanas de 24 horas (reseteando a medianoche) usando nuestro nuevo sistema de clasificación",
-      "no_messages_found": {
-        "title": "No se encontraron mensajes en esta conversación",
-        "description": "Si el soporte humano envió el mensaje o activó una acción automática, lo puedes ver en {studio_link}.",
-        "studio_link": "Estudio"
-      },
-      "unclassified_status_tooltip": "Las conversaciones finalizadas antes del 8 de septiembre de 2025 no pueden clasificarse",
-      "export": {
-        "title": "Enviar exportación por email",
-        "description": "Vamos a preparar el archivo con los datos de IA y lo enviaremos a los siguientes emails:",
-        "token_label": "Token de API del proyecto",
-        "token_placeholder": "86d2ba6397cabd4b22f7da925ef89d78bfb2d90dd",
-        "token_help": "Puedes ver el token en la",
-        "project_settings": "configuración del proyecto",
-        "and_paste": "y pegarlo aquí",
-        "send": "Enviar exportación",
-        "success": "La exportación se enviará en breve a todos los emails listados",
-        "error": "Error al enviar exportación. Inténtalo de nuevo más tarde."
-      },
-      "filters": {
-        "filter_conversations": "Filtrar conversaciones",
-        "count_applied_filters": "{count, plural, one {(1 filtro aplicado)} other {({count} filtros aplicados)}}",
-        "filter_conversations_drawer": "Filtrar conversaciones",
-        "apply_filters": "Aplicar filtros",
-        "clear_filters": "Limpiar filtros",
-        "period": {
-          "label": "Periodo"
-        },
-        "status": {
-          "conversations": "Conversaciones",
-          "in_progress": "En progreso",
-          "optimized_resolution": "Atendido por IA",
-          "other_conclusion": "No atendido",
-          "unclassified": "No clasificado",
-          "transferred_to_human_support": "Encaminado a soporte humano"
-        },
-        "csat": {
-          "csat": "CSAT",
-          "very_satisfied": "🤩 Muy satisfecho",
-          "satisfied": "😃 Satisfecho",
-          "neutral": "😐 Neutral",
-          "dissatisfied": "😔 Insatisfecho",
-          "very_dissatisfied": "😡 Muy insatisfecho"
-        },
-        "topic": {
-          "topic": "Tópico",
-          "unclassified": "No clasificado"
-        }
-      },
-      "load_conversations": {
-        "error": "Error al cargar conversaciones"
       }
     },
     "instructions": {
@@ -463,6 +370,100 @@
           }
 
         }
+      }
+    }
+  },
+  "audit": {
+    "title": "Auditoría",
+    "description": "Analiza y revisa conversaciones entre agentes y clientes.",
+    "conversations": {
+      "title": "Conversaciones",
+      "learn_details_conversations": "Aprende sobre los detalles de una conversación.",
+      "conversation_details": {
+        "title": "Sobre conversación",
+        "what_is_a_conversation": "¿Qué es una conversación?",
+        "what_is_a_conversation_description": "Consideramos todas las conversaciones dentro de 24 horas (reseteando a medianoche) como una única conversación.",
+        "optimized_resolution": "Atendido por IA",
+        "optimized_resolution_description": "Conversaciones finalizadas con una resolución clara y efectiva para el contacto.",
+        "other_conclusion": "No atendido",
+        "other_conclusion_description": "Conversaciones que finalizaron de otras maneras, como interacciones breves, saludos, abandono o casos que siguieron un flujo diferente sin una resolución directa.",
+        "transferred_to_human_support": "Transferidas a soporte humano",
+        "transferred_to_human_support_description": "Incluye conversaciones (Atendido por IA y No atendido) transferidas a un representante humano."
+      },
+      "conversations_count": "{count} conversaciones encontradas",
+      "unnamed_contact": "Contacto sin nombre",
+      "attended_by_agent": {
+        "title": "Atendido por el agente",
+        "tooltip": "Conversaciones resueltas por el agente"
+      },
+      "forwarded_human_support": {
+        "title": "Enviado a soporte humano",
+        "tooltip": "Conversaciones transferidas a soporte humano"
+      },
+      "conversation_start_finish": {
+        "start": "Conversación iniciada: {datetime}",
+        "finish": "Conversación finalizada: {datetime}"
+      },
+      "contact_urn": "URN del contacto",
+      "topic": "Tópico",
+      "conversation_details_collapse": "Detalles de la conversación",
+      "view_full_history": "Ver historico completo",
+      "view_logs": "Mostrar logs",
+      "hide_logs": "Ocultar logs",
+      "search": "Buscar",
+      "conversations_empty": "No se encontraron conversaciones",
+      "conversations_separator": "Las conversaciones a continuación se clasificaron utilizando el sistema heredado",
+      "conversations_v2_disclaimer": "Comenzando el {day} de marzo, las conversas se organizan en ventanas de 24 horas (reseteando a medianoche) usando nuestro nuevo sistema de clasificación",
+      "no_messages_found": {
+        "title": "No se encontraron mensajes en esta conversación",
+        "description": "Si el soporte humano envió el mensaje o activó una acción automática, lo puedes ver en {studio_link}.",
+        "studio_link": "Estudio"
+      },
+      "unclassified_status_tooltip": "Las conversaciones finalizadas antes del 8 de septiembre de 2025 no pueden clasificarse",
+      "export": {
+        "title": "Enviar exportación por email",
+        "description": "Vamos a preparar el archivo con los datos de IA y lo enviaremos a los siguientes emails:",
+        "token_label": "Token de API del proyecto",
+        "token_placeholder": "86d2ba6397cabd4b22f7da925ef89d78bfb2d90dd",
+        "token_help": "Puedes ver el token en la",
+        "project_settings": "configuración del proyecto",
+        "and_paste": "y pegarlo aquí",
+        "send": "Enviar exportación",
+        "success": "La exportación se enviará en breve a todos los emails listados",
+        "error": "Error al enviar exportación. Inténtalo de nuevo más tarde."
+      },
+      "filters": {
+        "filter_conversations": "Filtrar conversaciones",
+        "count_applied_filters": "{count, plural, one {(1 filtro aplicado)} other {({count} filtros aplicados)}}",
+        "filter_conversations_drawer": "Filtrar conversaciones",
+        "apply_filters": "Aplicar filtros",
+        "clear_filters": "Limpiar filtros",
+        "period": {
+          "label": "Periodo"
+        },
+        "status": {
+          "conversations": "Conversaciones",
+          "in_progress": "En progreso",
+          "optimized_resolution": "Atendido por IA",
+          "other_conclusion": "No atendido",
+          "unclassified": "No clasificado",
+          "transferred_to_human_support": "Encaminado a soporte humano"
+        },
+        "csat": {
+          "csat": "CSAT",
+          "very_satisfied": "🤩 Muy satisfecho",
+          "satisfied": "😃 Satisfecho",
+          "neutral": "😐 Neutral",
+          "dissatisfied": "😔 Insatisfecho",
+          "very_dissatisfied": "😡 Muy insatisfecho"
+        },
+        "topic": {
+          "topic": "Tópico",
+          "unclassified": "No clasificado"
+        }
+      },
+      "load_conversations": {
+        "error": "Error al cargar conversaciones"
       }
     }
   },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -13,10 +13,6 @@
   "unexpected_error": "Ocorreu um erro inesperado",
   "agent_builder": {
     "tabs": {
-      "conversations": {
-        "title": "Conversas",
-        "description": "Analise e revise conversas entre agentes e clientes."
-      },
       "knowledge": {
         "title": "Conhecimento",
         "description": "Adicione conhecimento através de arquivos, links ou texto para que o agente possa responder com precisão"
@@ -24,95 +20,6 @@
       "tunings": {
         "title": "Ajustes",
         "description": "Gerencie as configurações e acompanhe as alterações realizadas"
-      }
-    },
-    "supervisor": {
-      "learn_details_conversations": "Aprenda sobre os detalhes de uma conversa.",
-      "conversation_details": {
-        "title": "Sobre conversa",
-        "what_is_a_conversation": "O que é uma conversa?",
-        "what_is_a_conversation_description": "Consideramos todas as mensagens trocadas dentro de 24 horas (resetando à meia-noite) como uma única conversa.",
-        "optimized_resolution": "Atendido por IA",
-        "optimized_resolution_description": "Conversas que terminaram com uma resolução clara e eficaz para o contato.",
-        "other_conclusion": "Não atendido",
-        "other_conclusion_description": "Conversas que terminaram de outras formas, como interações breves, saudações, desistências ou casos que seguiram um fluxo diferente sem uma resolução direta.",
-        "transferred_to_human_support": "Transferido para o atendimento humano",
-        "transferred_to_human_support_description": "Inclui conversas (Atendido por IA e Não atendido) encaminhadas a um atendente humano."
-      },
-      "conversations_count": "{count} conversas encontradas",
-      "unnamed_contact": "Contato sem nome",
-      "attended_by_agent": {
-        "title": "Atendido pelo agente",
-        "tooltip": "Conversas resolvidas pelo agente"
-      },
-      "forwarded_human_support": {
-        "title": "Encaminhado para suporte humano",
-        "tooltip": "Conversas encaminhadas para suporte humano"
-      },
-      "conversation_start_finish": {
-        "start": "Conversa iniciada: {datetime}",
-        "finish": "Conversa finalizada: {datetime}"
-      },
-      "contact_urn": "URN do contato",
-      "topic": "Tópico",
-      "conversation_details_collapse": "Detalhes da conversa",
-      "view_full_history": "Ver histórico completo",
-      "view_logs": "Mostrar logs",
-      "hide_logs": "Ocultar logs",
-      "search": "Buscar",
-      "conversations_empty": "Nenhuma conversa encontrada",
-      "conversations_separator": "As conversas abaixo foram classificadas usando o sistema legado",
-      "conversations_v2_disclaimer": "Começando em {day} de março, as conversas são organizadas em janelas de 24 horas (resetando à meia-noite) usando nosso novo sistema de classificação",
-      "no_messages_found": {
-        "title": "Nenhuma mensagem encontrada nesta conversa",
-        "description": "Se a mensagem foi enviada pelo suporte humano ou ativou uma ação automática, você pode encontrá-la no {studio_link}.",
-        "studio_link": "Estúdio"
-      },
-      "unclassified_status_tooltip": "Conversas encerradas antes de 8 de setembro de 2025 não podem ser classificadas",
-      "export": {
-        "title": "Enviar exportação por email",
-        "description": "Vamos preparar o arquivo com os dados de IA e enviá-lo para os seguintes emails:",
-        "token_label": "Token de API do projeto",
-        "token_placeholder": "86d2ba6397cabd4b22f7da925ef89d78bfb2d90dd",
-        "token_help": "Você pode encontrar este token nas",
-        "project_settings": "configurações do projeto",
-        "and_paste": "e colá-lo aqui",
-        "send": "Enviar exportação",
-        "success": "A exportação será enviada para todos os emails listados em breve",
-        "error": "Erro ao enviar exportação. Tente novamente mais tarde."
-      },
-      "filters": {
-        "filter_conversations": "Filtrar conversas",
-        "count_applied_filters": "{count, plural, one {(1 filtro aplicado)} other {({count} filtros aplicados)}}",
-        "filter_conversations_drawer": "Filtrar conversas",
-        "apply_filters": "Aplicar filtros",
-        "clear_filters": "Limpar filtros",
-        "period": {
-          "label": "Período"
-        },
-        "status": {
-          "conversations": "Conversas",
-          "in_progress": "Em progresso",
-          "optimized_resolution": "Atendido por IA",
-          "other_conclusion": "Não atendido",
-          "unclassified": "Não classificado",
-          "transferred_to_human_support": "Encaminhado para suporte humano"
-        },
-        "csat": {
-          "csat": "CSAT",
-          "very_satisfied": "🤩 Muito satisfeito",
-          "satisfied": "😃 Satisfeito",
-          "neutral": "😐 Neutro",
-          "dissatisfied": "😔 Insatisfeito",
-          "very_dissatisfied": "😡 Muito insatisfeito"
-        },
-        "topic": {
-          "topic": "Tópico",
-          "unclassified": "Não classificado"
-        }
-      },
-      "load_conversations": {
-        "error": "Erro ao carregar conversas"
       }
     },
     "instructions": {
@@ -463,6 +370,100 @@
           }
 
         }
+      }
+    }
+  },
+  "audit": {
+    "title": "Auditoria",
+    "description": "Analise e revise conversas entre agentes e clientes.",
+    "conversations": {
+      "title": "Conversas",
+      "learn_details_conversations": "Aprenda sobre os detalhes de uma conversa.",
+      "conversation_details": {
+        "title": "Sobre conversa",
+        "what_is_a_conversation": "O que é uma conversa?",
+        "what_is_a_conversation_description": "Consideramos todas as mensagens trocadas dentro de 24 horas (resetando à meia-noite) como uma única conversa.",
+        "optimized_resolution": "Atendido por IA",
+        "optimized_resolution_description": "Conversas que terminaram com uma resolução clara e eficaz para o contato.",
+        "other_conclusion": "Não atendido",
+        "other_conclusion_description": "Conversas que terminaram de outras formas, como interações breves, saudações, desistências ou casos que seguiram um fluxo diferente sem uma resolução direta.",
+        "transferred_to_human_support": "Transferido para o atendimento humano",
+        "transferred_to_human_support_description": "Inclui conversas (Atendido por IA e Não atendido) encaminhadas a um atendente humano."
+      },
+      "conversations_count": "{count} conversas encontradas",
+      "unnamed_contact": "Contato sem nome",
+      "attended_by_agent": {
+        "title": "Atendido pelo agente",
+        "tooltip": "Conversas resolvidas pelo agente"
+      },
+      "forwarded_human_support": {
+        "title": "Encaminhado para suporte humano",
+        "tooltip": "Conversas encaminhadas para suporte humano"
+      },
+      "conversation_start_finish": {
+        "start": "Conversa iniciada: {datetime}",
+        "finish": "Conversa finalizada: {datetime}"
+      },
+      "contact_urn": "URN do contato",
+      "topic": "Tópico",
+      "conversation_details_collapse": "Detalhes da conversa",
+      "view_full_history": "Ver histórico completo",
+      "view_logs": "Mostrar logs",
+      "hide_logs": "Ocultar logs",
+      "search": "Buscar",
+      "conversations_empty": "Nenhuma conversa encontrada",
+      "conversations_separator": "As conversas abaixo foram classificadas usando o sistema legado",
+      "conversations_v2_disclaimer": "Começando em {day} de março, as conversas são organizadas em janelas de 24 horas (resetando à meia-noite) usando nosso novo sistema de classificação",
+      "no_messages_found": {
+        "title": "Nenhuma mensagem encontrada nesta conversa",
+        "description": "Se a mensagem foi enviada pelo suporte humano ou ativou uma ação automática, você pode encontrá-la no {studio_link}.",
+        "studio_link": "Estúdio"
+      },
+      "unclassified_status_tooltip": "Conversas encerradas antes de 8 de setembro de 2025 não podem ser classificadas",
+      "export": {
+        "title": "Enviar exportação por email",
+        "description": "Vamos preparar o arquivo com os dados de IA e enviá-lo para os seguintes emails:",
+        "token_label": "Token de API do projeto",
+        "token_placeholder": "86d2ba6397cabd4b22f7da925ef89d78bfb2d90dd",
+        "token_help": "Você pode encontrar este token nas",
+        "project_settings": "configurações do projeto",
+        "and_paste": "e colá-lo aqui",
+        "send": "Enviar exportação",
+        "success": "A exportação será enviada para todos os emails listados em breve",
+        "error": "Erro ao enviar exportação. Tente novamente mais tarde."
+      },
+      "filters": {
+        "filter_conversations": "Filtrar conversas",
+        "count_applied_filters": "{count, plural, one {(1 filtro aplicado)} other {({count} filtros aplicados)}}",
+        "filter_conversations_drawer": "Filtrar conversas",
+        "apply_filters": "Aplicar filtros",
+        "clear_filters": "Limpar filtros",
+        "period": {
+          "label": "Período"
+        },
+        "status": {
+          "conversations": "Conversas",
+          "in_progress": "Em progresso",
+          "optimized_resolution": "Atendido por IA",
+          "other_conclusion": "Não atendido",
+          "unclassified": "Não classificado",
+          "transferred_to_human_support": "Encaminhado para suporte humano"
+        },
+        "csat": {
+          "csat": "CSAT",
+          "very_satisfied": "🤩 Muito satisfeito",
+          "satisfied": "😃 Satisfeito",
+          "neutral": "😐 Neutro",
+          "dissatisfied": "😔 Insatisfeito",
+          "very_dissatisfied": "😡 Muito insatisfeito"
+        },
+        "topic": {
+          "topic": "Tópico",
+          "unclassified": "Não classificado"
+        }
+      },
+      "load_conversations": {
+        "error": "Erro ao carregar conversas"
       }
     }
   },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -13,10 +13,6 @@
   "unexpected_error": "A apărut o eroare neașteptată",
   "agent_builder": {
     "tabs": {
-      "conversations": {
-        "title": "Conversații",
-        "description": "Revizuiește și analizează conversațiile dintre agenți și clienți."
-      },
       "knowledge": {
         "title": "Cunoștințe",
         "description": "Adaugă cunoștințe prin fișiere, linkuri sau text pentru ca agentul să poată răspunde cu acuratețe"
@@ -24,95 +20,6 @@
       "tunings": {
         "title": "Setări",
         "description": "Gestionează setările și urmărește modificările făcute"
-      }
-    },
-    "supervisor": {
-      "learn_details_conversations": "Află detalii despre o conversație.",
-      "conversation_details": {
-        "title": "Despre conversație",
-        "what_is_a_conversation": "Ce este o conversație?",
-        "what_is_a_conversation_description": "Considerăm că toate mesajele schimbate în decurs de 24 de ore (cu resetare la miezul nopții) constituie o singură conversație.",
-        "optimized_resolution": "Asistat de IA",
-        "optimized_resolution_description": "Conversația s-a încheiat cu o rezoluție clară și eficientă pentru contact.",
-        "other_conclusion": "Neasistat",
-        "other_conclusion_description": "Conversații care s-au încheiat în alte moduri, cum ar fi interacțiuni scurte, salutări, abandonuri sau cazuri care au urmat un flux diferit fără o rezoluție directă.",
-        "transferred_to_human_support": "Transferat la asistență umană",
-        "transferred_to_human_support_description": "Include conversații (asistat de IA și neasistat) transferate către un reprezentant uman."
-      },
-      "conversations_count": "{count} conversații găsite",
-      "unnamed_contact": "Contact fără nume",
-      "attended_by_agent": {
-        "title": "Asistat de un agent",
-        "tooltip": "Conversații finalizate de un agent"
-      },
-      "forwarded_human_support": {
-        "title": "Transferat la asistență umană",
-        "tooltip": "Conversații transferate către asistență umană"
-      },
-      "conversation_start_finish": {
-        "start": "Conversație începută: {datetime}",
-        "finish": "Conversație încheiată: {datetime}"
-      },
-      "contact_urn": "URN contact",
-      "topic": "Subiect",
-      "conversation_details_collapse": "Detalii conversație",
-      "view_full_history": "Vezi istoricul complet",
-      "view_logs": "Afișează jurnalele",
-      "hide_logs": "Ascunde jurnalele",
-      "search": "Căutare",
-      "conversations_empty": "Nu s-au găsit conversații",
-      "conversations_separator": "Conversațiile de mai jos au fost clasificate folosind sistemul anterior",
-      "conversations_v2_disclaimer": "Începând cu {day} martie, conversațiile sunt organizate în ferestre de 24 de ore (cu resetare la miezul nopții) folosind noul nostru sistem de clasificare",
-      "no_messages_found": {
-        "title": "Nu s-au găsit mesaje în această conversație",
-        "description": "Dacă mesajul a fost trimis de asistența umană sau a declanșat o acțiune automată, îl poți găsi în {studio_link}.",
-        "studio_link": "Studio"
-      },
-      "unclassified_status_tooltip": "Conversațiile închise înainte de 8 septembrie 2025 nu pot fi clasificate",
-      "export": {
-        "title": "Exportă pe e-mail",
-        "description": "Vom pregăti fișierul cu informațiile AI și îl vom trimite la următoarele adrese de e-mail:",
-        "token_label": "Token API proiect",
-        "token_placeholder": "86d2ba6397cabd4b22f7da925ef89d78bfb2d90dd",
-        "token_help": "Poți găsi acest token în",
-        "project_settings": "setări proiect",
-        "and_paste": "și lipește-l aici",
-        "send": "Trimite exportul",
-        "success": "Exportul va fi trimis în curând către toate adresele de e-mail listate",
-        "error": "Eroare la trimiterea exportului. Încearcă din nou mai târziu."
-      },
-      "filters": {
-        "filter_conversations": "Filtrează conversațiile",
-        "count_applied_filters": "{count, plural, one {(1 filtru aplicat)} few {({count} filtre aplicate)} other {({count} de filtre aplicate)}}",
-        "filter_conversations_drawer": "Filtrează conversațiile",
-        "apply_filters": "Aplicare filtre",
-        "clear_filters": "Elimină filtrele",
-        "period": {
-          "label": "Perioadă"
-        },
-        "status": {
-          "conversations": "Conversații",
-          "in_progress": "În curs",
-          "optimized_resolution": "Asistat de IA",
-          "other_conclusion": "Neasistat",
-          "unclassified": "Neclasificat",
-          "transferred_to_human_support": "Transferat la asistență umană"
-        },
-        "csat": {
-          "csat": "CSAT",
-          "very_satisfied": "🤩 Foarte mulțumit",
-          "satisfied": "😃 Mulțumit",
-          "neutral": "😐 Neutru",
-          "dissatisfied": "😔 Nemulțumit",
-          "very_dissatisfied": "😡 Foarte nemulțumit"
-        },
-        "topic": {
-          "topic": "Subiect",
-          "unclassified": "Neclasificat"
-        }
-      },
-      "load_conversations": {
-        "error": "Eroare la încărcarea conversațiilor"
       }
     },
     "instructions": {
@@ -462,6 +369,100 @@
           }
 
         }
+      }
+    }
+  },
+  "audit": {
+    "title": "Audit",
+    "description": "Revizuiește și analizează conversațiile dintre agenți și clienți.",
+    "conversations": {
+      "title": "Conversații",
+      "learn_details_conversations": "Află detalii despre o conversație.",
+      "conversation_details": {
+        "title": "Despre conversație",
+        "what_is_a_conversation": "Ce este o conversație?",
+        "what_is_a_conversation_description": "Considerăm că toate mesajele schimbate în decurs de 24 de ore (cu resetare la miezul nopții) constituie o singură conversație.",
+        "optimized_resolution": "Asistat de IA",
+        "optimized_resolution_description": "Conversația s-a încheiat cu o rezoluție clară și eficientă pentru contact.",
+        "other_conclusion": "Neasistat",
+        "other_conclusion_description": "Conversații care s-au încheiat în alte moduri, cum ar fi interacțiuni scurte, salutări, abandonuri sau cazuri care au urmat un flux diferit fără o rezoluție directă.",
+        "transferred_to_human_support": "Transferat la asistență umană",
+        "transferred_to_human_support_description": "Include conversații (asistat de IA și neasistat) transferate către un reprezentant uman."
+      },
+      "conversations_count": "{count} conversații găsite",
+      "unnamed_contact": "Contact fără nume",
+      "attended_by_agent": {
+        "title": "Asistat de un agent",
+        "tooltip": "Conversații finalizate de un agent"
+      },
+      "forwarded_human_support": {
+        "title": "Transferat la asistență umană",
+        "tooltip": "Conversații transferate către asistență umană"
+      },
+      "conversation_start_finish": {
+        "start": "Conversație începută: {datetime}",
+        "finish": "Conversație încheiată: {datetime}"
+      },
+      "contact_urn": "URN contact",
+      "topic": "Subiect",
+      "conversation_details_collapse": "Detalii conversație",
+      "view_full_history": "Vezi istoricul complet",
+      "view_logs": "Afișează jurnalele",
+      "hide_logs": "Ascunde jurnalele",
+      "search": "Căutare",
+      "conversations_empty": "Nu s-au găsit conversații",
+      "conversations_separator": "Conversațiile de mai jos au fost clasificate folosind sistemul anterior",
+      "conversations_v2_disclaimer": "Începând cu {day} martie, conversațiile sunt organizate în ferestre de 24 de ore (cu resetare la miezul nopții) folosind noul nostru sistem de clasificare",
+      "no_messages_found": {
+        "title": "Nu s-au găsit mesaje în această conversație",
+        "description": "Dacă mesajul a fost trimis de asistența umană sau a declanșat o acțiune automată, îl poți găsi în {studio_link}.",
+        "studio_link": "Studio"
+      },
+      "unclassified_status_tooltip": "Conversațiile închise înainte de 8 septembrie 2025 nu pot fi clasificate",
+      "export": {
+        "title": "Exportă pe e-mail",
+        "description": "Vom pregăti fișierul cu informațiile AI și îl vom trimite la următoarele adrese de e-mail:",
+        "token_label": "Token API proiect",
+        "token_placeholder": "86d2ba6397cabd4b22f7da925ef89d78bfb2d90dd",
+        "token_help": "Poți găsi acest token în",
+        "project_settings": "setări proiect",
+        "and_paste": "și lipește-l aici",
+        "send": "Trimite exportul",
+        "success": "Exportul va fi trimis în curând către toate adresele de e-mail listate",
+        "error": "Eroare la trimiterea exportului. Încearcă din nou mai târziu."
+      },
+      "filters": {
+        "filter_conversations": "Filtrează conversațiile",
+        "count_applied_filters": "{count, plural, one {(1 filtru aplicat)} few {({count} filtre aplicate)} other {({count} de filtre aplicate)}}",
+        "filter_conversations_drawer": "Filtrează conversațiile",
+        "apply_filters": "Aplicare filtre",
+        "clear_filters": "Elimină filtrele",
+        "period": {
+          "label": "Perioadă"
+        },
+        "status": {
+          "conversations": "Conversații",
+          "in_progress": "În curs",
+          "optimized_resolution": "Asistat de IA",
+          "other_conclusion": "Neasistat",
+          "unclassified": "Neclasificat",
+          "transferred_to_human_support": "Transferat la asistență umană"
+        },
+        "csat": {
+          "csat": "CSAT",
+          "very_satisfied": "🤩 Foarte mulțumit",
+          "satisfied": "😃 Mulțumit",
+          "neutral": "😐 Neutru",
+          "dissatisfied": "😔 Nemulțumit",
+          "very_dissatisfied": "😡 Foarte nemulțumit"
+        },
+        "topic": {
+          "topic": "Subiect",
+          "unclassified": "Neclasificat"
+        }
+      },
+      "load_conversations": {
+        "error": "Eroare la încărcarea conversațiilor"
       }
     }
   },

--- a/src/store/Supervisor.js
+++ b/src/store/Supervisor.js
@@ -190,9 +190,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
       console.error('Error loading conversations:', error);
       alertStore.add({
         type: 'error',
-        text: i18n.global.t(
-          'agent_builder.supervisor.load_conversations.error',
-        ),
+        text: i18n.global.t('audit.conversations.load_conversations.error'),
       });
     } finally {
       conversationsAbortController = null;
@@ -300,12 +298,12 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
 
       alertStore.add({
         type: 'success',
-        text: i18n.global.t('agent_builder.supervisor.export.success'),
+        text: i18n.global.t('audit.conversations.export.success'),
       });
     } catch {
       alertStore.add({
         type: 'error',
-        text: i18n.global.t('agent_builder.supervisor.export.error'),
+        text: i18n.global.t('audit.conversations.export.error'),
       });
     }
   }

--- a/src/store/__tests__/Supervisor.unit.spec.js
+++ b/src/store/__tests__/Supervisor.unit.spec.js
@@ -440,7 +440,7 @@ describe('Supervisor Store', () => {
 
         expect(alertStore.add).toHaveBeenCalledWith({
           type: 'success',
-          text: 'agent_builder.supervisor.export.success',
+          text: 'audit.conversations.export.success',
         });
       });
 
@@ -453,7 +453,7 @@ describe('Supervisor Store', () => {
 
         expect(alertStore.add).toHaveBeenCalledWith({
           type: 'error',
-          text: 'agent_builder.supervisor.export.error',
+          text: 'audit.conversations.export.error',
         });
       });
 

--- a/src/views/Supervisor/SupervisorConversations/Conversation/Details/Table.vue
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/Details/Table.vue
@@ -2,18 +2,18 @@
   <table class="details__table">
     <tbody>
       <Row
-        :label="$t('agent_builder.supervisor.contact_urn')"
+        :label="$t('audit.conversations.contact_urn')"
         :data="formattedUrn"
       />
 
       <Row
-        :label="$t('agent_builder.supervisor.topic')"
+        :label="$t('audit.conversations.topic')"
         :data="formattedTopics"
       />
 
       <template v-if="!isCollapsed">
         <Row
-          :label="$t('agent_builder.supervisor.filters.csat.csat')"
+          :label="$t('audit.conversations.filters.csat.csat')"
           :data="formattedCsat"
         />
       </template>
@@ -52,7 +52,7 @@ const formattedCsat = computed(() => {
 
   if (!csat) return '-';
   return `${i18n.global.t(
-    `agent_builder.supervisor.filters.csat.${csat.id}`,
+    `audit.conversations.filters.csat.${csat.id}`,
   )} | CSAT: ${csat.score}`;
 });
 </script>

--- a/src/views/Supervisor/SupervisorConversations/Conversation/Details/index.vue
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/Details/index.vue
@@ -7,14 +7,14 @@
       type="secondary"
       @click="goToStudio"
     >
-      {{ $t('agent_builder.supervisor.view_full_history') }}
+      {{ $t('audit.conversations.view_full_history') }}
     </UnnnicButton>
 
     <button
       class="conversation-details__collapse-button"
       @click="isCollapsed = !isCollapsed"
     >
-      {{ $t('agent_builder.supervisor.conversation_details_collapse') }}
+      {{ $t('audit.conversations.conversation_details_collapse') }}
       <UnnnicIcon
         icon="keyboard_arrow_up"
         :class="[

--- a/src/views/Supervisor/SupervisorConversations/Conversation/NoMessagesFound.vue
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/NoMessagesFound.vue
@@ -12,7 +12,7 @@
       class="no-messages-found__title"
       data-testid="no-messages-title"
     >
-      {{ $t('agent_builder.supervisor.no_messages_found.title') }}
+      {{ $t('audit.conversations.no_messages_found.title') }}
     </p>
 
     <p
@@ -20,7 +20,7 @@
       data-testid="no-messages-description"
     >
       <i18n-t
-        keypath="agent_builder.supervisor.no_messages_found.description"
+        keypath="audit.conversations.no_messages_found.description"
         tag="p"
         data-testid="no-messages-description-i18n"
       >
@@ -31,7 +31,7 @@
             target="_blank"
             data-testid="studio-link"
           >
-            {{ $t('agent_builder.supervisor.no_messages_found.studio_link') }}
+            {{ $t('audit.conversations.no_messages_found.studio_link') }}
           </a>
         </template>
       </i18n-t>

--- a/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/ConversationStartFinish.vue
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/ConversationStartFinish.vue
@@ -26,7 +26,7 @@ const props = defineProps({
 
 const text = computed(() => {
   return i18n.global.t(
-    `agent_builder.supervisor.conversation_start_finish.${props.type}`,
+    `audit.conversations.conversation_start_finish.${props.type}`,
     {
       datetime: format(props.datetime, 'dd/MM/yy HH:mm'),
     },

--- a/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/ViewLogsButton.vue
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/ViewLogsButton.vue
@@ -37,8 +37,8 @@
       >
         {{
           active
-            ? $t('agent_builder.supervisor.hide_logs')
-            : $t('agent_builder.supervisor.view_logs')
+            ? $t('audit.conversations.hide_logs')
+            : $t('audit.conversations.view_logs')
         }}
       </UnnnicIntelligenceText>
     </section>

--- a/src/views/Supervisor/SupervisorConversations/Conversation/__tests__/NoMessagesFound.spec.js
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/__tests__/NoMessagesFound.spec.js
@@ -68,7 +68,7 @@ describe('NoMessagesFound.vue', () => {
       expect(description().exists()).toBe(true);
       expect(descriptionI18n().exists()).toBe(true);
       expect(descriptionI18n().props('keypath')).toBe(
-        'agent_builder.supervisor.no_messages_found.description',
+        'audit.conversations.no_messages_found.description',
       );
       expect(descriptionI18n().props('tag')).toBe('p');
     });

--- a/src/views/Supervisor/SupervisorConversations/ConversationsTable/ConversationRow.vue
+++ b/src/views/Supervisor/SupervisorConversations/ConversationsTable/ConversationRow.vue
@@ -31,7 +31,7 @@
         <UnnnicToolTip
           v-if="statusProps.text"
           side="top"
-          :text="$t('agent_builder.supervisor.unclassified_status_tooltip')"
+          :text="$t('audit.conversations.unclassified_status_tooltip')"
           :enabled="conversation.status === 'unclassified'"
         >
           <UnnnicTag
@@ -90,7 +90,7 @@ const statusProps = computed(() => {
   const status = props.conversation.status;
 
   const baseStatus = {
-    text: status ? t(`agent_builder.supervisor.filters.status.${status}`) : '',
+    text: status ? t(`audit.conversations.filters.status.${status}`) : '',
   };
 
   const mapStatus = {
@@ -122,7 +122,7 @@ const csatText = computed(() => {
 
   const csat = props.conversation.csat;
   const csatTranslation = i18n.global.t(
-    `agent_builder.supervisor.filters.csat.${csat.id}`,
+    `audit.conversations.filters.csat.${csat.id}`,
   );
 
   return `${csatTranslation} | CSAT: ${csat.score}`;

--- a/src/views/Supervisor/SupervisorConversations/ConversationsTable/index.vue
+++ b/src/views/Supervisor/SupervisorConversations/ConversationsTable/index.vue
@@ -15,7 +15,7 @@
             data-testid="conversations-separator"
           >
             <td class="conversations-table__separator-text">
-              {{ $t('agent_builder.supervisor.conversations_separator') }}
+              {{ $t('audit.conversations.conversations_separator') }}
             </td>
           </tr>
           <ConversationRow
@@ -51,7 +51,7 @@
       />
 
       <p class="conversations-table__empty-title">
-        {{ $t('agent_builder.supervisor.conversations_empty') }}
+        {{ $t('audit.conversations.conversations_empty') }}
       </p>
     </section>
   </table>

--- a/src/views/Supervisor/SupervisorConversations/index.vue
+++ b/src/views/Supervisor/SupervisorConversations/index.vue
@@ -9,7 +9,7 @@
     <UnnnicDisclaimer
       type="informational"
       :description="
-        $t('agent_builder.supervisor.conversations_v2_disclaimer', {
+        $t('audit.conversations.conversations_v2_disclaimer', {
           day: conversationsSwitchDay,
         })
       "

--- a/src/views/Supervisor/SupervisorFilters/FilterCsat.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterCsat.vue
@@ -1,5 +1,5 @@
 <template>
-  <UnnnicFormElement :label="$t('agent_builder.supervisor.filters.csat.csat')">
+  <UnnnicFormElement :label="$t('audit.conversations.filters.csat.csat')">
     <UnnnicSelectSmart
       v-model:modelValue="csatFilter"
       data-testid="csat-select"
@@ -36,7 +36,7 @@ type SelectOption = {
 };
 
 const translateCsat = (filter: string) =>
-  i18n.global.t(`agent_builder.supervisor.filters.csat.${filter}`);
+  i18n.global.t(`audit.conversations.filters.csat.${filter}`);
 
 const csatOptions = computed<SelectOption[]>(() => [
   { label: translateCsat('csat'), value: '' },

--- a/src/views/Supervisor/SupervisorFilters/FilterDate.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterDate.vue
@@ -1,7 +1,5 @@
 <template>
-  <UnnnicFormElement
-    :label="$t('agent_builder.supervisor.filters.period.label')"
-  >
+  <UnnnicFormElement :label="$t('audit.conversations.filters.period.label')">
     <UnnnicInputDatePicker
       v-model="dateFilter"
       position="right"

--- a/src/views/Supervisor/SupervisorFilters/FilterStatus.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterStatus.vue
@@ -1,6 +1,6 @@
 <template>
   <UnnnicFormElement
-    :label="$t('agent_builder.supervisor.filters.status.conversations')"
+    :label="$t('audit.conversations.filters.status.conversations')"
   >
     <UnnnicSelectSmart
       v-model:modelValue="statusFilter"
@@ -23,7 +23,7 @@ import { useSupervisorStore } from '@/store/Supervisor';
 const supervisorStore = useSupervisorStore();
 
 const getStatusTranslation = (filter) =>
-  i18n.global.t(`agent_builder.supervisor.filters.status.${filter}`);
+  i18n.global.t(`audit.conversations.filters.status.${filter}`);
 
 const statusOptions = computed(() => [
   { label: getStatusTranslation('conversations'), value: '' },

--- a/src/views/Supervisor/SupervisorFilters/FilterText.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterText.vue
@@ -3,7 +3,7 @@
     v-model="search"
     iconLeft="search"
     data-testid="search-input"
-    :placeholder="$t('agent_builder.supervisor.search')"
+    :placeholder="$t('audit.conversations.search')"
   />
 </template>
 

--- a/src/views/Supervisor/SupervisorFilters/FilterTopics.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterTopics.vue
@@ -1,7 +1,5 @@
 <template>
-  <UnnnicFormElement
-    :label="$t('agent_builder.supervisor.filters.topic.topic')"
-  >
+  <UnnnicFormElement :label="$t('audit.conversations.filters.topic.topic')">
     <UnnnicSelectSmart
       v-model:modelValue="topicFilter"
       data-testid="topic-select"
@@ -23,13 +21,13 @@ import { useSupervisorStore } from '@/store/Supervisor';
 const supervisorStore = useSupervisorStore();
 
 const UNCLASSIFIED_TOPIC = {
-  label: i18n.global.t('agent_builder.supervisor.filters.topic.unclassified'),
+  label: i18n.global.t('audit.conversations.filters.topic.unclassified'),
   value: 'unclassified',
 };
 
 const topicOptions = computed(() => [
   {
-    label: i18n.global.t(`agent_builder.supervisor.filters.topic.topic`),
+    label: i18n.global.t(`audit.conversations.filters.topic.topic`),
     value: '',
   },
   UNCLASSIFIED_TOPIC,

--- a/src/views/Supervisor/SupervisorFilters/__tests__/FilterText.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/FilterText.spec.js
@@ -63,7 +63,7 @@ describe('FilterText.vue', () => {
       expect(input().exists()).toBe(true);
       expect(input().props('iconLeft')).toBe('search');
       expect(input().props('placeholder')).toBe(
-        i18n.global.t('agent_builder.supervisor.search'),
+        i18n.global.t('audit.conversations.search'),
       );
     });
 

--- a/src/views/Supervisor/SupervisorFilters/__tests__/SupervisorFilters.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/SupervisorFilters.spec.js
@@ -79,18 +79,15 @@ describe('SupervisorFilters.vue', () => {
 
     it('not show count of applied filters when no filters are applied', () => {
       expect(buttonFilter().props('text')).toBe(
-        i18n.global.t('agent_builder.supervisor.filters.filter_conversations'),
+        i18n.global.t('audit.conversations.filters.filter_conversations'),
       );
     });
 
     it('show count of applied filters when filters are applied', async () => {
       const countTranslation = (count) =>
-        i18n.global.t(
-          'agent_builder.supervisor.filters.count_applied_filters',
-          {
-            count,
-          },
-        );
+        i18n.global.t('audit.conversations.filters.count_applied_filters', {
+          count,
+        });
 
       store.filters.status = ['status'];
       await wrapper.vm.$nextTick();

--- a/src/views/Supervisor/SupervisorFilters/index.vue
+++ b/src/views/Supervisor/SupervisorFilters/index.vue
@@ -14,14 +14,10 @@
       data-testid="drawer-filter"
       :modelValue="isFilterDrawerOpen"
       class="supervisor-filters__drawer"
-      :title="
-        $t('agent_builder.supervisor.filters.filter_conversations_drawer')
-      "
-      :primaryButtonText="$t('agent_builder.supervisor.filters.apply_filters')"
+      :title="$t('audit.conversations.filters.filter_conversations_drawer')"
+      :primaryButtonText="$t('audit.conversations.filters.apply_filters')"
       :disabledPrimaryButton="filterDrawerApplyButtonDisabled"
-      :secondaryButtonText="
-        $t('agent_builder.supervisor.filters.clear_filters')
-      "
+      :secondaryButtonText="$t('audit.conversations.filters.clear_filters')"
       :disabledSecondaryButton="filterDrawerClearButtonDisabled"
       @close="closeFilterDrawer"
       @primary-button-click="applyFilters"
@@ -74,13 +70,10 @@ const filterButtonText = computed(() => {
   const { t } = i18n.global;
   const count = countAppliedFilters.value;
 
-  const text = t('agent_builder.supervisor.filters.filter_conversations');
-  const countText = t(
-    'agent_builder.supervisor.filters.count_applied_filters',
-    {
-      count,
-    },
-  );
+  const text = t('audit.conversations.filters.filter_conversations');
+  const countText = t('audit.conversations.filters.count_applied_filters', {
+    count,
+  });
 
   return count > 0 ? `${text} ${countText}` : text;
 });

--- a/src/views/Supervisor/SupervisorHeader.vue
+++ b/src/views/Supervisor/SupervisorHeader.vue
@@ -55,11 +55,9 @@ const { t } = i18n.global;
 
 const featureFlagsStore = useFeatureFlagsStore();
 
-const headerTitle = computed(() => t('agent_builder.tabs.conversations.title'));
+const headerTitle = computed(() => t('audit.title'));
 
-const headerDescription = computed(() =>
-  t('agent_builder.tabs.conversations.description'),
-);
+const headerDescription = computed(() => t('audit.description'));
 
 const showExport = computed(() => featureFlagsStore.flags.supervisorExport);
 


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The conversation-related i18n keys and locale strings previously lived under `agent_builder.supervisor` and `agent_builder.tabs.conversations`. As the Supervisor/Conversations feature has grown into its own distinct "Audit" section, the translation keys needed to be reorganized to reflect that structure more accurately.

### Summary of Changes
All i18n translation keys previously under `agent_builder.supervisor` and `agent_builder.tabs.conversations` have been moved to a new top-level `audit.conversations` namespace across all locale files (`en.json`, `es.json`, `pt_br.json`, `ro.json`). The `audit` namespace also introduces top-level `title` and `description` keys, replacing the former `agent_builder.tabs.conversations.title` and `agent_builder.tabs.conversations.description` used in the supervisor header.

All component references in `SupervisorExportModal.vue`, `SupervisorHeaderDetails.vue`, `SupervisorUsername.vue`, `SupervisorHeader.vue`, the filter components, the conversation table and detail views, and the Supervisor store have been updated to use the new `audit.conversations.*` key paths. The API mock references in the Supervisor store tests have also been updated from `nexusaiAPI.agent_builder.supervisor.conversations` to `nexusaiAPI.audit.conversations.conversations`.