### PR TITLE
feat: Add type tag, conversations count, and footer actions to ImprovementDrawer

### DIFF
--- a/src/components/ConversationsImprovements/ImprovementDrawer.vue
+++ b/src/components/ConversationsImprovements/ImprovementDrawer.vue
@@ -8,6 +8,26 @@
         <UnnnicDrawerTitle data-testid="improvement-drawer-title">
           {{ improvement?.text }}
         </UnnnicDrawerTitle>
+
+        <section class="improvement-drawer__header-info">
+          <UnnnicTag
+            class="improvement-drawer__type"
+            data-testid="improvement-drawer-type"
+            :scheme="typeTag.scheme"
+            :text="typeTag.text"
+          />
+
+          <p
+            class="improvement-drawer__conversations-count"
+            data-testid="improvement-drawer-conversations-count"
+          >
+            {{
+              t('audit.improvements.drawer.affected_conversations_count', {
+                count: improvement?.conversationsCount ?? 0,
+              })
+            }}
+          </p>
+        </section>
       </UnnnicDrawerHeader>
 
       <section
@@ -16,20 +36,66 @@
       >
         <!-- TODO: Implement improvement detail drawer in next branch -->
       </section>
+
+      <UnnnicDrawerFooter>
+        <UnnnicDrawerClose>
+          <UnnnicButton
+            data-testid="improvement-drawer-ignore-button"
+            :text="$t('audit.improvements.drawer.ignore_improvement')"
+            type="tertiary"
+          />
+        </UnnnicDrawerClose>
+        <UnnnicButton
+          data-testid="improvement-drawer-mark-resolved-button"
+          :text="$t('audit.improvements.drawer.mark_as_resolved')"
+          type="primary"
+        />
+      </UnnnicDrawerFooter>
     </UnnnicDrawerContent>
   </UnnnicDrawerNext>
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { getImprovementTypeTag } from '@/utils/improvements/getImprovementTypeTag';
+
 import type { Improvement } from '@/store/types/Improvements.types';
 
 const drawerOpen = defineModel<boolean>('open', {
   required: true,
 });
 
-defineProps<{
+const props = defineProps<{
   improvement: Improvement | null;
 }>();
+
+const { t } = useI18n();
+
+const typeTag = computed(() => {
+  const { category, scheme } = getImprovementTypeTag(props.improvement?.type);
+
+  return {
+    scheme,
+    text: t(`audit.improvements.types.${category}`),
+  };
+});
 </script>
 
-<style scoped lang="scss"></style>
+<style scoped lang="scss">
+.improvement-drawer {
+  &__header-info {
+    margin-top: $unnnic-space-1;
+
+    display: flex;
+    gap: $unnnic-space-3;
+    align-items: center;
+  }
+
+  &__conversations-count {
+    @include unnnic-font-caption-1;
+    color: $unnnic-color-fg-base;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/ImprovementsList.vue
+++ b/src/components/ConversationsImprovements/ImprovementsList.vue
@@ -67,7 +67,9 @@ function handleRowClick(improvement: Improvement) {
 
 watch(isDrawerOpen, (open) => {
   if (!open) {
-    selectedImprovement.value = null;
+    setTimeout(() => {
+      selectedImprovement.value = null;
+    }, 300);
   }
 });
 </script>

--- a/src/components/ConversationsImprovements/__tests__/ImprovementDrawer.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementDrawer.spec.js
@@ -1,0 +1,197 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import i18n from '@/utils/plugins/i18n';
+
+import ImprovementDrawer from '../ImprovementDrawer.vue';
+
+describe('ImprovementDrawer.vue', () => {
+  let wrapper;
+
+  const baseImprovement = {
+    uuid: 'improvement-uuid-1',
+    text: 'The agent tone does not match the configured brand voice in refund conversations.',
+    type: 'personality_deviation',
+    conversationsCount: 18,
+  };
+
+  const createWrapper = (props = {}) => {
+    wrapper = mount(ImprovementDrawer, {
+      props: {
+        open: true,
+        improvement: baseImprovement,
+        ...props,
+      },
+      global: {
+        stubs: {
+          UnnnicDrawerContent: {
+            template: '<div><slot /></div>',
+          },
+          UnnnicDrawerHeader: {
+            template: '<div><slot /></div>',
+          },
+          UnnnicDrawerTitle: {
+            template: '<div><slot /></div>',
+          },
+          UnnnicDrawerFooter: {
+            template:
+              '<div data-testid="improvement-drawer-footer"><slot /></div>',
+          },
+          UnnnicDrawerClose: {
+            template: '<div><slot /></div>',
+          },
+        },
+      },
+    });
+  };
+
+  const elements = {
+    drawer: () => wrapper.find('[data-testid="improvement-drawer"]'),
+    title: () => wrapper.find('[data-testid="improvement-drawer-title"]'),
+    typeTag: () =>
+      wrapper.findComponent('[data-testid="improvement-drawer-type"]'),
+    conversationsCount: () =>
+      wrapper.find('[data-testid="improvement-drawer-conversations-count"]'),
+    ignoreButton: () =>
+      wrapper.findComponent('[data-testid="improvement-drawer-ignore-button"]'),
+    markResolvedButton: () =>
+      wrapper.findComponent(
+        '[data-testid="improvement-drawer-mark-resolved-button"]',
+      ),
+    footer: () => wrapper.find('[data-testid="improvement-drawer-footer"]'),
+  };
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  describe('header', () => {
+    it('renders the drawer', () => {
+      createWrapper();
+
+      expect(elements.drawer().exists()).toBe(true);
+    });
+
+    it('renders the improvement text as the drawer title', () => {
+      createWrapper();
+
+      expect(elements.title().text()).toBe(baseImprovement.text);
+    });
+
+    it('renders the affected conversations count with pluralization', () => {
+      createWrapper();
+
+      expect(elements.conversationsCount().text()).toBe(
+        i18n.global.t(
+          'audit.improvements.drawer.affected_conversations_count',
+          {
+            count: baseImprovement.conversationsCount,
+          },
+        ),
+      );
+    });
+
+    it('renders zero affected conversations when improvement is null', () => {
+      createWrapper({ improvement: null });
+
+      expect(elements.title().text()).toBe('');
+      expect(elements.conversationsCount().text()).toBe(
+        i18n.global.t(
+          'audit.improvements.drawer.affected_conversations_count',
+          {
+            count: 0,
+          },
+        ),
+      );
+    });
+
+    describe('type tag mapping', () => {
+      it.each([
+        {
+          type: 'many_questions_before_answering',
+          scheme: 'blue',
+          category: 'behavior',
+        },
+        {
+          type: 'wrong_behavior_due_to_instructions',
+          scheme: 'blue',
+          category: 'behavior',
+        },
+        {
+          type: 'personality_deviation',
+          scheme: 'blue',
+          category: 'behavior',
+        },
+        {
+          type: 'repetitive_response',
+          scheme: 'blue',
+          category: 'behavior',
+        },
+        {
+          type: 'missing_static_knowledge',
+          scheme: 'purple',
+          category: 'knowledge',
+        },
+        {
+          type: 'poor_product_search_results',
+          scheme: 'orange',
+          category: 'technical_issue',
+        },
+        {
+          type: 'custom_analysis',
+          scheme: 'yellow',
+          category: 'custom_analysis',
+        },
+      ])(
+        'renders $category tag with $scheme scheme for $type',
+        ({ type, scheme, category }) => {
+          createWrapper({
+            improvement: {
+              ...baseImprovement,
+              type,
+            },
+          });
+
+          const typeTag = elements.typeTag();
+
+          expect(typeTag.props('scheme')).toBe(scheme);
+          expect(typeTag.props('text')).toBe(
+            i18n.global.t(`audit.improvements.types.${category}`),
+          );
+        },
+      );
+    });
+  });
+
+  describe('footer', () => {
+    it('renders the drawer footer', () => {
+      createWrapper();
+
+      expect(elements.footer().exists()).toBe(true);
+    });
+
+    it('renders the ignore improvement button with tertiary type', () => {
+      createWrapper();
+
+      const ignoreButton = elements.ignoreButton();
+
+      expect(ignoreButton.exists()).toBe(true);
+      expect(ignoreButton.props('type')).toBe('tertiary');
+      expect(ignoreButton.props('text')).toBe(
+        i18n.global.t('audit.improvements.drawer.ignore_improvement'),
+      );
+    });
+
+    it('renders the mark as resolved button with primary type', () => {
+      createWrapper();
+
+      const markResolvedButton = elements.markResolvedButton();
+
+      expect(markResolvedButton.exists()).toBe(true);
+      expect(markResolvedButton.props('type')).toBe('primary');
+      expect(markResolvedButton.props('text')).toBe(
+        i18n.global.t('audit.improvements.drawer.mark_as_resolved'),
+      );
+    });
+  });
+});

--- a/src/components/ConversationsImprovements/__tests__/ImprovementsList.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementsList.spec.js
@@ -145,10 +145,15 @@ describe('ImprovementsList.vue', () => {
     });
 
     it('clears the selection when the drawer is closed', async () => {
+      vi.useFakeTimers();
+
       await elements.rows()[0].trigger('click');
       await nextTick();
 
       await elements.drawer().setValue(false, 'open');
+      await nextTick();
+
+      vi.advanceTimersByTime(300);
       await nextTick();
 
       expect(elements.drawer().props('open')).toBe(false);
@@ -157,6 +162,8 @@ describe('ImprovementsList.vue', () => {
       expect(elements.list().classes()).not.toContain(
         'improvements-list--selected',
       );
+
+      vi.useRealTimers();
     });
   });
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -487,6 +487,11 @@
         "improvement": "Improvement",
         "type": "Type"
       },
+      "drawer": {
+        "affected_conversations_count": "{count, plural, one {# affected conversation} other {# affected conversations}}",
+        "ignore_improvement": "Ignore improvement",
+        "mark_as_resolved": "Mark as resolved"
+      },
       "header": {
         "custom_analysis": "Custom analysis",
         "description": "Ran on {date} at {time}",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -486,6 +486,11 @@
         "improvement": "Mejora",
         "type": "Tipo"
       },
+      "drawer": {
+        "affected_conversations_count": "{count, plural, one {# conversación afectada} other {# conversaciones afectadas}}",
+        "ignore_improvement": "Ignorar mejora",
+        "mark_as_resolved": "Marcar como resuelta"
+      },
       "header": {
         "custom_analysis": "Análisis personalizado",
         "description": "Ejecutado el {date} a las {time}",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -486,6 +486,11 @@
         "improvement": "Melhoria",
         "type": "Tipo"
       },
+      "drawer": {
+        "affected_conversations_count": "{count, plural, one {# conversa afetada} other {# conversas afetadas}}",
+        "ignore_improvement": "Ignorar melhoria",
+        "mark_as_resolved": "Marcar como resolvida"
+      },
       "header": {
         "custom_analysis": "Análise personalizada",
         "description": "Executado em {date} às {time}",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -485,6 +485,11 @@
         "improvement": "Îmbunătățire",
         "type": "Tip"
       },
+      "drawer": {
+        "affected_conversations_count": "{count, plural, one {# conversație afectată} few {# conversații afectate} other {# conversații afectate}}",
+        "ignore_improvement": "Ignoră îmbunătățirea",
+        "mark_as_resolved": "Marchează ca rezolvată"
+      },
       "header": {
         "custom_analysis": "Analiză personalizată",
         "description": "Rulat pe {date} la {time}",


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The improvement drawer previously had no header metadata or footer actions, leaving users without context about the improvement type or a way to act on it.

### Summary of Changes

- Added a type tag to the drawer header using `getImprovementTypeTag`, displaying the improvement category with its corresponding color scheme
- Added an affected conversations count to the drawer header with pluralization support
- Added a footer with an "Ignore improvement" (tertiary) button and a "Mark as resolved" (primary) button
- Added localized strings for the drawer's affected conversations count, ignore, and mark as resolved actions in English, Spanish, Portuguese (BR), and Romanian
- Added unit tests covering the header type tag mapping for all improvement types, the affected conversations count (including null/zero cases), and the footer button rendering and types

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/0013b264-567f-44e5-bdd8-8cbbd00958bd.png)

