### PR TITLE
feat: Introduce Run Analysis dialog and enhance button functionality

### DIFF
--- a/src/components/ConversationsImprovements/RunAnalysisButton.vue
+++ b/src/components/ConversationsImprovements/RunAnalysisButton.vue
@@ -10,13 +10,15 @@
       :disabled="improvementsStore.isRunAnalysisDisabled"
       :loading="improvementsStore.analysis.status === 'loading'"
       :data-testid="dataTestid"
-      @click="improvementsStore.runAnalysis"
+      @click="handleRunAnalysisClick"
     />
   </UnnnicToolTip>
+
+  <RunAnalysisDialog v-model:open="isRunAnalysisDialogOpen" />
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
 
@@ -24,6 +26,8 @@ import {
   MIN_CONVERSATIONS_FOR_ANALYSIS,
   useImprovementsStore,
 } from '@/store/Improvements';
+
+import RunAnalysisDialog from './RunAnalysisDialog.vue';
 
 const props = withDefaults(
   defineProps<{
@@ -38,7 +42,9 @@ const props = withDefaults(
 
 const { t } = useI18n();
 const improvementsStore = useImprovementsStore();
-const { runAnalysisBlockReason } = storeToRefs(improvementsStore);
+const { runAnalysisBlockReason, improvements } = storeToRefs(improvementsStore);
+
+const isRunAnalysisDialogOpen = ref(false);
 
 const buttonText = computed(() => t(props.translationKey));
 
@@ -58,4 +64,13 @@ const tooltipText = computed(() => {
 
   return '';
 });
+
+const handleRunAnalysisClick = () => {
+  if (improvements.value.data.length > 0) {
+    isRunAnalysisDialogOpen.value = true;
+    return;
+  }
+
+  improvementsStore.runAnalysis();
+};
 </script>

--- a/src/components/ConversationsImprovements/RunAnalysisDialog.vue
+++ b/src/components/ConversationsImprovements/RunAnalysisDialog.vue
@@ -1,0 +1,80 @@
+<template>
+  <UnnnicDialog
+    data-testid="run-analysis-dialog"
+    :open="open"
+    lazyMount
+    @update:open="open = false"
+  >
+    <UnnnicDialogContent>
+      <UnnnicDialogHeader type="attention">
+        <UnnnicDialogTitle>
+          {{ $t('audit.improvements.run_analysis_dialog.title') }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+      <section class="run-analysis-dialog__content">
+        <p>{{ dialogDescription }}</p>
+      </section>
+      <UnnnicDialogFooter>
+        <UnnnicDialogClose>
+          <UnnnicButton
+            :text="$t('audit.improvements.run_analysis_dialog.cancel')"
+            type="tertiary"
+          />
+        </UnnnicDialogClose>
+        <UnnnicButton
+          :text="$t('audit.improvements.run_analysis_dialog.run')"
+          type="attention"
+          :loading="improvementsStore.analysis.status === 'loading'"
+          @click="handleRunAnalysis"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { subDays } from 'date-fns';
+import { storeToRefs } from 'pinia';
+
+import { useImprovementsStore } from '@/store/Improvements';
+import {
+  formatMonthDayDate,
+  getYesterdayFormattedDate,
+} from '@/utils/formatters';
+
+const open = defineModel<boolean>('open', {
+  required: true,
+});
+
+const { t } = useI18n();
+const improvementsStore = useImprovementsStore();
+const { analysis, improvements } = storeToRefs(improvementsStore);
+
+const handleRunAnalysis = () => {
+  open.value = false;
+  improvementsStore.runAnalysis();
+};
+
+const dialogDescription = computed(() => {
+  const createdAt = analysis.value.task?.createdAt;
+  const currentDate = createdAt
+    ? formatMonthDayDate(subDays(new Date(createdAt), 1).toISOString())
+    : '';
+
+  return t('audit.improvements.run_analysis_dialog.description', {
+    count: improvements.value.data.length,
+    current_date: currentDate,
+    new_date: getYesterdayFormattedDate(),
+  });
+});
+</script>
+
+<style scoped lang="scss">
+.run-analysis-dialog {
+  &__content {
+    padding: $unnnic-space-6;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/__tests__/NoAnalysisPerformed.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/NoAnalysisPerformed.spec.js
@@ -103,6 +103,12 @@ describe('NoAnalysisPerformed.vue', () => {
       wrapper = mount(NoAnalysisPerformed, {
         global: {
           plugins: [pinia],
+          stubs: {
+            RunAnalysisDialog: {
+              template: '<div data-testid="run-analysis-dialog-stub" />',
+              props: ['open'],
+            },
+          },
         },
       });
       improvementsStore = useImprovementsStore(pinia);

--- a/src/components/ConversationsImprovements/__tests__/RunAnalysisButton.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/RunAnalysisButton.spec.js
@@ -9,6 +9,7 @@ import {
 } from '@/store/Improvements';
 
 import RunAnalysisButton from '../RunAnalysisButton.vue';
+import RunAnalysisDialog from '../RunAnalysisDialog.vue';
 
 describe('RunAnalysisButton.vue', () => {
   let wrapper;
@@ -28,6 +29,11 @@ describe('RunAnalysisButton.vue', () => {
             yesterdayConversationsCount: 20,
             ...(stateOverrides.analysis || {}),
           },
+          improvements: {
+            data: [],
+            status: 'complete',
+            ...(stateOverrides.improvements || {}),
+          },
         },
       },
     });
@@ -36,6 +42,12 @@ describe('RunAnalysisButton.vue', () => {
       attachTo: document.body,
       global: {
         plugins: [pinia],
+        stubs: {
+          RunAnalysisDialog: {
+            template: '<div data-testid="run-analysis-dialog-stub" />',
+            props: ['open'],
+          },
+        },
       },
       props,
     });
@@ -144,10 +156,34 @@ describe('RunAnalysisButton.vue', () => {
   });
 
   describe('User interactions', () => {
-    it('calls runAnalysis when the button is clicked and enabled', async () => {
+    const findDialog = () => wrapper.findComponent(RunAnalysisDialog);
+
+    it('calls runAnalysis when there are no improvements', async () => {
       await findButton().trigger('click');
 
       expect(improvementsStore.runAnalysis).toHaveBeenCalledOnce();
+      expect(findDialog().props('open')).toBe(false);
+    });
+
+    it('opens the dialog when there are improvements', async () => {
+      wrapper.unmount();
+      createWrapper({
+        improvements: {
+          data: [
+            {
+              uuid: 'improvement-1',
+              text: 'Improve response time',
+              type: 'repetitive_response',
+              conversationsCount: 3,
+            },
+          ],
+        },
+      });
+
+      await findButton().trigger('click');
+
+      expect(improvementsStore.runAnalysis).not.toHaveBeenCalled();
+      expect(findDialog().props('open')).toBe(true);
     });
 
     it('does not call runAnalysis when the button is disabled', async () => {

--- a/src/components/ConversationsImprovements/__tests__/RunAnalysisDialog.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/RunAnalysisDialog.spec.js
@@ -1,0 +1,85 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import { useImprovementsStore } from '@/store/Improvements';
+
+import RunAnalysisDialog from '../RunAnalysisDialog.vue';
+
+describe('RunAnalysisDialog.vue', () => {
+  let wrapper;
+  let improvementsStore;
+
+  const findRunButton = () =>
+    wrapper
+      .findAllComponents({ name: 'UnnnicButton' })
+      .find((button) => button.props('type') === 'attention');
+
+  const createWrapper = (stateOverrides = {}, props = { open: true }) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      initialState: {
+        Improvements: {
+          analysis: {
+            status: 'complete',
+            task: {
+              createdAt: '2026-07-08T12:00:00.000Z',
+            },
+            yesterdayConversationsCount: 20,
+            ...(stateOverrides.analysis || {}),
+          },
+          improvements: {
+            data: [
+              {
+                uuid: 'improvement-1',
+                text: 'Improve response time',
+                type: 'repetitive_response',
+                conversationsCount: 3,
+              },
+            ],
+            status: 'complete',
+            ...(stateOverrides.improvements || {}),
+          },
+        },
+      },
+    });
+
+    wrapper = shallowMount(RunAnalysisDialog, {
+      global: {
+        plugins: [pinia],
+      },
+      props,
+    });
+
+    improvementsStore = useImprovementsStore(pinia);
+
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('User interactions', () => {
+    it('closes the dialog and calls runAnalysis when Run is clicked', async () => {
+      await findRunButton().trigger('click');
+
+      expect(wrapper.emitted('update:open')).toEqual([[false]]);
+      expect(improvementsStore.runAnalysis).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('Component rendering', () => {
+    it('renders the run button label', () => {
+      expect(findRunButton().props('text')).toBe(
+        i18n.global.t('audit.improvements.run_analysis_dialog.run'),
+      );
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -500,6 +500,12 @@
         "run_analysis": "Run analysis",
         "title": "No analysis has been run yet"
       },
+      "run_analysis_dialog": {
+        "cancel": "Cancel",
+        "description": "There are still {count, plural, one {# unresolved improvement} other {# unresolved improvements}} from {current_date}. A new analysis will replace this list with the conversations from {new_date}. The current improvements will be lost.",
+        "run": "Run",
+        "title": "Run analysis"
+      },
       "running_analysis": {
         "description": "This may take a few hours. You can close this screen.",
         "title": "Analyzing {count} conversations from yesterday"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -499,6 +499,12 @@
         "run_analysis": "Ejecutar análisis",
         "title": "Aún no se ha ejecutado ningún análisis"
       },
+      "run_analysis_dialog": {
+        "cancel": "Cancelar",
+        "description": "Aún hay {count, plural, one {# mejora sin resolver} other {# mejoras sin resolver}} del {current_date}. Un nuevo análisis reemplazará esta lista con las conversaciones del {new_date}. Las mejoras actuales se perderán.",
+        "run": "Ejecutar",
+        "title": "Ejecutar análisis"
+      },
       "running_analysis": {
         "description": "Esto puede tardar unas horas. Puedes cerrar esta pantalla.",
         "title": "Analizando {count} conversaciones de ayer"

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -499,6 +499,12 @@
         "run_analysis": "Executar análise",
         "title": "Nenhuma análise foi executada ainda"
       },
+      "run_analysis_dialog": {
+        "cancel": "Cancelar",
+        "description": "Ainda há {count, plural, one {# melhoria não resolvida} other {# melhorias não resolvidas}} de {current_date}. Uma nova análise substituirá esta lista pelas conversas de {new_date}. As melhorias atuais serão perdidas.",
+        "run": "Executar",
+        "title": "Executar análise"
+      },
       "running_analysis": {
         "description": "Isso pode levar algumas horas. Você pode fechar esta tela.",
         "title": "Analisando {count} conversas de ontem"

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -498,6 +498,12 @@
         "run_analysis": "Rulează analiza",
         "title": "Nicio analiză nu a fost executată încă"
       },
+      "run_analysis_dialog": {
+        "cancel": "Anulează",
+        "description": "Încă există {count, plural, one {# îmbunătățire nerezolvată} few {# îmbunătățiri nerezolvate} other {# îmbunătățiri nerezolvate}} din {current_date}. O nouă analiză va înlocui această listă cu conversațiile din {new_date}. Îmbunătățirile actuale vor fi pierdute.",
+        "run": "Rulează",
+        "title": "Rulează analiza"
+      },
       "running_analysis": {
         "description": "Acest proces poate dura câteva ore. Poți închide acest ecran.",
         "title": "Se analizează {count} conversații de ieri"


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

When a user clicks "Run Analysis" while there are existing unresolved improvements, running the analysis immediately would silently discard those improvements. A confirmation step is needed to prevent accidental data loss.

### Summary of Changes

- Added a `RunAnalysisDialog` component that warns users when running a new analysis will overwrite existing unresolved improvements, showing the count of pending improvements, the date of the current analysis, and the date the new analysis will cover.
- Updated `RunAnalysisButton` to intercept the click event: if there are existing improvements, it opens the confirmation dialog instead of immediately triggering the analysis. If there are no improvements, the analysis runs directly as before.
- Added localization strings for the new dialog (title, description with plural support, cancel, and run actions) in English, Spanish, Portuguese, and Romanian.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/98eea99c-6d0e-4f30-a5cb-23ca9d49dff5.png)

