### PR TITLE
feat: Add components for displaying analysis progress and improve localization

### DIFF
--- a/src/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue
+++ b/src/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue
@@ -1,0 +1,27 @@
+<template>
+  <UnnnicDisclaimer
+    v-if="analysis.task?.isRunning"
+    data-testid="analysis-in-progress-disclaimer"
+    type="informational"
+    :description="
+      $t('audit.improvements.analysis_in_progress_disclaimer', {
+        progress: analysis.task?.progress ?? 0,
+        total: analysis.task?.total ?? 0,
+      })
+    "
+  >
+    <template #icon>
+      <UnnnicIconLoading
+        size="sm"
+        stroke-width="3"
+      />
+    </template>
+  </UnnnicDisclaimer>
+</template>
+<script setup lang="ts">
+import { useImprovementsStore } from '@/store/Improvements';
+import { storeToRefs } from 'pinia';
+
+const improvementsStore = useImprovementsStore();
+const { analysis } = storeToRefs(improvementsStore);
+</script>

--- a/src/components/ConversationsImprovements/ImprovementsHeader.vue
+++ b/src/components/ConversationsImprovements/ImprovementsHeader.vue
@@ -1,0 +1,8 @@
+<template>
+  <header
+    class="conversations-improvements-header"
+    data-testid="conversations-improvements-header"
+  ></header>
+</template>
+<script setup lang="ts"></script>
+<style scoped lang="scss"></style>

--- a/src/components/ConversationsImprovements/ImprovementsList.vue
+++ b/src/components/ConversationsImprovements/ImprovementsList.vue
@@ -1,0 +1,8 @@
+<template>
+  <section
+    class="conversationsimprovements-list"
+    data-testid="improvements-list"
+  ></section>
+</template>
+<script setup lang="ts"></script>
+<style scoped lang="scss"></style>

--- a/src/components/ConversationsImprovements/__tests__/AnalysisInProgressDisclaimer.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/AnalysisInProgressDisclaimer.spec.js
@@ -1,0 +1,156 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import { useImprovementsStore } from '@/store/Improvements';
+
+import AnalysisInProgressDisclaimer from '../AnalysisInProgressDisclaimer.vue';
+
+describe('AnalysisInProgressDisclaimer.vue', () => {
+  let wrapper;
+  let improvementsStore;
+
+  const findDisclaimer = () =>
+    wrapper.findComponent('[data-testid="analysis-in-progress-disclaimer"]');
+  const findLoadingIcon = () =>
+    wrapper.findComponent({ name: 'UnnnicIconLoading' });
+
+  const createWrapper = (stateOverrides = {}) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      initialState: {
+        Improvements: {
+          analysis: {
+            status: 'loading',
+            task: {
+              isRunning: true,
+              progress: 10,
+              total: 437,
+            },
+            ...(stateOverrides.analysis || {}),
+          },
+          improvements: {
+            data: [],
+            status: 'loading',
+            ...(stateOverrides.improvements || {}),
+          },
+        },
+      },
+    });
+
+    wrapper = shallowMount(AnalysisInProgressDisclaimer, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          UnnnicDisclaimer: {
+            name: 'UnnnicDisclaimer',
+            template:
+              '<div data-testid="analysis-in-progress-disclaimer"><slot name="icon" /></div>',
+            props: ['type', 'description'],
+          },
+        },
+      },
+    });
+
+    improvementsStore = useImprovementsStore(pinia);
+
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Component rendering', () => {
+    it('renders the disclaimer when the analysis task is running', () => {
+      const disclaimer = findDisclaimer();
+
+      expect(disclaimer.exists()).toBe(true);
+      expect(disclaimer.props('type')).toBe('informational');
+      expect(disclaimer.props('description')).toBe(
+        i18n.global.t('audit.improvements.analysis_in_progress_disclaimer', {
+          progress: 10,
+          total: 437,
+        }),
+      );
+    });
+
+    it('renders the loading icon with the correct configuration', () => {
+      const loadingIcon = findLoadingIcon();
+
+      expect(loadingIcon.exists()).toBe(true);
+      expect(loadingIcon.props('size')).toBe('sm');
+      expect(loadingIcon.props('strokeWidth')).toBe('3');
+    });
+
+    it('does not render the disclaimer when the analysis task is not running', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: { isRunning: false, progress: 437, total: 437 },
+        },
+      });
+
+      expect(findDisclaimer().exists()).toBe(false);
+    });
+
+    it('does not render the disclaimer when there is no analysis task', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: null,
+          task: null,
+        },
+      });
+
+      expect(findDisclaimer().exists()).toBe(false);
+    });
+
+    it('uses zero for progress and total when task values are missing', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'loading',
+          task: { isRunning: true },
+        },
+      });
+
+      expect(findDisclaimer().props('description')).toBe(
+        i18n.global.t('audit.improvements.analysis_in_progress_disclaimer', {
+          progress: 0,
+          total: 0,
+        }),
+      );
+    });
+  });
+
+  describe('Store reactivity', () => {
+    it('updates the description when progress changes', async () => {
+      improvementsStore.analysis.task.progress = 25;
+
+      await wrapper.vm.$nextTick();
+
+      expect(findDisclaimer().props('description')).toBe(
+        i18n.global.t('audit.improvements.analysis_in_progress_disclaimer', {
+          progress: 25,
+          total: 437,
+        }),
+      );
+    });
+
+    it('hides the disclaimer when the task stops running', async () => {
+      improvementsStore.analysis.task.isRunning = false;
+
+      await wrapper.vm.$nextTick();
+
+      expect(findDisclaimer().exists()).toBe(false);
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -468,6 +468,7 @@
     },
 
     "improvements": {
+      "analysis_in_progress_disclaimer": "Analysis in progress: {progress} of {total} conversations processed. New items may appear shortly.",
       "analysis_complete": {
         "no_improvements_description": "No improvements identified in the conversations from {date}",
         "ready_description": "Improvements from {date} are ready in your backlog.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -467,6 +467,7 @@
       }
     },
     "improvements": {
+      "analysis_in_progress_disclaimer": "Análisis en curso: {progress} de {total} conversaciones procesadas. Pueden aparecer nuevos ítems en breve.",
       "analysis_complete": {
         "no_improvements_description": "No se identificaron mejoras en las conversaciones del {date}",
         "ready_description": "Las mejoras del {date} están listas en el backlog.",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -467,6 +467,7 @@
       }
     },
     "improvements": {
+      "analysis_in_progress_disclaimer": "Análise em andamento: {progress} de {total} conversas processadas. Novos itens podem aparecer em breve.",
       "analysis_complete": {
         "no_improvements_description": "Nenhuma melhoria identificada nas conversas de {date}",
         "ready_description": "As melhorias de {date} estão prontas no backlog.",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -466,6 +466,7 @@
       }
     },
     "improvements": {
+      "analysis_in_progress_disclaimer": "Analiză în curs: {progress} din {total} conversații procesate. Pot apărea elemente noi în curând.",
       "analysis_complete": {
         "no_improvements_description": "Nu s-au identificat îmbunătățiri în conversațiile din {date}",
         "ready_description": "Îmbunătățirile din {date} sunt gata în backlog.",

--- a/src/views/Supervisor/Improvements/__tests__/index.spec.js
+++ b/src/views/Supervisor/Improvements/__tests__/index.spec.js
@@ -4,6 +4,9 @@ import { createTestingPinia } from '@pinia/testing';
 
 import { useImprovementsStore } from '@/store/Improvements';
 
+import AnalysisInProgressDisclaimer from '@/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue';
+import ImprovementsHeader from '@/components/ConversationsImprovements/ImprovementsHeader.vue';
+import ImprovementsList from '@/components/ConversationsImprovements/ImprovementsList.vue';
 import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
 import RunningAnalysis from '@/components/ConversationsImprovements/RunningAnalysis.vue';
 
@@ -18,6 +21,11 @@ describe('Improvements view', () => {
   const findNoAnalysisPerformed = () =>
     wrapper.findComponent(NoAnalysisPerformed);
   const findRunningAnalysis = () => wrapper.findComponent(RunningAnalysis);
+  const findAnalysisInProgressDisclaimer = () =>
+    wrapper.findComponent(AnalysisInProgressDisclaimer);
+  const findImprovementsHeader = () =>
+    wrapper.findComponent(ImprovementsHeader);
+  const findImprovementsList = () => wrapper.findComponent(ImprovementsList);
 
   const createWrapper = (stateOverrides = {}) => {
     const pinia = createTestingPinia({
@@ -27,6 +35,7 @@ describe('Improvements view', () => {
           analysis: {
             status: null,
             task: null,
+            conversationsCount: 0,
             ...(stateOverrides.analysis || {}),
           },
           improvements: {
@@ -58,6 +67,12 @@ describe('Improvements view', () => {
     vi.clearAllMocks();
   });
 
+  describe('on mount', () => {
+    it('loads improvements when the view mounts', () => {
+      expect(improvementsStore.fetchImprovements).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('NoAnalysisPerformed state', () => {
     it('renders the improvements section', () => {
       expect(findSection().exists()).toBe(true);
@@ -72,7 +87,7 @@ describe('Improvements view', () => {
       createWrapper({
         analysis: {
           status: 'complete',
-          task: { isRunning: false, progress: 5, total: 5 },
+          task: { isRunning: false, progress: 5, total: 5, createdAt: null },
         },
       });
 
@@ -86,6 +101,7 @@ describe('Improvements view', () => {
         isRunning: true,
         progress: 0,
         total: 3,
+        createdAt: null,
       };
 
       await wrapper.vm.$nextTick();
@@ -100,7 +116,7 @@ describe('Improvements view', () => {
       createWrapper({
         analysis: {
           status: 'loading',
-          task: { isRunning: true, progress: 0, total: 437 },
+          task: { isRunning: true, progress: 0, total: 437, createdAt: null },
         },
       });
 
@@ -117,7 +133,12 @@ describe('Improvements view', () => {
       createWrapper({
         analysis: {
           status: 'complete',
-          task: { isRunning: false, progress: 437, total: 437 },
+          task: {
+            isRunning: false,
+            progress: 437,
+            total: 437,
+            createdAt: null,
+          },
         },
       });
 
@@ -129,14 +150,14 @@ describe('Improvements view', () => {
       createWrapper({
         analysis: {
           status: 'loading',
-          task: { isRunning: true, progress: 10, total: 437 },
+          task: { isRunning: true, progress: 10, total: 437, createdAt: null },
         },
         improvements: {
           data: [
             {
               uuid: 'improvement-1',
               text: 'Improve response time',
-              type: 'instruction_non_compliance',
+              type: 'wrong_behavior_due_to_instructions',
               conversationsCount: 5,
             },
           ],
@@ -154,6 +175,7 @@ describe('Improvements view', () => {
         isRunning: true,
         progress: 0,
         total: 437,
+        createdAt: null,
       };
 
       await wrapper.vm.$nextTick();
@@ -163,15 +185,99 @@ describe('Improvements view', () => {
     });
   });
 
-  it('loads improvements when the view mounts', () => {
-    wrapper = shallowMount(Improvements, {
-      global: {
-        plugins: [createTestingPinia()],
-      },
+  describe('Improvements list state', () => {
+    const improvementItem = {
+      uuid: 'improvement-1',
+      text: 'Improve response time',
+      type: 'wrong_behavior_due_to_instructions',
+      conversationsCount: 5,
+    };
+
+    it('renders the improvements header and list when improvements data is available', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: {
+            isRunning: false,
+            progress: 437,
+            total: 437,
+            createdAt: null,
+          },
+        },
+        improvements: {
+          data: [improvementItem],
+          status: 'complete',
+        },
+      });
+
+      expect(findImprovementsHeader().exists()).toBe(true);
+      expect(findImprovementsList().exists()).toBe(true);
+      expect(findNoAnalysisPerformed().exists()).toBe(false);
+      expect(findRunningAnalysis().exists()).toBe(false);
     });
 
-    const improvementsStore = useImprovementsStore();
+    it('renders AnalysisInProgressDisclaimer when improvements exist and the task is running', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'loading',
+          task: { isRunning: true, progress: 10, total: 437, createdAt: null },
+        },
+        improvements: {
+          data: [improvementItem],
+          status: 'loading',
+        },
+      });
 
-    expect(improvementsStore.fetchImprovements).toHaveBeenCalledTimes(1);
+      expect(findAnalysisInProgressDisclaimer().exists()).toBe(true);
+      expect(findImprovementsHeader().exists()).toBe(true);
+      expect(findImprovementsList().exists()).toBe(true);
+      expect(findRunningAnalysis().exists()).toBe(false);
+    });
+
+    it('does not render AnalysisInProgressDisclaimer when the task is not running', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: {
+            isRunning: false,
+            progress: 437,
+            total: 437,
+            createdAt: null,
+          },
+        },
+        improvements: {
+          data: [improvementItem],
+          status: 'complete',
+        },
+      });
+
+      expect(findAnalysisInProgressDisclaimer().exists()).toBe(false);
+    });
+
+    it('does not render improvements content when there is no improvements data', () => {
+      expect(findImprovementsHeader().exists()).toBe(false);
+      expect(findImprovementsList().exists()).toBe(false);
+      expect(findAnalysisInProgressDisclaimer().exists()).toBe(false);
+    });
+
+    it('shows AnalysisInProgressDisclaimer after improvements load while the task is running', async () => {
+      improvementsStore.analysis.task = {
+        isRunning: true,
+        progress: 5,
+        total: 437,
+        createdAt: null,
+      };
+      improvementsStore.improvements.data = [improvementItem];
+
+      await wrapper.vm.$nextTick();
+
+      expect(findAnalysisInProgressDisclaimer().exists()).toBe(true);
+      expect(findImprovementsHeader().exists()).toBe(true);
+      expect(findImprovementsList().exists()).toBe(true);
+      expect(findRunningAnalysis().exists()).toBe(false);
+    });
   });
 });

--- a/src/views/Supervisor/Improvements/index.vue
+++ b/src/views/Supervisor/Improvements/index.vue
@@ -7,6 +7,14 @@
     <RunningAnalysis
       v-else-if="analysis.task?.isRunning && !improvements.data.length"
     />
+
+    <template v-else-if="improvements.data.length">
+      <AnalysisInProgressDisclaimer v-if="analysis.task?.isRunning" />
+
+      <ImprovementsHeader />
+
+      <ImprovementsList />
+    </template>
   </section>
 </template>
 
@@ -18,6 +26,9 @@ import { useImprovementsStore } from '@/store/Improvements';
 
 import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
 import RunningAnalysis from '@/components/ConversationsImprovements/RunningAnalysis.vue';
+import ImprovementsHeader from '@/components/ConversationsImprovements/ImprovementsHeader.vue';
+import ImprovementsList from '@/components/ConversationsImprovements/ImprovementsList.vue';
+import AnalysisInProgressDisclaimer from '@/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue';
 
 const improvementsStore = useImprovementsStore();
 const { analysis, improvements } = storeToRefs(improvementsStore);


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

When an analysis task is running but improvements data already exists, users need visibility into the ongoing analysis progress without losing access to the current improvements list.

### Summary of Changes

- Added `AnalysisInProgressDisclaimer` component that displays an informational banner with the current analysis progress (`{progress} of {total} conversations processed`) when a task is running. It uses a loading icon and reacts to store changes in real time.
- Added scaffold components `ImprovementsHeader` and `ImprovementsList` to structure the improvements view layout.
- Updated the `Improvements` view to render the header, list, and optional disclaimer when improvements data is available, distinguishing this state from the `RunningAnalysis` empty-state component (which only shows when no improvements exist yet).
- Added the `analysis_in_progress_disclaimer` locale key in English, Spanish, Portuguese, and Romanian.
- Added unit tests for `AnalysisInProgressDisclaimer` covering rendering conditions, fallback values, and store reactivity, as well as tests for the improvements list state in the `Improvements` view.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/75ba1aae-b6bd-4fc5-829f-9775d263c3b6.png)

