### PR TITLE
feat: Show analysis complete alert after running improvements analysis

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -468,6 +468,12 @@
     },
 
     "improvements": {
+      "analysis_complete": {
+        "no_improvements_description": "No improvements identified in the conversations from {date}",
+        "ready_description": "Improvements from {date} are ready in your backlog.",
+        "title": "Analysis complete",
+        "title_with_count": "{count, plural, one {Analysis complete ({count} improvement found)} other {Analysis complete ({count} improvements found)}}"
+      },
       "no_analysis": {
         "description": "Run your first analysis to identify opportunities for improvement in yesterday's conversations",
         "run_analysis": "Run analysis",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -467,6 +467,12 @@
       }
     },
     "improvements": {
+      "analysis_complete": {
+        "no_improvements_description": "No se identificaron mejoras en las conversaciones del {date}",
+        "ready_description": "Las mejoras del {date} están listas en el backlog.",
+        "title": "Análisis completo",
+        "title_with_count": "{count, plural, one {Análisis completo ({count} mejora encontrada)} other {Análisis completo ({count} mejoras encontradas)}}"
+      },
       "no_analysis": {
         "description": "Ejecuta el primer análisis para identificar oportunidades de mejora en las conversaciones de ayer",
         "run_analysis": "Ejecutar análisis",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -467,6 +467,12 @@
       }
     },
     "improvements": {
+      "analysis_complete": {
+        "no_improvements_description": "Nenhuma melhoria identificada nas conversas de {date}",
+        "ready_description": "As melhorias de {date} estão prontas no backlog.",
+        "title": "Análise concluída",
+        "title_with_count": "{count, plural, one {Análise concluída ({count} melhoria encontrada)} other {Análise concluída ({count} melhorias encontradas)}}"
+      },
       "no_analysis": {
         "description": "Execute a primeira análise para identificar oportunidades de melhoria nas conversas de ontem",
         "run_analysis": "Executar análise",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -466,6 +466,12 @@
       }
     },
     "improvements": {
+      "analysis_complete": {
+        "no_improvements_description": "Nu s-au identificat îmbunătățiri în conversațiile din {date}",
+        "ready_description": "Îmbunătățirile din {date} sunt gata în backlog.",
+        "title": "Analiză finalizată",
+        "title_with_count": "{count, plural, one {Analiză finalizată ({count} îmbunătățire găsită)} other {Analiză finalizată ({count} îmbunătățiri găsite)}}"
+      },
       "no_analysis": {
         "description": "Rulează prima analiză pentru a identifica oportunități de îmbunătățire în conversațiile de ieri",
         "run_analysis": "Rulează analiza",

--- a/src/store/Improvements.ts
+++ b/src/store/Improvements.ts
@@ -1,8 +1,10 @@
 import { computed, reactive } from 'vue';
 import { defineStore } from 'pinia';
-
 import nexusaiAPI from '@/api/nexusaiAPI';
+import i18n from '@/utils/plugins/i18n';
+import { getYesterdayFormattedDate } from '@/utils/formatters';
 import { useProjectStore } from './Project';
+import { useAlertStore } from './Alert';
 
 import type {
   Improvement,
@@ -47,7 +49,33 @@ function wait(ms: number) {
   });
 }
 
+function notifyAnalysisComplete(
+  alertStore: ReturnType<typeof useAlertStore>,
+  improvementCount: number,
+) {
+  const date = getYesterdayFormattedDate();
+
+  const analysisT = (field: string, params?: Record<string, string | number>) =>
+    i18n.global.t(`audit.improvements.analysis_complete.${field}`, params);
+
+  let alertText = analysisT('title');
+  let alertDescription = analysisT('no_improvements_description', { date });
+
+  if (improvementCount > 0) {
+    alertText = analysisT('title_with_count', { count: improvementCount });
+    alertDescription = analysisT('ready_description', { date });
+  }
+
+  alertStore.add({
+    type: 'success',
+    text: alertText,
+    description: alertDescription,
+  });
+}
+
 export const useImprovementsStore = defineStore('Improvements', () => {
+  const alertStore = useAlertStore();
+
   const projectUuid = computed(() => useProjectStore().uuid);
   const supervisorApi = nexusaiAPI.agent_builder.supervisor;
 
@@ -141,6 +169,7 @@ export const useImprovementsStore = defineStore('Improvements', () => {
       });
 
       await loadImprovementsData();
+      notifyAnalysisComplete(alertStore, improvements.data.length);
     } catch (error) {
       setStatus('error');
       console.error(error);

--- a/src/store/__tests__/Improvements.unit.spec.js
+++ b/src/store/__tests__/Improvements.unit.spec.js
@@ -2,7 +2,10 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 
 import { useImprovementsStore } from '@/store/Improvements';
+import { useAlertStore } from '@/store/Alert';
 import nexusaiAPI from '@/api/nexusaiAPI';
+import i18n from '@/utils/plugins/i18n';
+import { getYesterdayFormattedDate } from '@/utils/formatters';
 
 vi.mock('@/api/nexusaiAPI', () => ({
   default: {
@@ -74,14 +77,17 @@ describe('Improvements Store', () => {
   let store;
   let improvementsApi;
   let consoleErrorSpy;
-
+  let alertStore;
   beforeEach(() => {
     vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-18T12:00:00'));
     setActivePinia(createPinia());
     vi.clearAllMocks();
     consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     store = useImprovementsStore();
+    alertStore = useAlertStore();
+    vi.spyOn(alertStore, 'add');
     improvementsApi = nexusaiAPI.agent_builder.supervisor.improvements;
   });
 
@@ -125,6 +131,7 @@ describe('Improvements Store', () => {
       expect(store.improvements.status).toBe('complete');
       expect(store.analysis.yesterdayConversationsCount).toBe(25);
       expect(store.improvements.data).toEqual(improvements);
+      expect(alertStore.add).not.toHaveBeenCalled();
     });
 
     it('polls getAnalysis when the task is still running', async () => {
@@ -157,6 +164,7 @@ describe('Improvements Store', () => {
       expect(store.improvements.data).toEqual(improvements);
       expect(store.analysis.status).toBe('loading');
       expect(store.improvements.status).toBe('loading');
+      expect(alertStore.add).not.toHaveBeenCalled();
     });
 
     it('sets error status and logs error when the request fails', async () => {
@@ -168,6 +176,7 @@ describe('Improvements Store', () => {
       expect(store.analysis.status).toBe('error');
       expect(store.improvements.status).toBe('error');
       expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+      expect(alertStore.add).not.toHaveBeenCalled();
     });
   });
 
@@ -337,6 +346,7 @@ describe('Improvements Store', () => {
       expect(store.improvements.status).toBe('error');
       expect(improvementsApi.getAnalysis).not.toHaveBeenCalled();
       expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+      expect(alertStore.add).not.toHaveBeenCalled();
     });
 
     it('sets error status and logs error when polling fails', async () => {
@@ -359,6 +369,65 @@ describe('Improvements Store', () => {
       expect(store.analysis.status).toBe('error');
       expect(store.improvements.status).toBe('error');
       expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+      expect(alertStore.add).not.toHaveBeenCalled();
+    });
+
+    it('shows a success alert when analysis completes without improvements', async () => {
+      improvementsApi.runAnalysis.mockResolvedValue();
+      improvementsApi.getAnalysis.mockResolvedValue(
+        buildAnalysisResponse({
+          conversationsCount: 0,
+          improvements: [],
+        }),
+      );
+
+      await store.runAnalysis();
+
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'success',
+        text: i18n.global.t('audit.improvements.analysis_complete.title'),
+        description: i18n.global.t(
+          'audit.improvements.analysis_complete.no_improvements_description',
+          { date: getYesterdayFormattedDate() },
+        ),
+      });
+    });
+
+    it('shows a success alert when analysis completes with improvements', async () => {
+      const improvements = [
+        buildImprovement(),
+        buildImprovement({ uuid: 'improvement-uuid-2' }),
+      ];
+
+      improvementsApi.runAnalysis.mockResolvedValue();
+      improvementsApi.getAnalysis.mockResolvedValue(
+        buildAnalysisResponse({
+          conversationsCount: 25,
+          improvements,
+        }),
+      );
+
+      await store.runAnalysis();
+
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'success',
+        text: i18n.global.t(
+          'audit.improvements.analysis_complete.title_with_count',
+          { count: improvements.length },
+        ),
+        description: i18n.global.t(
+          'audit.improvements.analysis_complete.ready_description',
+          { date: getYesterdayFormattedDate() },
+        ),
+      });
+    });
+
+    it('does not show a success alert when analysis fails', async () => {
+      improvementsApi.runAnalysis.mockRejectedValue(new Error('boom'));
+
+      await store.runAnalysis();
+
+      expect(alertStore.add).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/utils/__tests__/formatters.spec.js
+++ b/src/utils/__tests__/formatters.spec.js
@@ -1,9 +1,11 @@
-import { afterEach, describe, it, expect } from 'vitest';
+import { afterEach, describe, it, expect, vi } from 'vitest';
 import {
   formatListToReadable,
   formatWhatsappUrn,
   formatLongDate,
+  formatMonthDayDate,
   formatTime,
+  getYesterdayFormattedDate,
 } from '@/utils/formatters';
 import i18n from '@/utils/plugins/i18n';
 
@@ -120,6 +122,56 @@ describe('formatters', () => {
 
     it('returns an empty string for an invalid date', () => {
       expect(formatLongDate('not-a-date')).toBe('');
+    });
+  });
+
+  describe('formatMonthDayDate', () => {
+    const TIMESTAMP = '2026-05-18T15:15:00';
+
+    afterEach(() => {
+      i18n.global.locale.value = 'en';
+    });
+
+    it('formats the month and day without the year', () => {
+      expect(formatMonthDayDate(TIMESTAMP)).toBe('May 18');
+    });
+
+    it('falls back to the en pattern for an unmapped locale', () => {
+      i18n.global.locale.value = 'unmapped';
+      expect(formatMonthDayDate(TIMESTAMP)).toBe('May 18');
+    });
+
+    it('returns an empty string for an invalid date', () => {
+      expect(formatMonthDayDate('not-a-date')).toBe('');
+    });
+  });
+
+  describe('getYesterdayFormattedDate', () => {
+    afterEach(() => {
+      vi.useRealTimers();
+      i18n.global.locale.value = 'en';
+    });
+
+    it('formats yesterday relative to the current date', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-18T15:15:00'));
+
+      expect(getYesterdayFormattedDate()).toBe('May 17');
+    });
+
+    it('formats yesterday across month boundaries', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-01T15:15:00'));
+
+      expect(getYesterdayFormattedDate()).toBe('April 30');
+    });
+
+    it('falls back to the en pattern for an unmapped locale', () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-18T15:15:00'));
+      i18n.global.locale.value = 'unmapped';
+
+      expect(getYesterdayFormattedDate()).toBe('May 17');
     });
   });
 

--- a/src/utils/formatters.ts
+++ b/src/utils/formatters.ts
@@ -1,6 +1,6 @@
 import i18n from '@/utils/plugins/i18n';
 
-import { format } from 'date-fns';
+import { format, subDays } from 'date-fns';
 import { enUS, es as esLocale, ptBR, ro as roLocale } from 'date-fns/locale';
 
 const DATE_FNS_LOCALE_MAP = {
@@ -114,6 +114,25 @@ export function formatLongDate(timestamp: string) {
       es: "d 'de' MMMM 'de' yyyy",
       'pt-br': "d 'de' MMMM 'de' yyyy",
       ro: 'd MMMM yyyy',
+    },
+    FALLBACK_PATTERN,
+  );
+}
+
+export function getYesterdayFormattedDate() {
+  return formatMonthDayDate(subDays(new Date(), 1).toISOString());
+}
+
+export function formatMonthDayDate(timestamp: string) {
+  const FALLBACK_PATTERN = 'MMMM d';
+
+  return formatWithLocalePattern(
+    timestamp,
+    {
+      en: FALLBACK_PATTERN,
+      es: "d 'de' MMMM",
+      'pt-br': "d 'de' MMMM",
+      ro: 'd MMMM',
     },
     FALLBACK_PATTERN,
   );


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

When a user runs an analysis, there was no feedback indicating whether the process completed successfully or what the outcome was. A success alert is needed to inform the user that the analysis finished and how many improvements were found.

### Summary of Changes

- Added a `notifyAnalysisComplete` function to the Improvements store that triggers a success alert once an analysis finishes, displaying the number of improvements found (or a message indicating none were found) along with yesterday's formatted date.
- Added a `formatMonthDayDate` formatter that returns a locale-aware month and day string (e.g., "May 18", "18 de mayo") used in the alert messages.
- Added `analysis_complete` locale keys (`title`, `title_with_count`, `no_improvements_description`, `ready_description`) to the `en`, `es`, `pt_br`, and `ro` locale files.
- Added unit tests covering the alert behavior for completed analyses with improvements, without improvements, and on failure, as well as tests for the new `formatMonthDayDate` formatter.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/9bd8a074-11f2-4798-88c0-30959c0d8713.png)

