### PR TITLE
feat: Add NoAnalysisPerformed empty state to Improvements view

### DIFF
--- a/src/components/ConversationsImprovements/NoAnalysisPerformed.vue
+++ b/src/components/ConversationsImprovements/NoAnalysisPerformed.vue
@@ -1,0 +1,67 @@
+<template>
+  <section
+    class="no-analysis-performed"
+    data-testid="no-analysis-performed"
+  >
+    <header class="no-analysis-performed__header">
+      <h2
+        class="no-analysis-performed__title"
+        data-testid="no-analysis-performed-title"
+      >
+        {{ $t('audit.improvements.no_analysis.title') }}
+      </h2>
+      <p
+        class="no-analysis-performed__description"
+        data-testid="no-analysis-performed-description"
+      >
+        {{ $t('audit.improvements.no_analysis.description') }}
+      </p>
+    </header>
+
+    <UnnnicButton
+      data-testid="no-analysis-performed-run-button"
+      type="primary"
+      :text="$t('audit.improvements.no_analysis.run_analysis')"
+      :loading="improvementsStore.analysis.status === 'loading'"
+      @click="improvementsStore.runAnalysis"
+    />
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useImprovementsStore } from '@/store/Improvements';
+
+const improvementsStore = useImprovementsStore();
+</script>
+
+<style scoped lang="scss">
+.no-analysis-performed {
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: $unnnic-space-4;
+
+  &__header {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: $unnnic-space-1;
+
+    text-align: center;
+  }
+
+  &__title {
+    font: $unnnic-font-action;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__description {
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/__tests__/NoAnalysisPerformed.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/NoAnalysisPerformed.spec.js
@@ -1,0 +1,83 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import { useImprovementsStore } from '@/store/Improvements';
+
+import NoAnalysisPerformed from '../NoAnalysisPerformed.vue';
+
+describe('NoAnalysisPerformed.vue', () => {
+  let wrapper;
+  let improvementsStore;
+
+  const findTitle = () =>
+    wrapper.find('[data-testid="no-analysis-performed-title"]');
+  const findDescription = () =>
+    wrapper.find('[data-testid="no-analysis-performed-description"]');
+  const findRunAnalysisButton = () =>
+    wrapper.findComponent('[data-testid="no-analysis-performed-run-button"]');
+
+  const createWrapper = () => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+    });
+
+    wrapper = shallowMount(NoAnalysisPerformed, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+
+    improvementsStore = useImprovementsStore(pinia);
+
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Component rendering', () => {
+    it('renders the empty state section', () => {
+      expect(
+        wrapper.find('[data-testid="no-analysis-performed"]').exists(),
+      ).toBe(true);
+    });
+
+    it('renders the title with the correct translation', () => {
+      expect(findTitle().text()).toBe(
+        i18n.global.t('audit.improvements.no_analysis.title'),
+      );
+    });
+
+    it('renders the description with the correct translation', () => {
+      expect(findDescription().text()).toBe(
+        i18n.global.t('audit.improvements.no_analysis.description'),
+      );
+    });
+
+    it('renders the run analysis button with the correct configuration', () => {
+      const button = findRunAnalysisButton();
+
+      expect(button.exists()).toBe(true);
+      expect(button.props('type')).toBe('primary');
+      expect(button.props('text')).toBe(
+        i18n.global.t('audit.improvements.no_analysis.run_analysis'),
+      );
+    });
+  });
+
+  describe('User interactions', () => {
+    it('calls runAnalysis when the run analysis button is clicked', async () => {
+      await findRunAnalysisButton().trigger('click');
+
+      expect(improvementsStore.runAnalysis).toHaveBeenCalledOnce();
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -468,8 +468,12 @@
     },
 
     "improvements": {
+      "no_analysis": {
+        "description": "Run your first analysis to identify opportunities for improvement in yesterday's conversations",
+        "run_analysis": "Run analysis",
+        "title": "No analysis has been run yet"
+      },
       "title": "Improvement backlog"
-
     }
   },
   "router": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -467,6 +467,11 @@
       }
     },
     "improvements": {
+      "no_analysis": {
+        "description": "Ejecuta el primer análisis para identificar oportunidades de mejora en las conversaciones de ayer",
+        "run_analysis": "Ejecutar análisis",
+        "title": "Aún no se ha ejecutado ningún análisis"
+      },
       "title": "Backlog de mejoras"
     }
   },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -467,6 +467,11 @@
       }
     },
     "improvements": {
+      "no_analysis": {
+        "description": "Execute a primeira análise para identificar oportunidades de melhoria nas conversas de ontem",
+        "run_analysis": "Executar análise",
+        "title": "Nenhuma análise foi executada ainda"
+      },
       "title": "Backlog de melhorias"
     }
   },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -466,6 +466,11 @@
       }
     },
     "improvements": {
+      "no_analysis": {
+        "description": "Rulează prima analiză pentru a identifica oportunități de îmbunătățire în conversațiile de ieri",
+        "run_analysis": "Rulează analiza",
+        "title": "Nicio analiză nu a fost executată încă"
+      },
       "title": "Backlog de îmbunătățiri"
     }
   },

--- a/src/views/Supervisor/Improvements/__tests__/index.spec.js
+++ b/src/views/Supervisor/Improvements/__tests__/index.spec.js
@@ -1,12 +1,54 @@
 import { shallowMount } from '@vue/test-utils';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
-import Improvements from '@/views/Supervisor/Improvements/index.vue';
 import { useImprovementsStore } from '@/store/Improvements';
+
+import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
+import Improvements from '@/views/Supervisor/Improvements/index.vue';
 
 describe('Improvements view', () => {
   let wrapper;
+  let improvementsStore;
+
+  const findSection = () =>
+    wrapper.find('[data-testid="conversations-improvements"]');
+  const findNoAnalysisPerformed = () =>
+    wrapper.findComponent(NoAnalysisPerformed);
+
+  const createWrapper = (stateOverrides = {}) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      initialState: {
+        Improvements: {
+          analysis: {
+            status: null,
+            task: null,
+            ...(stateOverrides.analysis || {}),
+          },
+          improvements: {
+            data: [],
+            status: null,
+            ...(stateOverrides.improvements || {}),
+          },
+        },
+      },
+    });
+
+    wrapper = shallowMount(Improvements, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+
+    improvementsStore = useImprovementsStore(pinia);
+
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
 
   afterEach(() => {
     wrapper?.unmount();
@@ -14,13 +56,37 @@ describe('Improvements view', () => {
   });
 
   it('renders the improvements section', () => {
-    wrapper = shallowMount(Improvements, {
-      global: {
-        plugins: [createTestingPinia()],
+    expect(findSection().exists()).toBe(true);
+  });
+
+  it('renders NoAnalysisPerformed when there is no analysis task', () => {
+    expect(findNoAnalysisPerformed().exists()).toBe(true);
+  });
+
+  it('does not render NoAnalysisPerformed when an analysis task exists', () => {
+    wrapper.unmount();
+    createWrapper({
+      analysis: {
+        status: 'complete',
+        task: { isRunning: false, progress: 5, total: 5 },
       },
     });
 
-    expect(wrapper.find('.conversations-improvements').exists()).toBe(true);
+    expect(findNoAnalysisPerformed().exists()).toBe(false);
+  });
+
+  it('hides NoAnalysisPerformed after the analysis task is set', async () => {
+    expect(findNoAnalysisPerformed().exists()).toBe(true);
+
+    improvementsStore.analysis.task = {
+      isRunning: true,
+      progress: 0,
+      total: 3,
+    };
+
+    await wrapper.vm.$nextTick();
+
+    expect(findNoAnalysisPerformed().exists()).toBe(false);
   });
 
   it('loads improvements when the view mounts', () => {

--- a/src/views/Supervisor/Improvements/index.vue
+++ b/src/views/Supervisor/Improvements/index.vue
@@ -1,13 +1,22 @@
 <template>
-  <section class="conversations-improvements"></section>
+  <section
+    class="conversations-improvements"
+    data-testid="conversations-improvements"
+  >
+    <NoAnalysisPerformed v-if="!analysis.task" />
+  </section>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { onMounted } from 'vue';
+import { storeToRefs } from 'pinia';
 
 import { useImprovementsStore } from '@/store/Improvements';
 
+import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
+
 const improvementsStore = useImprovementsStore();
+const { analysis } = storeToRefs(improvementsStore);
 
 onMounted(() => {
   improvementsStore.fetchImprovements();
@@ -16,6 +25,8 @@ onMounted(() => {
 
 <style scoped lang="scss">
 .conversations-improvements {
+  height: 100%;
+
   padding: $unnnic-space-4;
   padding-top: 0;
 }


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

When a user navigates to the Improvements view for the first time and no analysis has been run yet, there was no feedback or call-to-action to guide them. This change introduces an empty state that prompts users to run their first analysis.

### Summary of Changes

- Added a `NoAnalysisPerformed` component that displays an empty state with a title, description, and a "Run analysis" button that triggers `improvementsStore.runAnalysis`.
- Integrated `NoAnalysisPerformed` into the Improvements view, showing it conditionally when no analysis task exists (`!analysis.task`).
- Added localized strings for the empty state (title, description, and button label) in English, Spanish, Portuguese (BR), and Romanian.
- Added unit tests for the `NoAnalysisPerformed` component covering rendering and the run analysis button interaction.
- Expanded the Improvements view tests to cover the conditional rendering of `NoAnalysisPerformed` based on the presence of an analysis task, including reactivity when the task is set dynamically.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/0012fb90-523e-470f-af0f-3e69c65ba28d.png)

