### PR TITLE
feat: Add Improvements backlog tab to Audit view

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -465,6 +465,11 @@
       "load_conversations": {
         "error": "Error loading conversations"
       }
+    },
+
+    "improvements": {
+      "title": "Improvement backlog"
+
     }
   },
   "router": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -465,6 +465,9 @@
       "load_conversations": {
         "error": "Error al cargar conversaciones"
       }
+    },
+    "improvements": {
+      "title": "Backlog de mejoras"
     }
   },
   "router": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -465,6 +465,9 @@
       "load_conversations": {
         "error": "Erro ao carregar conversas"
       }
+    },
+    "improvements": {
+      "title": "Backlog de melhorias"
     }
   },
   "router": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -464,6 +464,9 @@
       "load_conversations": {
         "error": "Eroare la încărcarea conversațiilor"
       }
+    },
+    "improvements": {
+      "title": "Backlog de îmbunătățiri"
     }
   },
   "router": {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -33,6 +33,13 @@ const conversationsRoutes: RouteRecordRaw[] = [
     path: MODULE_PATHS.conversations,
     name: 'conversations',
     component: () => import('@/views/Supervisor/index.vue'),
+    children: [
+      {
+        path: 'improvements',
+        name: 'improvements',
+        component: () => import('@/views/Supervisor/Improvements/index.vue'),
+      },
+    ],
   },
 ];
 

--- a/src/store/FeatureFlags.js
+++ b/src/store/FeatureFlags.js
@@ -45,6 +45,7 @@ export const useFeatureFlagsStore = defineStore('FeatureFlags', () => {
   const flags = computed(() => ({
     supervisorExport: isProjectEnabledForFlag('FF_SUPERVISOR_EXPORT'),
     settingsAgentVoice: isFeatureFlagEnabled('settings_agent_voice'),
+    conversationsImprovements: isFeatureFlagEnabled('improvements'),
   }));
 
   return {

--- a/src/views/Supervisor/Improvements/__tests__/index.spec.js
+++ b/src/views/Supervisor/Improvements/__tests__/index.spec.js
@@ -1,0 +1,18 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import Improvements from '@/views/Supervisor/Improvements/index.vue';
+
+describe('Improvements view', () => {
+  let wrapper;
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders the improvements section', () => {
+    wrapper = shallowMount(Improvements);
+
+    expect(wrapper.find('.conversations-improvements').exists()).toBe(true);
+  });
+});

--- a/src/views/Supervisor/Improvements/index.vue
+++ b/src/views/Supervisor/Improvements/index.vue
@@ -1,0 +1,12 @@
+<template>
+  <section class="conversations-improvements"></section>
+</template>
+
+<script setup></script>
+
+<style scoped lang="scss">
+.conversations-improvements {
+  padding: $unnnic-space-4;
+  padding-top: 0;
+}
+</style>

--- a/src/views/Supervisor/SupervisorHeader.vue
+++ b/src/views/Supervisor/SupervisorHeader.vue
@@ -15,7 +15,7 @@
         >
           {{ headerDescription }}
 
-          <SupervisorHeaderDetails />
+          <SupervisorHeaderDetails v-if="activeTab === 'conversations'" />
         </p>
       </section>
     </template>
@@ -38,10 +38,32 @@
         data-testid="export-modal"
       />
     </template>
+
+    <template
+      v-if="featureFlagsStore.flags.conversationsImprovements"
+      #tabs
+    >
+      <UnnnicTabs
+        :modelValue="activeTab"
+        @update:model-value="router.replace({ name: $event })"
+      >
+        <UnnnicTabsList>
+          <UnnnicTabsTrigger value="conversations">
+            {{ $t('audit.conversations.title') }}
+          </UnnnicTabsTrigger>
+          <UnnnicTabsTrigger value="improvements">
+            {{ $t('audit.improvements.title') }}
+          </UnnnicTabsTrigger>
+        </UnnnicTabsList>
+      </UnnnicTabs>
+    </template>
   </UnnnicPageHeader>
 </template>
 
 <script setup>
+import { computed, ref } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+
 import SupervisorExportModal from '@/components/Supervisor/SupervisorExportModal.vue';
 import SupervisorHeaderDetails from '@/components/Supervisor/SupervisorHeaderDetails.vue';
 
@@ -49,19 +71,18 @@ import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 
 import i18n from '@/utils/plugins/i18n';
 
-import { computed, ref } from 'vue';
-
 const { t } = i18n.global;
 
 const featureFlagsStore = useFeatureFlagsStore();
+const router = useRouter();
+const route = useRoute();
+
+const activeTab = computed(() => route.name || 'conversations');
+const isExportModalOpen = ref(false);
 
 const headerTitle = computed(() => t('audit.title'));
-
 const headerDescription = computed(() => t('audit.description'));
-
 const showExport = computed(() => featureFlagsStore.flags.supervisorExport);
-
-const isExportModalOpen = ref(false);
 
 function openExportModal() {
   isExportModalOpen.value = true;

--- a/src/views/Supervisor/__tests__/SupervisorHeader.spec.js
+++ b/src/views/Supervisor/__tests__/SupervisorHeader.spec.js
@@ -1,12 +1,27 @@
 import { mount } from '@vue/test-utils';
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import SupervisorHeader from '../SupervisorHeader.vue';
-import { useFeatureFlagsStore } from '@/store/FeatureFlags';
+import { reactive } from 'vue';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
+
+import SupervisorHeader from '../SupervisorHeader.vue';
+import SupervisorHeaderDetails from '@/components/Supervisor/SupervisorHeaderDetails.vue';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
+import i18n from '@/utils/plugins/i18n';
+
+const mockRoute = reactive({ name: 'conversations' });
+const mockReplace = vi.fn();
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mockRoute,
+  useRouter: () => ({
+    replace: mockReplace,
+  }),
+}));
 
 const pinia = createTestingPinia({
   initialState: {
     featureFlags: {
+      activeFeatures: ['improvements'],
       flags: {
         supervisorExport: false,
       },
@@ -18,7 +33,17 @@ describe('SupervisorHeader', () => {
   let wrapper;
   let featureFlagsStore;
 
+  const findPageTitle = () => wrapper.find('[data-testid="page-title"]');
+  const findPageDescription = () =>
+    wrapper.find('[data-testid="page-description"]');
+  const findExportButton = () => wrapper.find('[data-testid="export-button"]');
+  const findExportModal = () => wrapper.find('[data-testid="export-modal"]');
+  const findTabs = () => wrapper.findComponent({ name: 'UnnnicTabs' });
+
   beforeEach(() => {
+    vi.clearAllMocks();
+    mockRoute.name = 'conversations';
+
     wrapper = mount(SupervisorHeader, {
       global: {
         plugins: [pinia],
@@ -26,6 +51,7 @@ describe('SupervisorHeader', () => {
     });
 
     featureFlagsStore = useFeatureFlagsStore();
+    featureFlagsStore.activeFeatures = ['improvements'];
   });
 
   afterEach(() => {
@@ -33,20 +59,58 @@ describe('SupervisorHeader', () => {
   });
 
   it('should render the component correctly', () => {
-    expect(wrapper.find('[data-testid="page-title"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="page-description"]').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="export-button"]').exists()).toBe(false);
-    expect(wrapper.find('[data-testid="export-modal"]').exists()).toBe(false);
+    expect(findPageTitle().exists()).toBe(true);
+    expect(findPageDescription().exists()).toBe(true);
+    expect(findExportButton().exists()).toBe(false);
+    expect(findExportModal().exists()).toBe(false);
   });
 
   it('should not show export button when supervisorExport flag is false', () => {
     featureFlagsStore.flags.supervisorExport = false;
 
-    expect(
-      wrapper.findComponent('[data-testid="export-button"]').exists(),
-    ).toBe(false);
-    expect(wrapper.findComponent('[data-testid="export-modal"]').exists()).toBe(
-      false,
-    );
+    expect(findExportButton().exists()).toBe(false);
+    expect(findExportModal().exists()).toBe(false);
+  });
+
+  it('should render conversations and improvements tabs when conversationsImprovements flag is enabled', () => {
+    const { t } = i18n.global;
+
+    expect(findTabs().exists()).toBe(true);
+    expect(wrapper.text()).toContain(t('audit.conversations.title'));
+    expect(wrapper.text()).toContain(t('audit.improvements.title'));
+  });
+
+  it('should not render tabs when conversationsImprovements flag is disabled', async () => {
+    featureFlagsStore.activeFeatures = [];
+    await wrapper.unmount();
+
+    wrapper = mount(SupervisorHeader, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+
+    expect(findTabs().exists()).toBe(false);
+  });
+
+  it('should show header details only on conversations tab', async () => {
+    expect(wrapper.findComponent(SupervisorHeaderDetails).exists()).toBe(true);
+
+    mockRoute.name = 'improvements';
+    await wrapper.unmount();
+
+    wrapper = mount(SupervisorHeader, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+
+    expect(wrapper.findComponent(SupervisorHeaderDetails).exists()).toBe(false);
+  });
+
+  it('should navigate to the selected tab route', async () => {
+    await findTabs().vm.$emit('update:modelValue', 'improvements');
+
+    expect(mockReplace).toHaveBeenCalledWith({ name: 'improvements' });
   });
 });

--- a/src/views/Supervisor/__tests__/__snapshots__/index.spec.js.snap
+++ b/src/views/Supervisor/__tests__/__snapshots__/index.spec.js.snap
@@ -1,6 +1,16 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`Supervisor view > matches snapshot 1`] = `
+exports[`Supervisor view > improvements route > matches snapshot on improvements route 1`] = `
+"<section data-v-8a19bad7="" class="supervisor">
+  <section data-v-8a19bad7="" class="supervisor__content">
+    <supervisor-header-stub data-v-8a19bad7="" class="supervisor__header" data-testid="header"></supervisor-header-stub>
+    <router-view-stub data-v-8a19bad7="" name="default"></router-view-stub>
+  </section>
+  <!--v-if-->
+</section>"
+`;
+
+exports[`Supervisor view > matches snapshot on conversations route 1`] = `
 "<section data-v-8a19bad7="" class="supervisor">
   <section data-v-8a19bad7="" class="supervisor__content">
     <supervisor-header-stub data-v-8a19bad7="" class="supervisor__header" data-testid="header"></supervisor-header-stub>

--- a/src/views/Supervisor/__tests__/index.spec.js
+++ b/src/views/Supervisor/__tests__/index.spec.js
@@ -1,4 +1,5 @@
 import { shallowMount } from '@vue/test-utils';
+import { reactive } from 'vue';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { useRouter } from 'vue-router';
@@ -6,17 +7,20 @@ import { useRouter } from 'vue-router';
 import Supervisor from '@/views/Supervisor/index.vue';
 import { useSupervisorStore } from '@/store/Supervisor';
 
+const mockRoute = reactive({
+  name: 'conversations',
+  query: {
+    started_day: '2024-01-01',
+    ended_day: '2024-01-31',
+  },
+});
+
 vi.mock('vue-router', async () => {
   const actual = await vi.importActual('vue-router');
 
   return {
     ...actual,
-    useRoute: vi.fn(() => ({
-      query: {
-        started_day: '2024-01-01',
-        ended_day: '2024-01-31',
-      },
-    })),
+    useRoute: vi.fn(() => mockRoute),
     useRouter: vi.fn(() => ({
       replace: vi.fn(),
     })),
@@ -27,7 +31,16 @@ describe('Supervisor view', () => {
   let wrapper;
   let supervisorStore;
 
+  const findHeader = () => wrapper.findComponent('[data-testid="header"]');
+  const findConversations = () =>
+    wrapper.findComponent('[data-testid="supervisor-conversations"]');
+  const findConversation = () =>
+    wrapper.findComponent('[data-testid="supervisor-conversation"]');
+  const findRouterView = () => wrapper.findComponent({ name: 'RouterView' });
+
   beforeEach(() => {
+    mockRoute.name = 'conversations';
+
     const pinia = createTestingPinia();
 
     supervisorStore = useSupervisorStore();
@@ -42,30 +55,26 @@ describe('Supervisor view', () => {
   });
 
   afterEach(() => {
+    wrapper?.unmount();
     vi.clearAllMocks();
     vi.restoreAllMocks();
   });
 
-  it('matches snapshot', () => {
+  it('matches snapshot on conversations route', () => {
     expect(wrapper.html()).toMatchSnapshot();
   });
 
   it('renders SupervisorHeader component', () => {
-    expect(wrapper.findComponent('[data-testid="header"]').exists()).toBe(true);
+    expect(findHeader().exists()).toBe(true);
   });
 
-  it('renders SupervisorConversations component', () => {
-    expect(
-      wrapper
-        .findComponent('[data-testid="supervisor-conversations"]')
-        .exists(),
-    ).toBe(true);
+  it('renders SupervisorConversations component on conversations route', () => {
+    expect(findConversations().exists()).toBe(true);
+    expect(findRouterView().exists()).toBe(false);
   });
 
   it('renders Conversation component when selectedConversation is present', async () => {
-    expect(
-      wrapper.findComponent('[data-testid="supervisor-conversation"]').exists(),
-    ).toBe(false);
+    expect(findConversation().exists()).toBe(false);
 
     supervisorStore.selectedConversation = {
       id: 1,
@@ -75,9 +84,43 @@ describe('Supervisor view', () => {
     await wrapper.vm.$nextTick();
 
     expect(wrapper.classes()).toContain('supervisor--with-conversation');
-    expect(
-      wrapper.findComponent('[data-testid="supervisor-conversation"]').exists(),
-    ).toBe(true);
+    expect(findConversation().exists()).toBe(true);
+  });
+
+  describe('improvements route', () => {
+    beforeEach(async () => {
+      mockRoute.name = 'improvements';
+      await wrapper.unmount();
+
+      wrapper = shallowMount(Supervisor, {
+        global: {
+          plugins: [createTestingPinia()],
+        },
+      });
+
+      supervisorStore = useSupervisorStore();
+    });
+
+    it('matches snapshot on improvements route', () => {
+      expect(wrapper.html()).toMatchSnapshot();
+    });
+
+    it('renders RouterView instead of SupervisorConversations', () => {
+      expect(findConversations().exists()).toBe(false);
+      expect(findRouterView().exists()).toBe(true);
+    });
+
+    it('does not render Conversation panel even when a conversation is selected', async () => {
+      supervisorStore.selectedConversation = {
+        id: 1,
+        title: 'Test Conversation',
+      };
+
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.classes()).not.toContain('supervisor--with-conversation');
+      expect(findConversation().exists()).toBe(false);
+    });
   });
 
   describe('Auto-load conversations without scrollbar', () => {

--- a/src/views/Supervisor/index.vue
+++ b/src/views/Supervisor/index.vue
@@ -2,7 +2,10 @@
   <section
     :class="[
       'supervisor',
-      { 'supervisor--with-conversation': selectedConversation },
+      {
+        'supervisor--with-conversation':
+          isConversationsRoute && selectedConversation,
+      },
     ]"
   >
     <section
@@ -15,13 +18,16 @@
         data-testid="header"
       />
       <SupervisorConversations
+        v-if="isConversationsRoute"
         ref="supervisorConversations"
         class="supervisor__conversations"
         data-testid="supervisor-conversations"
       />
+
+      <RouterView v-else />
     </section>
     <Conversation
-      v-if="selectedConversation"
+      v-if="isConversationsRoute && selectedConversation"
       class="supervisor__conversation"
       data-testid="supervisor-conversation"
     />
@@ -30,15 +36,13 @@
 
 <script setup>
 import { computed, onBeforeMount, watch, ref, nextTick } from 'vue';
-import { useRouter, useRoute } from 'vue-router';
+import { useRouter, useRoute, RouterView } from 'vue-router';
 
 import SupervisorHeader from './SupervisorHeader.vue';
 import SupervisorConversations from './SupervisorConversations/index.vue';
 import Conversation from './SupervisorConversations/Conversation/index.vue';
 
-import {
-  hasMoreToLoad,
-} from '@/api/adapters/supervisor/conversationSources';
+import { hasMoreToLoad } from '@/api/adapters/supervisor/conversationSources';
 import { useSupervisorStore } from '@/store/Supervisor';
 import { cleanParams } from '@/utils/http';
 
@@ -53,6 +57,8 @@ const isCheckingScroll = ref(false);
 const selectedConversation = computed(() => {
   return supervisorStore.selectedConversation;
 });
+
+const isConversationsRoute = computed(() => route.name === 'conversations');
 
 const conversations = computed(() => supervisorStore.conversations);
 


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other
```

### Motivation and Context

A new "Improvements" section needs to be accessible from the Supervisor view, allowing supervisors to navigate between the existing conversations view and a new improvements backlog. This feature is gated behind a feature flag to allow controlled rollout.

### Summary of Changes

- Added a new `improvements` child route under the `conversations` route, rendering a new `Improvements` view component
- Created the `Improvements` view (`src/views/Supervisor/Improvements/index.vue`) as the entry point for the improvements backlog section
- Added a `conversationsImprovements` feature flag (`improvements`) to control visibility of the new section
- Updated `SupervisorHeader` to render a tabbed navigation (`UnnnicTabs`) between "Conversations" and "Improvements" when the feature flag is enabled, with tab changes triggering route navigation
- Restricted `SupervisorHeaderDetails` visibility to only the conversations tab
- Updated the `Supervisor` index view to conditionally render `SupervisorConversations` or a `RouterView` based on the active route, and scoped the `supervisor--with-conversation` class and the `Conversation` panel to the conversations route only
- Added the `improvements` title translation key across `en`, `es`, `pt_br`, and `ro` locales
- Added and updated tests for the new routing behavior, tab rendering, and improvements view

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/a6fd6737-5289-421a-8223-f2d3f2d10da7.png)

