### PR TITLE
feat: Add localization for insufficient conversation volume messages

### DIFF
--- a/src/api/adapters/supervisor/__tests__/improvements.spec.ts
+++ b/src/api/adapters/supervisor/__tests__/improvements.spec.ts
@@ -45,12 +45,7 @@ describe('Supervisor improvements adapter', () => {
     it('returns safe defaults when API fields are missing', () => {
       expect(ImprovementsAdapter.fromApi()).toEqual({
         yesterdayConversationsCount: 0,
-        task: {
-          isRunning: false,
-          progress: 0,
-          total: 0,
-          createdAt: null,
-        },
+        task: null,
         improvements: [],
       });
     });
@@ -93,7 +88,7 @@ describe('Supervisor improvements adapter', () => {
       ]);
     });
 
-    it('defaults yesterdayConversationsCount to zero when count is missing', () => {
+    it('defaults improvement conversationsCount to zero when count is missing', () => {
       const result = ImprovementsAdapter.fromApi({
         improvements: [
           {

--- a/src/api/adapters/supervisor/improvements.ts
+++ b/src/api/adapters/supervisor/improvements.ts
@@ -39,7 +39,11 @@ function isImprovementType(value: unknown): value is ImprovementType {
   return IMPROVEMENT_TYPES.includes(value as ImprovementType);
 }
 
-function parseTask(task: ImprovementsTaskApi = {}): ImprovementsTask {
+function parseTask(task?: ImprovementsTaskApi | null): ImprovementsTask | null {
+  if (!task) {
+    return null;
+  }
+
   return {
     isRunning: Boolean(task.is_running),
     progress: Number(task.progress) || 0,

--- a/src/components/ConversationsImprovements/ImprovementsHeader.vue
+++ b/src/components/ConversationsImprovements/ImprovementsHeader.vue
@@ -24,10 +24,8 @@
       :text="$t('audit.improvements.header.custom_analysis')"
       @click="openCustomAnalysisModal"
     />
-    <UnnnicButton
-      type="primary"
-      :text="$t('audit.improvements.header.run_analysis')"
-      @click="improvementsStore.runAnalysis"
+    <RunAnalysisButton
+      data-testid="conversations-improvements-header-run-button"
     />
   </header>
 </template>
@@ -44,6 +42,7 @@ import {
   formatTime,
   getYesterdayFormattedDate,
 } from '@/utils/formatters';
+import RunAnalysisButton from '@/components/ConversationsImprovements/RunAnalysisButton.vue';
 
 const { t } = useI18n();
 const improvementsStore = useImprovementsStore();

--- a/src/components/ConversationsImprovements/InsufficientConversationsVolume.vue
+++ b/src/components/ConversationsImprovements/InsufficientConversationsVolume.vue
@@ -1,36 +1,40 @@
 <template>
   <section
-    class="no-analysis-performed"
-    data-testid="no-analysis-performed"
+    class="insufficient-conversations-volume"
+    data-testid="insufficient-conversations-volume"
   >
-    <header class="no-analysis-performed__header">
+    <header class="insufficient-conversations-volume__header">
       <h2
-        class="no-analysis-performed__title"
-        data-testid="no-analysis-performed-title"
+        class="insufficient-conversations-volume__title"
+        data-testid="insufficient-conversations-volume-title"
       >
-        {{ $t('audit.improvements.no_analysis.title') }}
+        {{ $t('audit.improvements.insufficient_volume.title') }}
       </h2>
       <p
-        class="no-analysis-performed__description"
-        data-testid="no-analysis-performed-description"
+        class="insufficient-conversations-volume__description"
+        data-testid="insufficient-conversations-volume-description"
       >
-        {{ $t('audit.improvements.no_analysis.description') }}
+        {{
+          $t('audit.improvements.insufficient_volume.description', {
+            min: MIN_CONVERSATIONS_FOR_ANALYSIS,
+          })
+        }}
       </p>
     </header>
 
     <RunAnalysisButton
-      data-testid="no-analysis-performed-run-button"
-      translationKey="audit.improvements.no_analysis.run_analysis"
+      data-testid="insufficient-conversations-volume-run-button"
     />
   </section>
 </template>
 
 <script setup lang="ts">
 import RunAnalysisButton from '@/components/ConversationsImprovements/RunAnalysisButton.vue';
+import { MIN_CONVERSATIONS_FOR_ANALYSIS } from '@/store/Improvements';
 </script>
 
 <style scoped lang="scss">
-.no-analysis-performed {
+.insufficient-conversations-volume {
   height: 100%;
 
   display: flex;

--- a/src/components/ConversationsImprovements/RunAnalysisButton.vue
+++ b/src/components/ConversationsImprovements/RunAnalysisButton.vue
@@ -1,0 +1,61 @@
+<template>
+  <UnnnicToolTip
+    side="left"
+    :text="tooltipText"
+    :enabled="Boolean(improvementsStore.runAnalysisBlockReason)"
+  >
+    <UnnnicButton
+      type="primary"
+      :text="buttonText"
+      :disabled="improvementsStore.isRunAnalysisDisabled"
+      :loading="improvementsStore.analysis.status === 'loading'"
+      :data-testid="dataTestid"
+      @click="improvementsStore.runAnalysis"
+    />
+  </UnnnicToolTip>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { storeToRefs } from 'pinia';
+
+import {
+  MIN_CONVERSATIONS_FOR_ANALYSIS,
+  useImprovementsStore,
+} from '@/store/Improvements';
+
+const props = withDefaults(
+  defineProps<{
+    dataTestid?: string;
+    translationKey?: string;
+  }>(),
+  {
+    dataTestid: 'run-analysis-button',
+    translationKey: 'audit.improvements.header.run_analysis',
+  },
+);
+
+const { t } = useI18n();
+const improvementsStore = useImprovementsStore();
+const { runAnalysisBlockReason } = storeToRefs(improvementsStore);
+
+const buttonText = computed(() => t(props.translationKey));
+
+const tooltipText = computed(() => {
+  if (runAnalysisBlockReason.value === 'already_run_today') {
+    return t(
+      'audit.improvements.header.run_analysis_already_run_today_tooltip',
+    );
+  }
+
+  if (runAnalysisBlockReason.value === 'insufficient_volume') {
+    return t(
+      'audit.improvements.header.run_analysis_insufficient_volume_tooltip',
+      { min: MIN_CONVERSATIONS_FOR_ANALYSIS },
+    );
+  }
+
+  return '';
+});
+</script>

--- a/src/components/ConversationsImprovements/__tests__/InsufficientConversationsVolume.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/InsufficientConversationsVolume.spec.js
@@ -1,0 +1,86 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import { MIN_CONVERSATIONS_FOR_ANALYSIS } from '@/store/Improvements';
+
+import InsufficientConversationsVolume from '../InsufficientConversationsVolume.vue';
+import RunAnalysisButton from '../RunAnalysisButton.vue';
+
+describe('InsufficientConversationsVolume.vue', () => {
+  let wrapper;
+
+  const findTitle = () =>
+    wrapper.find('[data-testid="insufficient-conversations-volume-title"]');
+  const findDescription = () =>
+    wrapper.find(
+      '[data-testid="insufficient-conversations-volume-description"]',
+    );
+  const findRunAnalysisButton = () => wrapper.findComponent(RunAnalysisButton);
+
+  const createWrapper = () => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      initialState: {
+        Improvements: {
+          analysis: {
+            status: 'complete',
+            task: null,
+            yesterdayConversationsCount: 10,
+          },
+        },
+      },
+    });
+
+    wrapper = shallowMount(InsufficientConversationsVolume, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Component rendering', () => {
+    it('renders the insufficient volume section', () => {
+      expect(
+        wrapper
+          .find('[data-testid="insufficient-conversations-volume"]')
+          .exists(),
+      ).toBe(true);
+    });
+
+    it('renders the title with the correct translation', () => {
+      expect(findTitle().text()).toBe(
+        i18n.global.t('audit.improvements.insufficient_volume.title'),
+      );
+    });
+
+    it('renders the description with the correct translation', () => {
+      expect(findDescription().text()).toBe(
+        i18n.global.t('audit.improvements.insufficient_volume.description', {
+          min: MIN_CONVERSATIONS_FOR_ANALYSIS,
+        }),
+      );
+    });
+
+    it('renders the shared run analysis button', () => {
+      const button = findRunAnalysisButton();
+
+      expect(button.exists()).toBe(true);
+      expect(button.props('dataTestid')).toBe(
+        'insufficient-conversations-volume-run-button',
+      );
+    });
+  });
+});

--- a/src/components/ConversationsImprovements/__tests__/NoAnalysisPerformed.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/NoAnalysisPerformed.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount, shallowMount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
@@ -6,6 +6,7 @@ import i18n from '@/utils/plugins/i18n';
 import { useImprovementsStore } from '@/store/Improvements';
 
 import NoAnalysisPerformed from '../NoAnalysisPerformed.vue';
+import RunAnalysisButton from '../RunAnalysisButton.vue';
 
 describe('NoAnalysisPerformed.vue', () => {
   let wrapper;
@@ -15,12 +16,20 @@ describe('NoAnalysisPerformed.vue', () => {
     wrapper.find('[data-testid="no-analysis-performed-title"]');
   const findDescription = () =>
     wrapper.find('[data-testid="no-analysis-performed-description"]');
-  const findRunAnalysisButton = () =>
-    wrapper.findComponent('[data-testid="no-analysis-performed-run-button"]');
+  const findRunAnalysisButton = () => wrapper.findComponent(RunAnalysisButton);
 
   const createWrapper = () => {
     const pinia = createTestingPinia({
       createSpy: vi.fn,
+      initialState: {
+        Improvements: {
+          analysis: {
+            status: 'complete',
+            task: null,
+            yesterdayConversationsCount: 20,
+          },
+        },
+      },
     });
 
     wrapper = shallowMount(NoAnalysisPerformed, {
@@ -66,16 +75,39 @@ describe('NoAnalysisPerformed.vue', () => {
       const button = findRunAnalysisButton();
 
       expect(button.exists()).toBe(true);
-      expect(button.props('type')).toBe('primary');
-      expect(button.props('text')).toBe(
-        i18n.global.t('audit.improvements.no_analysis.run_analysis'),
+      expect(button.props('dataTestid')).toBe(
+        'no-analysis-performed-run-button',
+      );
+      expect(button.props('translationKey')).toBe(
+        'audit.improvements.no_analysis.run_analysis',
       );
     });
   });
 
   describe('User interactions', () => {
     it('calls runAnalysis when the run analysis button is clicked', async () => {
-      await findRunAnalysisButton().trigger('click');
+      wrapper.unmount();
+      const pinia = createTestingPinia({
+        createSpy: vi.fn,
+        initialState: {
+          Improvements: {
+            analysis: {
+              status: 'complete',
+              task: null,
+              yesterdayConversationsCount: 20,
+            },
+          },
+        },
+      });
+
+      wrapper = mount(NoAnalysisPerformed, {
+        global: {
+          plugins: [pinia],
+        },
+      });
+      improvementsStore = useImprovementsStore(pinia);
+
+      await wrapper.findComponent({ name: 'UnnnicButton' }).trigger('click');
 
       expect(improvementsStore.runAnalysis).toHaveBeenCalledOnce();
     });

--- a/src/components/ConversationsImprovements/__tests__/RunAnalysisButton.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/RunAnalysisButton.spec.js
@@ -1,0 +1,168 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import {
+  MIN_CONVERSATIONS_FOR_ANALYSIS,
+  useImprovementsStore,
+} from '@/store/Improvements';
+
+import RunAnalysisButton from '../RunAnalysisButton.vue';
+
+describe('RunAnalysisButton.vue', () => {
+  let wrapper;
+  let improvementsStore;
+
+  const findTooltip = () => wrapper.findComponent({ name: 'UnnnicTooltip' });
+  const findButton = () => wrapper.findComponent({ name: 'UnnnicButton' });
+
+  const createWrapper = (stateOverrides = {}, props = {}) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      initialState: {
+        Improvements: {
+          analysis: {
+            status: 'complete',
+            task: null,
+            yesterdayConversationsCount: 20,
+            ...(stateOverrides.analysis || {}),
+          },
+        },
+      },
+    });
+
+    wrapper = mount(RunAnalysisButton, {
+      attachTo: document.body,
+      global: {
+        plugins: [pinia],
+      },
+      props,
+    });
+
+    improvementsStore = useImprovementsStore(pinia);
+
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Component rendering', () => {
+    it('renders the run analysis button with default translation', () => {
+      expect(findButton().exists()).toBe(true);
+      expect(findButton().props('text')).toBe(
+        i18n.global.t('audit.improvements.header.run_analysis'),
+      );
+    });
+
+    it('uses the provided translation key', () => {
+      wrapper.unmount();
+      createWrapper(
+        {},
+        { translationKey: 'audit.improvements.no_analysis.run_analysis' },
+      );
+
+      expect(findButton().props('text')).toBe(
+        i18n.global.t('audit.improvements.no_analysis.run_analysis'),
+      );
+    });
+
+    it('uses the provided data-testid', () => {
+      wrapper.unmount();
+      createWrapper({}, { dataTestid: 'custom-run-button' });
+
+      expect(findButton().attributes('data-testid')).toBe('custom-run-button');
+    });
+  });
+
+  describe('Disabled state and tooltip', () => {
+    it('disables the button and enables tooltip for insufficient volume', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          yesterdayConversationsCount: 10,
+          task: null,
+        },
+      });
+
+      expect(findButton().props('disabled')).toBe(true);
+      expect(findTooltip().props('enabled')).toBe(true);
+      expect(findTooltip().props('text')).toBe(
+        i18n.global.t(
+          'audit.improvements.header.run_analysis_insufficient_volume_tooltip',
+          { min: MIN_CONVERSATIONS_FOR_ANALYSIS },
+        ),
+      );
+      expect(findTooltip().props('side')).toBe('left');
+    });
+
+    it('disables the button and enables tooltip when analysis already ran today', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          yesterdayConversationsCount: 50,
+          task: {
+            isRunning: false,
+            progress: 5,
+            total: 5,
+            createdAt: new Date().toISOString(),
+          },
+        },
+      });
+
+      expect(findButton().props('disabled')).toBe(true);
+      expect(findTooltip().props('enabled')).toBe(true);
+      expect(findTooltip().props('text')).toBe(
+        i18n.global.t(
+          'audit.improvements.header.run_analysis_already_run_today_tooltip',
+        ),
+      );
+    });
+
+    it('does not enable tooltip when the button is only disabled due to loading', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'loading',
+          yesterdayConversationsCount: 20,
+          task: null,
+        },
+      });
+
+      expect(findButton().props('disabled')).toBe(true);
+      expect(findTooltip().props('enabled')).toBe(false);
+    });
+  });
+
+  describe('User interactions', () => {
+    it('calls runAnalysis when the button is clicked and enabled', async () => {
+      await findButton().trigger('click');
+
+      expect(improvementsStore.runAnalysis).toHaveBeenCalledOnce();
+    });
+
+    it('does not call runAnalysis when the button is disabled', async () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          yesterdayConversationsCount: 10,
+          task: null,
+        },
+      });
+
+      await findButton().trigger('click');
+
+      expect(improvementsStore.runAnalysis).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -480,7 +480,13 @@
         "description": "Ran on {date} at {time}",
         "description_today": "Ran today at {time}",
         "run_analysis": "Run analysis",
+        "run_analysis_already_run_today_tooltip": "Analysis already ran today\nReturn tomorrow to run a new analysis",
+        "run_analysis_insufficient_volume_tooltip": "Insufficient conversation volume to run analysis\nMinimum of {min} conversations required",
         "title": "{count, plural, one {Analysis of conversations from {date} · {count} improvement identified} other {Analysis of conversations from {date} · {count} improvements identified}}"
+      },
+      "insufficient_volume": {
+        "description": "Minimum of {min} conversations required to run analysis",
+        "title": "Insufficient conversation volume"
       },
       "no_analysis": {
         "description": "Run your first analysis to identify opportunities for improvement in yesterday's conversations",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -479,7 +479,13 @@
         "description": "Ejecutado el {date} a las {time}",
         "description_today": "Ejecutado hoy a las {time}",
         "run_analysis": "Ejecutar análisis",
+        "run_analysis_already_run_today_tooltip": "Análisis ya ejecutado hoy\nNueva ejecución disponible mañana",
+        "run_analysis_insufficient_volume_tooltip": "Volumen insuficiente de conversaciones para ejecutar el análisis\nMínimo de {min} conversaciones necesarias",
         "title": "{count, plural, one {Análisis de conversaciones del {date} · {count} mejora identificada} other {Análisis de conversaciones del {date} · {count} mejoras identificadas}}"
+      },
+      "insufficient_volume": {
+        "description": "Mínimo de {min} conversaciones necesarias para ejecutar el análisis",
+        "title": "Volumen insuficiente de conversaciones"
       },
       "no_analysis": {
         "description": "Ejecuta el primer análisis para identificar oportunidades de mejora en las conversaciones de ayer",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -479,7 +479,13 @@
         "description": "Executado em {date} às {time}",
         "description_today": "Executado hoje às {time}",
         "run_analysis": "Executar análise",
+        "run_analysis_already_run_today_tooltip": "Análise já executada hoje\nNova execução disponível amanhã",
+        "run_analysis_insufficient_volume_tooltip": "Volume insuficiente de conversas para executar a análise\nMínimo de {min} conversas necessárias",
         "title": "{count, plural, one {Análise das conversas de {date} · {count} melhoria identificada} other {Análise das conversas de {date} · {count} melhorias identificadas}}"
+      },
+      "insufficient_volume": {
+        "description": "Mínimo de {min} conversas necessárias para executar a análise",
+        "title": "Volume insuficiente de conversas"
       },
       "no_analysis": {
         "description": "Execute a primeira análise para identificar oportunidades de melhoria nas conversas de ontem",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -478,7 +478,13 @@
         "description": "Rulat pe {date} la {time}",
         "description_today": "Rulat astăzi la {time}",
         "run_analysis": "Rulează analiza",
+        "run_analysis_already_run_today_tooltip": "Analiza a fost deja executată astăzi\nO nouă execuție va fi disponibilă mâine",
+        "run_analysis_insufficient_volume_tooltip": "Volum insuficient de conversații pentru executarea analizei\nMinimum {min} conversații necesare",
         "title": "{count, plural, one {Analiza conversațiilor din {date} · {count} îmbunătățire identificată} other {Analiza conversațiilor din {date} · {count} îmbunătățiri identificate}}"
+      },
+      "insufficient_volume": {
+        "description": "Minimum {min} conversații necesare pentru executarea analizei",
+        "title": "Volum insuficient de conversații"
       },
       "no_analysis": {
         "description": "Rulează prima analiză pentru a identifica oportunități de îmbunătățire în conversațiile de ieri",

--- a/src/store/Improvements.ts
+++ b/src/store/Improvements.ts
@@ -1,5 +1,7 @@
 import { computed, reactive } from 'vue';
 import { defineStore } from 'pinia';
+import { isToday } from 'date-fns';
+
 import nexusaiAPI from '@/api/nexusaiAPI';
 import i18n from '@/utils/plugins/i18n';
 import { getYesterdayFormattedDate } from '@/utils/formatters';
@@ -11,7 +13,10 @@ import type {
   ImprovementsAnalysis,
   ImprovementsStatus,
   ImprovementsTask,
+  RunAnalysisBlockReason,
 } from './types/Improvements.types';
+
+export const MIN_CONVERSATIONS_FOR_ANALYSIS = 15;
 
 const POLL_INTERVALS_MS = {
   fast: 5_000,
@@ -103,6 +108,31 @@ export const useImprovementsStore = defineStore('Improvements', () => {
     improvements.data = response.improvements;
   }
 
+  const runAnalysisBlockReason = computed<RunAnalysisBlockReason>(() => {
+    if (analysis.status !== 'complete') {
+      return null;
+    }
+
+    const createdAt = analysis.task?.createdAt;
+
+    if (createdAt && isToday(new Date(createdAt))) {
+      return 'already_run_today';
+    }
+
+    if (analysis.yesterdayConversationsCount < MIN_CONVERSATIONS_FOR_ANALYSIS) {
+      return 'insufficient_volume';
+    }
+
+    return null;
+  });
+
+  const isRunAnalysisDisabled = computed(
+    () =>
+      analysis.status === 'loading' ||
+      Boolean(analysis.task?.isRunning) ||
+      runAnalysisBlockReason.value !== null,
+  );
+
   function setStatus(status: ImprovementsStatus) {
     analysis.status = status;
     improvements.status = status;
@@ -120,7 +150,7 @@ export const useImprovementsStore = defineStore('Improvements', () => {
     let response = initialResponse;
     let pollCount = 0;
 
-    while (response.task.isRunning && pollCount < POLL_PHASE_LIMITS.minute) {
+    while (response.task?.isRunning && pollCount < POLL_PHASE_LIMITS.minute) {
       await wait(getPollIntervalMs(pollCount));
 
       response = await supervisorApi.improvements.getAnalysis({
@@ -141,7 +171,7 @@ export const useImprovementsStore = defineStore('Improvements', () => {
 
     applyAnalysisResponse(response);
 
-    if (response.task.isRunning) {
+    if (response.task?.isRunning) {
       await pollAnalysisUntilComplete(response);
     } else {
       setStatus('complete');
@@ -160,6 +190,10 @@ export const useImprovementsStore = defineStore('Improvements', () => {
   }
 
   async function runAnalysis() {
+    if (isRunAnalysisDisabled.value) {
+      return;
+    }
+
     setStatus('loading');
     resetAnalysisState();
 
@@ -179,6 +213,8 @@ export const useImprovementsStore = defineStore('Improvements', () => {
   return {
     analysis,
     improvements,
+    runAnalysisBlockReason,
+    isRunAnalysisDisabled,
     fetchImprovements,
     runAnalysis,
   };

--- a/src/store/__tests__/Improvements.unit.spec.js
+++ b/src/store/__tests__/Improvements.unit.spec.js
@@ -162,6 +162,7 @@ describe('Improvements Store', () => {
 
       expect(improvementsApi.getAnalysis).toHaveBeenCalledTimes(3);
       expect(store.improvements.data).toEqual(improvements);
+      expect(store.analysis.task.isRunning).toBe(false);
       expect(store.analysis.status).toBe('loading');
       expect(store.improvements.status).toBe('loading');
       expect(alertStore.add).not.toHaveBeenCalled();
@@ -180,7 +181,94 @@ describe('Improvements Store', () => {
     });
   });
 
+  describe('runAnalysisBlockReason', () => {
+    it('returns null while status is loading', () => {
+      store.analysis.status = 'loading';
+      store.analysis.yesterdayConversationsCount = 5;
+
+      expect(store.runAnalysisBlockReason).toBeNull();
+    });
+
+    it('returns insufficient_volume when yesterday count is below minimum', () => {
+      store.analysis.status = 'complete';
+      store.analysis.yesterdayConversationsCount = 14;
+      store.analysis.task = null;
+
+      expect(store.runAnalysisBlockReason).toBe('insufficient_volume');
+    });
+
+    it('returns null when yesterday count meets minimum', () => {
+      store.analysis.status = 'complete';
+      store.analysis.yesterdayConversationsCount = 15;
+      store.analysis.task = null;
+
+      expect(store.runAnalysisBlockReason).toBeNull();
+    });
+
+    it('returns already_run_today when task was created today', () => {
+      store.analysis.status = 'complete';
+      store.analysis.yesterdayConversationsCount = 50;
+      store.analysis.task = {
+        isRunning: false,
+        progress: 5,
+        total: 5,
+        createdAt: new Date().toISOString(),
+      };
+
+      expect(store.runAnalysisBlockReason).toBe('already_run_today');
+    });
+
+    it('prioritizes already_run_today over insufficient_volume', () => {
+      store.analysis.status = 'complete';
+      store.analysis.yesterdayConversationsCount = 5;
+      store.analysis.task = {
+        isRunning: false,
+        progress: 5,
+        total: 5,
+        createdAt: new Date().toISOString(),
+      };
+
+      expect(store.runAnalysisBlockReason).toBe('already_run_today');
+    });
+  });
+
+  describe('isRunAnalysisDisabled', () => {
+    it('is true while status is loading', () => {
+      store.analysis.status = 'loading';
+
+      expect(store.isRunAnalysisDisabled).toBe(true);
+    });
+
+    it('is true when task is running', () => {
+      store.analysis.status = 'complete';
+      store.analysis.task = {
+        isRunning: true,
+        progress: 1,
+        total: 5,
+        createdAt: null,
+      };
+
+      expect(store.isRunAnalysisDisabled).toBe(true);
+    });
+
+    it('is true when run analysis is blocked', () => {
+      store.analysis.status = 'complete';
+      store.analysis.yesterdayConversationsCount = 10;
+
+      expect(store.isRunAnalysisDisabled).toBe(true);
+    });
+  });
+
   describe('runAnalysis', () => {
+    it('does not call API when run analysis is disabled', async () => {
+      store.analysis.status = 'complete';
+      store.analysis.yesterdayConversationsCount = 5;
+
+      await store.runAnalysis();
+
+      expect(improvementsApi.runAnalysis).not.toHaveBeenCalled();
+    });
+
     it('sets loading state and clears previous data before the request resolves', async () => {
       let resolveRunAnalysis;
       improvementsApi.runAnalysis.mockReturnValue(
@@ -376,7 +464,6 @@ describe('Improvements Store', () => {
       improvementsApi.runAnalysis.mockResolvedValue();
       improvementsApi.getAnalysis.mockResolvedValue(
         buildAnalysisResponse({
-          conversationsCount: 0,
           improvements: [],
         }),
       );
@@ -402,7 +489,6 @@ describe('Improvements Store', () => {
       improvementsApi.runAnalysis.mockResolvedValue();
       improvementsApi.getAnalysis.mockResolvedValue(
         buildAnalysisResponse({
-          conversationsCount: 25,
           improvements,
         }),
       );

--- a/src/store/types/Improvements.types.ts
+++ b/src/store/types/Improvements.types.ts
@@ -9,6 +9,11 @@ export type ImprovementType =
 
 export type ImprovementsStatus = null | 'loading' | 'complete' | 'error';
 
+export type RunAnalysisBlockReason =
+  | 'insufficient_volume'
+  | 'already_run_today'
+  | null;
+
 export interface ImprovementsTask {
   isRunning: boolean;
   progress: number;
@@ -25,6 +30,6 @@ export interface Improvement {
 
 export interface ImprovementsAnalysis {
   yesterdayConversationsCount: number;
-  task: ImprovementsTask;
+  task: ImprovementsTask | null;
   improvements: Improvement[];
 }

--- a/src/views/Supervisor/Improvements/__tests__/index.spec.js
+++ b/src/views/Supervisor/Improvements/__tests__/index.spec.js
@@ -8,6 +8,7 @@ import AnalysisInProgressDisclaimer from '@/components/ConversationsImprovements
 import ImprovementsHeader from '@/components/ConversationsImprovements/ImprovementsHeader.vue';
 import ImprovementsList from '@/components/ConversationsImprovements/ImprovementsList.vue';
 import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
+import InsufficientConversationsVolume from '@/components/ConversationsImprovements/InsufficientConversationsVolume.vue';
 import RunningAnalysis from '@/components/ConversationsImprovements/RunningAnalysis.vue';
 
 import Improvements from '@/views/Supervisor/Improvements/index.vue';
@@ -20,6 +21,8 @@ describe('Improvements view', () => {
     wrapper.find('[data-testid="conversations-improvements"]');
   const findNoAnalysisPerformed = () =>
     wrapper.findComponent(NoAnalysisPerformed);
+  const findInsufficientConversationsVolume = () =>
+    wrapper.findComponent(InsufficientConversationsVolume);
   const findRunningAnalysis = () => wrapper.findComponent(RunningAnalysis);
   const findAnalysisInProgressDisclaimer = () =>
     wrapper.findComponent(AnalysisInProgressDisclaimer);
@@ -35,7 +38,7 @@ describe('Improvements view', () => {
           analysis: {
             status: null,
             task: null,
-            conversationsCount: 0,
+            yesterdayConversationsCount: 0,
             ...(stateOverrides.analysis || {}),
           },
           improvements: {
@@ -70,6 +73,36 @@ describe('Improvements view', () => {
   describe('on mount', () => {
     it('loads improvements when the view mounts', () => {
       expect(improvementsStore.fetchImprovements).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('InsufficientConversationsVolume state', () => {
+    it('renders InsufficientConversationsVolume when volume is below minimum and there is no task', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: null,
+          yesterdayConversationsCount: 10,
+        },
+      });
+
+      expect(findInsufficientConversationsVolume().exists()).toBe(true);
+      expect(findNoAnalysisPerformed().exists()).toBe(false);
+    });
+
+    it('does not render InsufficientConversationsVolume when volume meets minimum', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: null,
+          yesterdayConversationsCount: 15,
+        },
+      });
+
+      expect(findInsufficientConversationsVolume().exists()).toBe(false);
+      expect(findNoAnalysisPerformed().exists()).toBe(true);
     });
   });
 
@@ -231,7 +264,7 @@ describe('Improvements view', () => {
       });
 
       expect(findAnalysisInProgressDisclaimer().exists()).toBe(true);
-      expect(findImprovementsHeader().exists()).toBe(true);
+      expect(findImprovementsHeader().exists()).toBe(false);
       expect(findImprovementsList().exists()).toBe(true);
       expect(findRunningAnalysis().exists()).toBe(false);
     });
@@ -275,7 +308,7 @@ describe('Improvements view', () => {
       await wrapper.vm.$nextTick();
 
       expect(findAnalysisInProgressDisclaimer().exists()).toBe(true);
-      expect(findImprovementsHeader().exists()).toBe(true);
+      expect(findImprovementsHeader().exists()).toBe(false);
       expect(findImprovementsList().exists()).toBe(true);
       expect(findRunningAnalysis().exists()).toBe(false);
     });

--- a/src/views/Supervisor/Improvements/index.vue
+++ b/src/views/Supervisor/Improvements/index.vue
@@ -3,7 +3,10 @@
     class="conversations-improvements"
     data-testid="conversations-improvements"
   >
-    <NoAnalysisPerformed v-if="!analysis.task" />
+    <InsufficientConversationsVolume
+      v-if="!analysis.task && runAnalysisBlockReason === 'insufficient_volume'"
+    />
+    <NoAnalysisPerformed v-else-if="!analysis.task" />
     <RunningAnalysis
       v-else-if="analysis.task?.isRunning && !improvements.data.length"
     />
@@ -11,7 +14,7 @@
     <template v-else-if="improvements.data.length">
       <AnalysisInProgressDisclaimer v-if="analysis.task?.isRunning" />
 
-      <ImprovementsHeader />
+      <ImprovementsHeader v-else />
 
       <ImprovementsList />
     </template>
@@ -25,13 +28,15 @@ import { storeToRefs } from 'pinia';
 import { useImprovementsStore } from '@/store/Improvements';
 
 import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
+import InsufficientConversationsVolume from '@/components/ConversationsImprovements/InsufficientConversationsVolume.vue';
 import RunningAnalysis from '@/components/ConversationsImprovements/RunningAnalysis.vue';
 import ImprovementsHeader from '@/components/ConversationsImprovements/ImprovementsHeader.vue';
 import ImprovementsList from '@/components/ConversationsImprovements/ImprovementsList.vue';
 import AnalysisInProgressDisclaimer from '@/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue';
 
 const improvementsStore = useImprovementsStore();
-const { analysis, improvements } = storeToRefs(improvementsStore);
+const { analysis, improvements, runAnalysisBlockReason } =
+  storeToRefs(improvementsStore);
 
 onMounted(() => {
   improvementsStore.fetchImprovements();
@@ -44,5 +49,9 @@ onMounted(() => {
 
   padding: $unnnic-space-4;
   padding-top: 0;
+
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-6;
 }
 </style>


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The analysis feature lacked guardrails to prevent users from running analysis when there were not enough conversations from the previous day, or when an analysis had already been run today. This led to a poor user experience with no feedback on why the action was unavailable.

### Summary of Changes

**Insufficient volume state:**

- Added a new `InsufficientConversationsVolume` view that is displayed when yesterday's conversation count falls below the minimum threshold of 15, replacing the `NoAnalysisPerformed` view in that scenario.

**Run analysis blocking logic:**

- Introduced a `runAnalysisBlockReason` computed property to the Improvements store that returns `'insufficient_volume'` or `'already_run_today'` based on the current state, or `null` when the action is allowed.
- Added an `isRunAnalysisDisabled` computed property that gates the run analysis action based on loading state, task running state, or a block reason.
- The `runAnalysis` action now returns early when disabled.

**Shared** **`RunAnalysisButton`** **component:**

- Extracted a reusable `RunAnalysisButton` component used across `ImprovementsHeader`, `NoAnalysisPerformed`, and `InsufficientConversationsVolume`. It handles disabled state and displays a contextual tooltip explaining why the button is blocked.

**API field rename:**

- Renamed `conversations_count` to `yesterday_conversations_count` in the API contract, adapter, and store to better reflect that the count refers to the previous day's conversations.

**Task nullability:**

- `ImprovementsTask` is now nullable (`null` when no task exists), and `parseTask` returns `null` when no task data is provided, replacing the previous default empty task object.

**`ImprovementsHeader`** **visibility:**

- `ImprovementsHeader` is now hidden while an analysis is in progress and improvements are already displayed, showing only the `AnalysisInProgressDisclaimer` in that state.

**Localization:**

- Added translations in English, Spanish, Portuguese, and Romanian for the insufficient volume screen and the two tooltip messages.



### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/0b01526f-e306-42cf-8f6f-bd80a9db940d.png)

