### PR TITLE
feat: Add RunningAnalysis component with localization support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@tsparticles/slim": "^3.9.1",
         "@tsparticles/vue3": "^3.0.1",
         "@vueuse/core": "^10.11.0",
-        "@weni/unnnic-system": "^3.27.1",
+        "@weni/unnnic-system": "^3.28.2-alpha.2",
         "axios": "^1.7.2",
         "cross-env": "^7.0.3",
         "date-fns": "^4.1.0",
@@ -4732,9 +4732,9 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "3.27.1",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.27.1.tgz",
-      "integrity": "sha512-xp6RECXtj1i7/X/+kP1oWyhMGQXY1Ud8XxLFTvhHNrpEzmpvDz2sFB4sjaZDZuKptXrLHszIRFJZIS/gMpBfJw==",
+      "version": "3.28.2-alpha.2",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.28.2-alpha.2.tgz",
+      "integrity": "sha512-OxyfQw1rF0+1AlGPJqvzCGZ1FfiGDQbXFsVbM2oe7dnarALdyQnSmJQoehWLU3KTCvOlK7PR2w368koqvzV2Nw==",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tsparticles/slim": "^3.9.1",
     "@tsparticles/vue3": "^3.0.1",
     "@vueuse/core": "^10.11.0",
-    "@weni/unnnic-system": "^3.27.1",
+    "@weni/unnnic-system": "^3.28.2-alpha.2",
     "axios": "^1.7.2",
     "cross-env": "^7.0.3",
     "date-fns": "^4.1.0",

--- a/src/components/ConversationsImprovements/RunningAnalysis.vue
+++ b/src/components/ConversationsImprovements/RunningAnalysis.vue
@@ -1,0 +1,66 @@
+<template>
+  <section
+    class="running-analysis"
+    data-testid="running-analysis"
+  >
+    <UnnnicIconLoading
+      size="md"
+      stroke-width="3"
+      scheme="fg-muted"
+    />
+    <hgroup class="running-analysis__content">
+      <h2
+        class="running-analysis__title"
+        data-testid="running-analysis-title"
+      >
+        {{
+          $t('audit.improvements.running_analysis.title', {
+            count: improvementsStore.analysis.task?.total ?? 0,
+          })
+        }}
+      </h2>
+      <p
+        class="running-analysis__description"
+        data-testid="running-analysis-description"
+      >
+        {{ $t('audit.improvements.running_analysis.description') }}
+      </p>
+    </hgroup>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { useImprovementsStore } from '@/store/Improvements';
+
+const improvementsStore = useImprovementsStore();
+</script>
+
+<style scoped lang="scss">
+.running-analysis {
+  height: 100%;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: $unnnic-space-4;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: $unnnic-space-1;
+  }
+
+  &__title {
+    font: $unnnic-font-action;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__description {
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/__tests__/RunningAnalysis.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/RunningAnalysis.spec.js
@@ -1,0 +1,121 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import { useImprovementsStore } from '@/store/Improvements';
+
+import RunningAnalysis from '../RunningAnalysis.vue';
+
+describe('RunningAnalysis.vue', () => {
+  let wrapper;
+  let improvementsStore;
+
+  const findSection = () => wrapper.find('[data-testid="running-analysis"]');
+  const findTitle = () =>
+    wrapper.find('[data-testid="running-analysis-title"]');
+  const findDescription = () =>
+    wrapper.find('[data-testid="running-analysis-description"]');
+  const findLoadingIcon = () =>
+    wrapper.findComponent({ name: 'UnnnicIconLoading' });
+
+  const createWrapper = (stateOverrides = {}) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      initialState: {
+        Improvements: {
+          analysis: {
+            status: 'loading',
+            task: {
+              isRunning: true,
+              progress: 0,
+              total: 437,
+            },
+            ...(stateOverrides.analysis || {}),
+          },
+          improvements: {
+            data: [],
+            status: 'loading',
+            ...(stateOverrides.improvements || {}),
+          },
+        },
+      },
+    });
+
+    wrapper = shallowMount(RunningAnalysis, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+
+    improvementsStore = useImprovementsStore(pinia);
+
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Component rendering', () => {
+    it('renders the running analysis section', () => {
+      expect(findSection().exists()).toBe(true);
+    });
+
+    it('renders the loading icon', () => {
+      const loadingIcon = findLoadingIcon();
+
+      expect(loadingIcon.exists()).toBe(true);
+      expect(loadingIcon.props('size')).toBe('md');
+    });
+
+    it('renders the title with the conversation count from the store', () => {
+      expect(findTitle().text()).toBe(
+        i18n.global.t('audit.improvements.running_analysis.title', {
+          count: 437,
+        }),
+      );
+    });
+
+    it('renders the title with zero when there is no analysis task', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'loading',
+          task: null,
+        },
+      });
+
+      expect(findTitle().text()).toBe(
+        i18n.global.t('audit.improvements.running_analysis.title', {
+          count: 0,
+        }),
+      );
+    });
+
+    it('renders the description with the correct translation', () => {
+      expect(findDescription().text()).toBe(
+        i18n.global.t('audit.improvements.running_analysis.description'),
+      );
+    });
+  });
+
+  describe('Store reactivity', () => {
+    it('updates the title when the conversation count changes', async () => {
+      improvementsStore.analysis.task.total = 12;
+
+      await wrapper.vm.$nextTick();
+
+      expect(findTitle().text()).toBe(
+        i18n.global.t('audit.improvements.running_analysis.title', {
+          count: 12,
+        }),
+      );
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -473,6 +473,10 @@
         "run_analysis": "Run analysis",
         "title": "No analysis has been run yet"
       },
+      "running_analysis": {
+        "description": "This may take a few hours. You can close this screen.",
+        "title": "Analyzing {count} conversations from yesterday"
+      },
       "title": "Improvement backlog"
     }
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -472,6 +472,10 @@
         "run_analysis": "Ejecutar análisis",
         "title": "Aún no se ha ejecutado ningún análisis"
       },
+      "running_analysis": {
+        "description": "Esto puede tardar unas horas. Puedes cerrar esta pantalla.",
+        "title": "Analizando {count} conversaciones de ayer"
+      },
       "title": "Backlog de mejoras"
     }
   },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -472,6 +472,10 @@
         "run_analysis": "Executar análise",
         "title": "Nenhuma análise foi executada ainda"
       },
+      "running_analysis": {
+        "description": "Isso pode levar algumas horas. Você pode fechar esta tela.",
+        "title": "Analisando {count} conversas de ontem"
+      },
       "title": "Backlog de melhorias"
     }
   },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -471,6 +471,10 @@
         "run_analysis": "Rulează analiza",
         "title": "Nicio analiză nu a fost executată încă"
       },
+      "running_analysis": {
+        "description": "Acest proces poate dura câteva ore. Poți închide acest ecran.",
+        "title": "Se analizează {count} conversații de ieri"
+      },
       "title": "Backlog de îmbunătățiri"
     }
   },

--- a/src/views/Supervisor/Improvements/__tests__/index.spec.js
+++ b/src/views/Supervisor/Improvements/__tests__/index.spec.js
@@ -5,6 +5,8 @@ import { createTestingPinia } from '@pinia/testing';
 import { useImprovementsStore } from '@/store/Improvements';
 
 import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
+import RunningAnalysis from '@/components/ConversationsImprovements/RunningAnalysis.vue';
+
 import Improvements from '@/views/Supervisor/Improvements/index.vue';
 
 describe('Improvements view', () => {
@@ -15,6 +17,7 @@ describe('Improvements view', () => {
     wrapper.find('[data-testid="conversations-improvements"]');
   const findNoAnalysisPerformed = () =>
     wrapper.findComponent(NoAnalysisPerformed);
+  const findRunningAnalysis = () => wrapper.findComponent(RunningAnalysis);
 
   const createWrapper = (stateOverrides = {}) => {
     const pinia = createTestingPinia({
@@ -55,38 +58,109 @@ describe('Improvements view', () => {
     vi.clearAllMocks();
   });
 
-  it('renders the improvements section', () => {
-    expect(findSection().exists()).toBe(true);
-  });
-
-  it('renders NoAnalysisPerformed when there is no analysis task', () => {
-    expect(findNoAnalysisPerformed().exists()).toBe(true);
-  });
-
-  it('does not render NoAnalysisPerformed when an analysis task exists', () => {
-    wrapper.unmount();
-    createWrapper({
-      analysis: {
-        status: 'complete',
-        task: { isRunning: false, progress: 5, total: 5 },
-      },
+  describe('NoAnalysisPerformed state', () => {
+    it('renders the improvements section', () => {
+      expect(findSection().exists()).toBe(true);
     });
 
-    expect(findNoAnalysisPerformed().exists()).toBe(false);
+    it('renders NoAnalysisPerformed when there is no analysis task', () => {
+      expect(findNoAnalysisPerformed().exists()).toBe(true);
+    });
+
+    it('does not render NoAnalysisPerformed when an analysis task exists', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: { isRunning: false, progress: 5, total: 5 },
+        },
+      });
+
+      expect(findNoAnalysisPerformed().exists()).toBe(false);
+    });
+
+    it('hides NoAnalysisPerformed after the analysis task is set', async () => {
+      expect(findNoAnalysisPerformed().exists()).toBe(true);
+
+      improvementsStore.analysis.task = {
+        isRunning: true,
+        progress: 0,
+        total: 3,
+      };
+
+      await wrapper.vm.$nextTick();
+
+      expect(findNoAnalysisPerformed().exists()).toBe(false);
+    });
   });
 
-  it('hides NoAnalysisPerformed after the analysis task is set', async () => {
-    expect(findNoAnalysisPerformed().exists()).toBe(true);
+  describe('RunningAnalysis state', () => {
+    it('renders RunningAnalysis when the task is running and there are no improvements', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'loading',
+          task: { isRunning: true, progress: 0, total: 437 },
+        },
+      });
 
-    improvementsStore.analysis.task = {
-      isRunning: true,
-      progress: 0,
-      total: 3,
-    };
+      expect(findRunningAnalysis().exists()).toBe(true);
+      expect(findNoAnalysisPerformed().exists()).toBe(false);
+    });
 
-    await wrapper.vm.$nextTick();
+    it('does not render RunningAnalysis when there is no analysis task', () => {
+      expect(findRunningAnalysis().exists()).toBe(false);
+    });
 
-    expect(findNoAnalysisPerformed().exists()).toBe(false);
+    it('does not render RunningAnalysis when the task is not running', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: { isRunning: false, progress: 437, total: 437 },
+        },
+      });
+
+      expect(findRunningAnalysis().exists()).toBe(false);
+    });
+
+    it('does not render RunningAnalysis when improvements data is available', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'loading',
+          task: { isRunning: true, progress: 10, total: 437 },
+        },
+        improvements: {
+          data: [
+            {
+              uuid: 'improvement-1',
+              text: 'Improve response time',
+              type: 'instruction_non_compliance',
+              conversationsCount: 5,
+            },
+          ],
+          status: 'loading',
+        },
+      });
+
+      expect(findRunningAnalysis().exists()).toBe(false);
+    });
+
+    it('shows RunningAnalysis after the analysis task starts running', async () => {
+      expect(findRunningAnalysis().exists()).toBe(false);
+
+      improvementsStore.analysis.task = {
+        isRunning: true,
+        progress: 0,
+        total: 437,
+      };
+
+      await wrapper.vm.$nextTick();
+
+      expect(findRunningAnalysis().exists()).toBe(true);
+      expect(findNoAnalysisPerformed().exists()).toBe(false);
+    });
   });
 
   it('loads improvements when the view mounts', () => {

--- a/src/views/Supervisor/Improvements/index.vue
+++ b/src/views/Supervisor/Improvements/index.vue
@@ -4,6 +4,9 @@
     data-testid="conversations-improvements"
   >
     <NoAnalysisPerformed v-if="!analysis.task" />
+    <RunningAnalysis
+      v-else-if="analysis.task?.isRunning && !improvements.data.length"
+    />
   </section>
 </template>
 
@@ -14,9 +17,10 @@ import { storeToRefs } from 'pinia';
 import { useImprovementsStore } from '@/store/Improvements';
 
 import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
+import RunningAnalysis from '@/components/ConversationsImprovements/RunningAnalysis.vue';
 
 const improvementsStore = useImprovementsStore();
-const { analysis } = storeToRefs(improvementsStore);
+const { analysis, improvements } = storeToRefs(improvementsStore);
 
 onMounted(() => {
   improvementsStore.fetchImprovements();


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

When an analysis task is running, users need visual feedback indicating that the system is processing conversations. Previously, there was no intermediate state shown between "no analysis performed" and the completed improvements list.

### Summary of Changes

- Added a new `RunningAnalysis` component that displays a loading indicator along with the number of conversations being analyzed and a message informing the user that the process may take a few minutes and the screen can be closed.
- The component is shown in the Improvements view when an analysis task is running and no improvements data has been loaded yet (`analysis.task?.isRunning && !improvements.data.length`).
- Added `running_analysis` locale keys (`title` and `description`) in English, Spanish, Portuguese (BR), and Romanian.
- Added unit tests for the `RunningAnalysis` component covering rendering, translation output, null task handling, and store reactivity.
- Expanded the Improvements view tests to cover the `RunningAnalysis` display conditions, including when it should and should not appear based on task state and improvements data availability.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/7083e338-3c5c-4798-8d36-452f98c6ca14.png)

