### PR TITLE
feat: Add ImprovementsList table with row selection

### DIFF
--- a/src/components/ConversationsImprovements/ImprovementDrawer.vue
+++ b/src/components/ConversationsImprovements/ImprovementDrawer.vue
@@ -1,0 +1,35 @@
+<template>
+  <UnnnicDrawerNext
+    v-model:open="drawerOpen"
+    data-testid="improvement-drawer"
+  >
+    <UnnnicDrawerContent size="large">
+      <UnnnicDrawerHeader>
+        <UnnnicDrawerTitle data-testid="improvement-drawer-title">
+          {{ improvement?.text }}
+        </UnnnicDrawerTitle>
+      </UnnnicDrawerHeader>
+
+      <section
+        class="improvement-drawer"
+        data-testid="improvement-drawer-content"
+      >
+        <!-- TODO: Implement improvement detail drawer in next branch -->
+      </section>
+    </UnnnicDrawerContent>
+  </UnnnicDrawerNext>
+</template>
+
+<script setup lang="ts">
+import type { Improvement } from '@/store/types/Improvements.types';
+
+const drawerOpen = defineModel<boolean>('open', {
+  required: true,
+});
+
+defineProps<{
+  improvement: Improvement | null;
+}>();
+</script>
+
+<style scoped lang="scss"></style>

--- a/src/components/ConversationsImprovements/ImprovementRow.vue
+++ b/src/components/ConversationsImprovements/ImprovementRow.vue
@@ -1,0 +1,90 @@
+<template>
+  <UnnnicTableRow
+    data-testid="improvement-row"
+    class="improvement-row"
+    :class="{
+      'improvement-row--selected': isSelected,
+    }"
+  >
+    <UnnnicTableCell
+      class="improvements-list__col improvements-list__col--improvement"
+    >
+      <p
+        class="improvement-row__text"
+        data-testid="improvement-row-text"
+      >
+        {{ improvement.text }}
+      </p>
+    </UnnnicTableCell>
+
+    <UnnnicTableCell
+      class="improvements-list__col improvements-list__col--type"
+    >
+      <UnnnicTag
+        class="improvement-row__type"
+        data-testid="improvement-row-type"
+        :scheme="typeTag.scheme"
+        :text="typeTag.text"
+      />
+    </UnnnicTableCell>
+
+    <UnnnicTableCell
+      class="improvements-list__col improvements-list__col--affected_conversations"
+    >
+      <p
+        class="improvement-row__conversations-count"
+        data-testid="improvement-row-conversations-count"
+      >
+        {{ improvement.conversationsCount }}
+      </p>
+    </UnnnicTableCell>
+  </UnnnicTableRow>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { getImprovementTypeTag } from '@/utils/improvements/getImprovementTypeTag';
+
+import type { Improvement } from '@/store/types/Improvements.types';
+
+const props = withDefaults(
+  defineProps<{
+    improvement: Improvement;
+    isSelected?: boolean;
+  }>(),
+  {
+    isSelected: false,
+  },
+);
+
+const { t } = useI18n();
+
+const typeTag = computed(() => {
+  const { category, scheme } = getImprovementTypeTag(props.improvement.type);
+
+  return {
+    scheme,
+    text: t(`audit.improvements.types.${category}`),
+  };
+});
+</script>
+
+<style scoped lang="scss">
+.improvement-row {
+  &--selected {
+    background-color: $unnnic-color-bg-base-soft;
+  }
+
+  &__text,
+  &__conversations-count {
+    @include unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+
+  &__type {
+    white-space: nowrap;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/ImprovementsList.vue
+++ b/src/components/ConversationsImprovements/ImprovementsList.vue
@@ -1,8 +1,96 @@
 <template>
   <section
-    class="conversationsimprovements-list"
+    :class="[
+      'improvements-list',
+      { 'improvements-list--selected': selectedImprovement },
+    ]"
     data-testid="improvements-list"
-  ></section>
+  >
+    <UnnnicTable version="2">
+      <UnnnicTableHeader class="improvements-list__header">
+        <UnnnicTableRow>
+          <UnnnicTableHead
+            v-for="column in columns"
+            :key="`improvement-table-head-${column}`"
+            :class="`improvements-list__col improvements-list__col--${column}`"
+            :data-testid="`improvement-table-head-${column}`"
+          >
+            {{ $t(`audit.improvements.columns.${column}`) }}
+          </UnnnicTableHead>
+        </UnnnicTableRow>
+      </UnnnicTableHeader>
+
+      <UnnnicTableBody class="improvements-list__rows">
+        <ImprovementRow
+          v-for="improvement in improvementResults"
+          :key="improvement.uuid"
+          data-testid="improvement-row"
+          :improvement="improvement"
+          :isSelected="improvement.uuid === selectedImprovement?.uuid"
+          @click="handleRowClick(improvement)"
+        />
+      </UnnnicTableBody>
+    </UnnnicTable>
+
+    <ImprovementDrawer
+      v-model:open="isDrawerOpen"
+      :improvement="selectedImprovement"
+    />
+  </section>
 </template>
-<script setup lang="ts"></script>
-<style scoped lang="scss"></style>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+
+import { useImprovementsStore } from '@/store/Improvements';
+
+import ImprovementDrawer from '@/components/ConversationsImprovements/ImprovementDrawer.vue';
+import ImprovementRow from '@/components/ConversationsImprovements/ImprovementRow.vue';
+
+import type { Improvement } from '@/store/types/Improvements.types';
+
+const improvementsStore = useImprovementsStore();
+const { improvements } = storeToRefs(improvementsStore);
+
+const selectedImprovement = ref<Improvement | null>(null);
+const isDrawerOpen = ref(false);
+
+const improvementResults = computed(() => improvements.value.data);
+
+const columns = ['improvement', 'type', 'affected_conversations'] as const;
+
+function handleRowClick(improvement: Improvement) {
+  selectedImprovement.value = improvement;
+  isDrawerOpen.value = true;
+}
+
+watch(isDrawerOpen, (open) => {
+  if (!open) {
+    selectedImprovement.value = null;
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.improvements-list {
+  margin-right: 0;
+  margin-bottom: $unnnic-spacing-sm;
+
+  height: 100%;
+
+  overflow: hidden;
+
+  display: flex;
+  flex-direction: column;
+
+  :deep(.improvements-list__col--improvement) {
+    width: calc(100% / 12 * 8);
+  }
+
+  :deep(.improvements-list__col--type),
+  :deep(.improvements-list__col--affected_conversations) {
+    width: calc(100% / 12 * 2);
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/__tests__/ImprovementRow.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementRow.spec.js
@@ -1,0 +1,137 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import i18n from '@/utils/plugins/i18n';
+
+import ImprovementRow from '../ImprovementRow.vue';
+
+describe('ImprovementRow.vue', () => {
+  let wrapper;
+
+  const baseImprovement = {
+    uuid: 'improvement-uuid-1',
+    text: 'The agent tone does not match the configured brand voice in refund conversations.',
+    type: 'personality_deviation',
+    conversationsCount: 18,
+  };
+
+  const createWrapper = (props = {}) => {
+    wrapper = mount(ImprovementRow, {
+      props: {
+        improvement: baseImprovement,
+        ...props,
+      },
+      global: {
+        stubs: {
+          UnnnicTableRow: {
+            template: '<tr v-bind="$attrs"><slot /></tr>',
+          },
+          UnnnicTableCell: {
+            template: '<td><slot /></td>',
+          },
+        },
+      },
+    });
+  };
+
+  const elements = {
+    row: () => wrapper.find('[data-testid="improvement-row"]'),
+    text: () => wrapper.find('[data-testid="improvement-row-text"]'),
+    conversationsCount: () =>
+      wrapper.find('[data-testid="improvement-row-conversations-count"]'),
+    typeTag: () => wrapper.findComponent({ name: 'UnnnicTag' }),
+  };
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders the row', () => {
+    createWrapper();
+
+    expect(elements.row().exists()).toBe(true);
+  });
+
+  it('renders the improvement text', () => {
+    createWrapper();
+
+    expect(elements.text().text()).toBe(baseImprovement.text);
+  });
+
+  it('renders the affected conversations count', () => {
+    createWrapper();
+
+    expect(elements.conversationsCount().text()).toBe(
+      String(baseImprovement.conversationsCount),
+    );
+  });
+
+  it('adds the selected class when isSelected is true', () => {
+    createWrapper({ isSelected: true });
+
+    expect(elements.row().classes()).toContain('improvement-row--selected');
+  });
+
+  it('does not add the selected class when isSelected is false', () => {
+    createWrapper({ isSelected: false });
+
+    expect(elements.row().classes()).not.toContain('improvement-row--selected');
+  });
+
+  describe('type tag mapping', () => {
+    it.each([
+      {
+        type: 'many_questions_before_answering',
+        scheme: 'blue',
+        category: 'behavior',
+      },
+      {
+        type: 'wrong_behavior_due_to_instructions',
+        scheme: 'blue',
+        category: 'behavior',
+      },
+      {
+        type: 'personality_deviation',
+        scheme: 'blue',
+        category: 'behavior',
+      },
+      {
+        type: 'repetitive_response',
+        scheme: 'blue',
+        category: 'behavior',
+      },
+      {
+        type: 'missing_static_knowledge',
+        scheme: 'purple',
+        category: 'knowledge',
+      },
+      {
+        type: 'poor_product_search_results',
+        scheme: 'orange',
+        category: 'technical_issue',
+      },
+      {
+        type: 'custom_analysis',
+        scheme: 'yellow',
+        category: 'custom_analysis',
+      },
+    ])(
+      'renders $category tag with $scheme scheme for $type',
+      ({ type, scheme, category }) => {
+        createWrapper({
+          improvement: {
+            ...baseImprovement,
+            type,
+          },
+        });
+
+        const typeTag = elements.typeTag();
+
+        expect(typeTag.props('scheme')).toBe(scheme);
+        expect(typeTag.props('text')).toBe(
+          i18n.global.t(`audit.improvements.types.${category}`),
+        );
+      },
+    );
+  });
+});

--- a/src/components/ConversationsImprovements/__tests__/ImprovementsList.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementsList.spec.js
@@ -1,0 +1,162 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { nextTick } from 'vue';
+
+import i18n from '@/utils/plugins/i18n';
+
+import ImprovementsList from '../ImprovementsList.vue';
+import ImprovementDrawer from '../ImprovementDrawer.vue';
+import ImprovementRow from '../ImprovementRow.vue';
+
+describe('ImprovementsList.vue', () => {
+  let wrapper;
+
+  const mockImprovements = [
+    {
+      uuid: 'improvement-uuid-1',
+      text: 'The agent tone does not match the configured brand voice in refund conversations.',
+      type: 'personality_deviation',
+      conversationsCount: 18,
+    },
+    {
+      uuid: 'improvement-uuid-2',
+      text: 'The agent asks too many questions before providing an answer about order status.',
+      type: 'many_questions_before_answering',
+      conversationsCount: 12,
+    },
+  ];
+
+  const createWrapper = (stateOverrides = {}) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      initialState: {
+        Improvements: {
+          improvements: {
+            data: mockImprovements,
+            status: 'complete',
+            ...(stateOverrides.improvements || {}),
+          },
+        },
+      },
+    });
+
+    wrapper = mount(ImprovementsList, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          ImprovementDrawer: true,
+          UnnnicTable: {
+            template: '<table><slot /></table>',
+          },
+          UnnnicTableHeader: {
+            template: '<thead><slot /></thead>',
+          },
+          UnnnicTableBody: {
+            template: '<tbody><slot /></tbody>',
+          },
+          UnnnicTableRow: {
+            template: '<tr><slot /></tr>',
+          },
+          UnnnicTableHead: {
+            template: '<th><slot /></th>',
+          },
+        },
+      },
+    });
+
+    return wrapper;
+  };
+
+  const elements = {
+    list: () => wrapper.find('[data-testid="improvements-list"]'),
+    columnHead: (column) =>
+      wrapper.find(`[data-testid="improvement-table-head-${column}"]`),
+    rows: () => wrapper.findAllComponents(ImprovementRow),
+    drawer: () => wrapper.findComponent(ImprovementDrawer),
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Component rendering', () => {
+    it('renders the improvements list section', () => {
+      expect(elements.list().exists()).toBe(true);
+    });
+
+    it('renders the table column headers', () => {
+      expect(elements.columnHead('improvement').text()).toBe(
+        i18n.global.t('audit.improvements.columns.improvement'),
+      );
+      expect(elements.columnHead('type').text()).toBe(
+        i18n.global.t('audit.improvements.columns.type'),
+      );
+      expect(elements.columnHead('affected_conversations').text()).toBe(
+        i18n.global.t('audit.improvements.columns.affected_conversations'),
+      );
+    });
+
+    it('renders one row per improvement from the store', () => {
+      const rows = elements.rows();
+
+      expect(rows).toHaveLength(mockImprovements.length);
+      expect(rows[0].props('improvement')).toEqual(mockImprovements[0]);
+      expect(rows[1].props('improvement')).toEqual(mockImprovements[1]);
+    });
+
+    it('does not apply the selected modifier class initially', () => {
+      expect(elements.list().classes()).not.toContain(
+        'improvements-list--selected',
+      );
+    });
+
+    it('renders the improvement drawer closed initially', () => {
+      expect(elements.drawer().props('open')).toBe(false);
+      expect(elements.drawer().props('improvement')).toBeNull();
+    });
+  });
+
+  describe('Row interaction', () => {
+    it('opens the drawer with the selected improvement when a row is clicked', async () => {
+      await elements.rows()[0].trigger('click');
+      await nextTick();
+
+      expect(elements.drawer().props('open')).toBe(true);
+      expect(elements.drawer().props('improvement')).toEqual(
+        mockImprovements[0],
+      );
+    });
+
+    it('marks the clicked row as selected', async () => {
+      await elements.rows()[0].trigger('click');
+      await nextTick();
+
+      expect(elements.rows()[0].props('isSelected')).toBe(true);
+      expect(elements.rows()[1].props('isSelected')).toBe(false);
+      expect(elements.list().classes()).toContain(
+        'improvements-list--selected',
+      );
+    });
+
+    it('clears the selection when the drawer is closed', async () => {
+      await elements.rows()[0].trigger('click');
+      await nextTick();
+
+      await elements.drawer().setValue(false, 'open');
+      await nextTick();
+
+      expect(elements.drawer().props('open')).toBe(false);
+      expect(elements.drawer().props('improvement')).toBeNull();
+      expect(elements.rows()[0].props('isSelected')).toBe(false);
+      expect(elements.list().classes()).not.toContain(
+        'improvements-list--selected',
+      );
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -482,6 +482,11 @@
         "title": "Analysis complete",
         "title_with_count": "{count, plural, one {Analysis complete ({count} improvement found)} other {Analysis complete ({count} improvements found)}}"
       },
+      "columns": {
+        "affected_conversations": "Affected conversations",
+        "improvement": "Improvement",
+        "type": "Type"
+      },
       "header": {
         "custom_analysis": "Custom analysis",
         "description": "Ran on {date} at {time}",
@@ -509,6 +514,12 @@
       "running_analysis": {
         "description": "This may take a few hours. You can close this screen.",
         "title": "Analyzing {count} conversations from yesterday"
+      },
+      "types": {
+        "behavior": "Behavior",
+        "custom_analysis": "Custom analysis",
+        "knowledge": "Knowledge",
+        "technical_issue": "Technical issue"
       },
       "title": "Improvement backlog"
     }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -481,6 +481,11 @@
         "title": "Análisis completo",
         "title_with_count": "{count, plural, one {Análisis completo ({count} mejora encontrada)} other {Análisis completo ({count} mejoras encontradas)}}"
       },
+      "columns": {
+        "affected_conversations": "Conversaciones afectadas",
+        "improvement": "Mejora",
+        "type": "Tipo"
+      },
       "header": {
         "custom_analysis": "Análisis personalizado",
         "description": "Ejecutado el {date} a las {time}",
@@ -508,6 +513,12 @@
       "running_analysis": {
         "description": "Esto puede tardar unas horas. Puedes cerrar esta pantalla.",
         "title": "Analizando {count} conversaciones de ayer"
+      },
+      "types": {
+        "behavior": "Comportamiento",
+        "custom_analysis": "Análisis personalizado",
+        "knowledge": "Conocimiento",
+        "technical_issue": "Problema técnico"
       },
       "title": "Backlog de mejoras"
     }

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -481,6 +481,11 @@
         "title": "Análise concluída",
         "title_with_count": "{count, plural, one {Análise concluída ({count} melhoria encontrada)} other {Análise concluída ({count} melhorias encontradas)}}"
       },
+      "columns": {
+        "affected_conversations": "Conversas afetadas",
+        "improvement": "Melhoria",
+        "type": "Tipo"
+      },
       "header": {
         "custom_analysis": "Análise personalizada",
         "description": "Executado em {date} às {time}",
@@ -508,6 +513,12 @@
       "running_analysis": {
         "description": "Isso pode levar algumas horas. Você pode fechar esta tela.",
         "title": "Analisando {count} conversas de ontem"
+      },
+      "types": {
+        "behavior": "Comportamento",
+        "custom_analysis": "Análise personalizada",
+        "knowledge": "Conhecimento",
+        "technical_issue": "Problema técnico"
       },
       "title": "Backlog de melhorias"
     }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -480,6 +480,11 @@
         "title": "Analiză finalizată",
         "title_with_count": "{count, plural, one {Analiză finalizată ({count} îmbunătățire găsită)} other {Analiză finalizată ({count} îmbunătățiri găsite)}}"
       },
+      "columns": {
+        "affected_conversations": "Conversații afectate",
+        "improvement": "Îmbunătățire",
+        "type": "Tip"
+      },
       "header": {
         "custom_analysis": "Analiză personalizată",
         "description": "Rulat pe {date} la {time}",
@@ -507,6 +512,12 @@
       "running_analysis": {
         "description": "Acest proces poate dura câteva ore. Poți închide acest ecran.",
         "title": "Se analizează {count} conversații de ieri"
+      },
+      "types": {
+        "behavior": "Comportament",
+        "custom_analysis": "Analiză personalizată",
+        "knowledge": "Cunoștințe",
+        "technical_issue": "Problemă tehnică"
       },
       "title": "Backlog de îmbunătățiri"
     }

--- a/src/utils/improvements/__tests__/getImprovementTypeTag.spec.ts
+++ b/src/utils/improvements/__tests__/getImprovementTypeTag.spec.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+
+import { getImprovementTypeTag } from '@/utils/improvements/getImprovementTypeTag';
+
+import type { ImprovementType } from '@/store/types/Improvements.types';
+
+describe('getImprovementTypeTag', () => {
+  it.each([
+    {
+      type: 'many_questions_before_answering',
+      category: 'behavior',
+      scheme: 'blue',
+    },
+    {
+      type: 'wrong_behavior_due_to_instructions',
+      category: 'behavior',
+      scheme: 'blue',
+    },
+    {
+      type: 'personality_deviation',
+      category: 'behavior',
+      scheme: 'blue',
+    },
+    {
+      type: 'repetitive_response',
+      category: 'behavior',
+      scheme: 'blue',
+    },
+    {
+      type: 'missing_static_knowledge',
+      category: 'knowledge',
+      scheme: 'purple',
+    },
+    {
+      type: 'poor_product_search_results',
+      category: 'technical_issue',
+      scheme: 'orange',
+    },
+    {
+      type: 'custom_analysis',
+      category: 'custom_analysis',
+      scheme: 'yellow',
+    },
+  ] as const)(
+    'maps $type to $category with $scheme scheme',
+    ({ type, category, scheme }) => {
+      expect(getImprovementTypeTag(type)).toEqual({
+        category,
+        scheme,
+      });
+    },
+  );
+
+  it('uses the same scheme for all types in the same category', () => {
+    const behaviorTypes: ImprovementType[] = [
+      'many_questions_before_answering',
+      'wrong_behavior_due_to_instructions',
+      'personality_deviation',
+      'repetitive_response',
+    ];
+
+    const schemes = behaviorTypes.map(
+      (type) => getImprovementTypeTag(type).scheme,
+    );
+
+    expect(new Set(schemes).size).toBe(1);
+    expect(schemes[0]).toBe('blue');
+  });
+});

--- a/src/utils/improvements/getImprovementTypeTag.ts
+++ b/src/utils/improvements/getImprovementTypeTag.ts
@@ -1,0 +1,43 @@
+import type { ImprovementType } from '@/store/types/Improvements.types';
+
+export type ImprovementTagCategory =
+  | 'behavior'
+  | 'custom_analysis'
+  | 'knowledge'
+  | 'technical_issue';
+
+export interface ImprovementTypeTag {
+  category: ImprovementTagCategory;
+  scheme: string;
+}
+
+const IMPROVEMENT_TYPE_CATEGORY_MAP: Record<
+  ImprovementType,
+  ImprovementTagCategory
+> = {
+  many_questions_before_answering: 'behavior',
+  wrong_behavior_due_to_instructions: 'behavior',
+  missing_static_knowledge: 'knowledge',
+  personality_deviation: 'behavior',
+  poor_product_search_results: 'technical_issue',
+  repetitive_response: 'behavior',
+  custom_analysis: 'custom_analysis',
+};
+
+const IMPROVEMENT_TAG_SCHEME_MAP: Record<ImprovementTagCategory, string> = {
+  behavior: 'blue',
+  knowledge: 'purple',
+  technical_issue: 'orange',
+  custom_analysis: 'yellow',
+};
+
+export function getImprovementTypeTag(
+  type: ImprovementType,
+): ImprovementTypeTag {
+  const category = IMPROVEMENT_TYPE_CATEGORY_MAP[type];
+
+  return {
+    category,
+    scheme: IMPROVEMENT_TAG_SCHEME_MAP[category],
+  };
+}


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The improvements list needed to be implemented with interactive row selection and a detail drawer, allowing users to browse and inspect conversation improvements from the audit backlog.

### Summary of Changes

- Implemented `ImprovementsList.vue` with a full table layout displaying improvement entries from the store, with columns for improvement text, type, and affected conversations count.
- Added `ImprovementRow.vue` to render individual improvement entries, including a colored type tag and a selected state highlight.
- Added `ImprovementDrawer.vue` as a placeholder drawer that opens when a row is clicked, displaying the improvement title (detail content is deferred to a follow-up branch).
- Clicking a row selects it and opens the drawer; closing the drawer clears the selection.
- Added `getImprovementTypeTag` utility that maps each `ImprovementType` to a display category (`behavior`, `knowledge`, `technical_issue`, `custom_analysis`) and a corresponding color scheme (`blue`, `purple`, `orange`, `yellow`).
- Added localization keys for table column headers (`improvement`, `type`, `affected_conversations`) and improvement type labels (`behavior`, `knowledge`, `technical_issue`, `custom_analysis`) in English, Spanish, Portuguese, and Romanian.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/e4949001-2aa1-4a58-b262-1b387cf231af.png)

