### PR TITLE
feat: Add improvement status update dialog with ignore and resolve actions

### DIFF
--- a/src/api/nexus/Supervisor.js
+++ b/src/api/nexus/Supervisor.js
@@ -83,5 +83,12 @@ export const Supervisor = {
 
       return ImprovementsAdapter.fromApi(data);
     },
+
+    async updateStatus({ projectUuid, improvementUuid, status }) {
+      await conversationsRequest.$http.patch(
+        `/api/v1/projects/${projectUuid}/improvements/${improvementUuid}/`,
+        { status },
+      );
+    },
   },
 };

--- a/src/components/ConversationsImprovements/ImprovementDrawer.vue
+++ b/src/components/ConversationsImprovements/ImprovementDrawer.vue
@@ -38,30 +38,41 @@
       </section>
 
       <UnnnicDrawerFooter>
-        <UnnnicDrawerClose>
-          <UnnnicButton
-            data-testid="improvement-drawer-ignore-button"
-            :text="$t('audit.improvements.drawer.ignore_improvement')"
-            type="tertiary"
-          />
-        </UnnnicDrawerClose>
+        <UnnnicButton
+          data-testid="improvement-drawer-ignore-button"
+          :text="$t('audit.improvements.drawer.ignore_improvement')"
+          type="tertiary"
+          @click="openStatusDialog('ignored')"
+        />
         <UnnnicButton
           data-testid="improvement-drawer-mark-resolved-button"
           :text="$t('audit.improvements.drawer.mark_as_resolved')"
           type="primary"
+          @click="openStatusDialog('resolved')"
         />
       </UnnnicDrawerFooter>
     </UnnnicDrawerContent>
+
+    <ImprovementStatusDialog
+      v-model:open="isStatusDialogOpen"
+      :status="statusDialogStatus"
+      :improvementUuid="improvement?.uuid ?? null"
+      @success="handleStatusUpdateSuccess"
+    />
   </UnnnicDrawerNext>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import ImprovementStatusDialog from '@/components/ConversationsImprovements/ImprovementStatusDialog.vue';
 import { getImprovementTypeTag } from '@/utils/improvements/getImprovementTypeTag';
 
-import type { Improvement } from '@/store/types/Improvements.types';
+import type {
+  Improvement,
+  ImprovementStatus,
+} from '@/store/types/Improvements.types';
 
 const drawerOpen = defineModel<boolean>('open', {
   required: true,
@@ -72,6 +83,18 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
+
+const isStatusDialogOpen = ref(false);
+const statusDialogStatus = ref<ImprovementStatus>('ignored');
+
+function openStatusDialog(status: ImprovementStatus) {
+  statusDialogStatus.value = status;
+  isStatusDialogOpen.value = true;
+}
+
+function handleStatusUpdateSuccess() {
+  drawerOpen.value = false;
+}
 
 const typeTag = computed(() => {
   const { category, scheme } = getImprovementTypeTag(props.improvement?.type);

--- a/src/components/ConversationsImprovements/ImprovementStatusDialog.vue
+++ b/src/components/ConversationsImprovements/ImprovementStatusDialog.vue
@@ -1,0 +1,121 @@
+<template>
+  <UnnnicDialog
+    :data-testid="`improvement-status-dialog-${status}`"
+    :open="open"
+    lazyMount
+    @update:open="handleOpenChange"
+  >
+    <UnnnicDialogContent>
+      <UnnnicDialogHeader>
+        <UnnnicDialogTitle
+          :data-testid="`improvement-status-dialog-${status}-title`"
+        >
+          {{ $t(`audit.improvements.status_dialog.${status}.title`) }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+
+      <p
+        class="improvement-status-dialog__description"
+        :data-testid="`improvement-status-dialog-${status}-description`"
+      >
+        {{ $t(`audit.improvements.status_dialog.${status}.description`) }}
+      </p>
+
+      <UnnnicDialogFooter>
+        <UnnnicDialogClose>
+          <UnnnicButton
+            :data-testid="`improvement-status-dialog-${status}-cancel`"
+            :disabled="isSubmitting"
+            :text="$t('audit.improvements.status_dialog.cancel')"
+            type="tertiary"
+            @click="close"
+          />
+        </UnnnicDialogClose>
+        <UnnnicButton
+          :data-testid="`improvement-status-dialog-${status}-confirm`"
+          :loading="isSubmitting"
+          :text="confirmButtonText"
+          type="primary"
+          @click="confirm"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { useImprovementsStore } from '@/store/Improvements';
+
+import type { ImprovementStatus } from '@/store/types/Improvements.types';
+
+const open = defineModel<boolean>('open', {
+  required: true,
+});
+
+const props = defineProps<{
+  status: ImprovementStatus;
+  improvementUuid: string | null;
+}>();
+
+const emit = defineEmits<{
+  success: [];
+}>();
+
+const { t } = useI18n();
+const improvementsStore = useImprovementsStore();
+
+const isSubmitting = ref(false);
+
+const confirmButtonText = computed(() => {
+  const key =
+    props.status === 'ignored'
+      ? 'audit.improvements.drawer.ignore_improvement'
+      : 'audit.improvements.drawer.mark_as_resolved';
+
+  return t(key);
+});
+
+function close() {
+  open.value = false;
+}
+
+function handleOpenChange(value: boolean) {
+  if (!value) {
+    close();
+  }
+}
+
+async function confirm() {
+  if (!props.improvementUuid || isSubmitting.value) {
+    return;
+  }
+
+  isSubmitting.value = true;
+
+  const result = await improvementsStore.updateImprovementStatus(
+    props.improvementUuid,
+    props.status,
+  );
+
+  isSubmitting.value = false;
+
+  if (result.status === 'complete') {
+    close();
+    emit('success');
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.improvement-status-dialog {
+  &__description {
+    margin: $unnnic-space-6;
+
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/__tests__/ImprovementDrawer.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementDrawer.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
 
 import i18n from '@/utils/plugins/i18n';
 
@@ -24,6 +25,12 @@ describe('ImprovementDrawer.vue', () => {
       },
       global: {
         stubs: {
+          ImprovementStatusDialog: {
+            template:
+              '<div data-testid="improvement-status-dialog-stub" :data-status="status" :data-open="String(open)"><button data-testid="emit-success" @click="$emit(\'success\')" /></div>',
+            props: ['status', 'improvementUuid', 'open'],
+            emits: ['success'],
+          },
           UnnnicDrawerContent: {
             template: '<div><slot /></div>',
           },
@@ -36,9 +43,6 @@ describe('ImprovementDrawer.vue', () => {
           UnnnicDrawerFooter: {
             template:
               '<div data-testid="improvement-drawer-footer"><slot /></div>',
-          },
-          UnnnicDrawerClose: {
-            template: '<div><slot /></div>',
           },
         },
       },
@@ -59,6 +63,8 @@ describe('ImprovementDrawer.vue', () => {
         '[data-testid="improvement-drawer-mark-resolved-button"]',
       ),
     footer: () => wrapper.find('[data-testid="improvement-drawer-footer"]'),
+    statusDialog: () =>
+      wrapper.find('[data-testid="improvement-status-dialog-stub"]'),
   };
 
   afterEach(() => {
@@ -192,6 +198,37 @@ describe('ImprovementDrawer.vue', () => {
       expect(markResolvedButton.props('text')).toBe(
         i18n.global.t('audit.improvements.drawer.mark_as_resolved'),
       );
+    });
+
+    it('opens the ignore status dialog when the ignore button is clicked', async () => {
+      createWrapper();
+
+      await elements.ignoreButton().trigger('click');
+
+      const statusDialog = elements.statusDialog();
+
+      expect(statusDialog.attributes('data-open')).toBe('true');
+      expect(statusDialog.attributes('data-status')).toBe('ignored');
+    });
+
+    it('opens the resolved status dialog when the mark as resolved button is clicked', async () => {
+      createWrapper();
+
+      await elements.markResolvedButton().trigger('click');
+
+      const statusDialog = elements.statusDialog();
+
+      expect(statusDialog.attributes('data-open')).toBe('true');
+      expect(statusDialog.attributes('data-status')).toBe('resolved');
+    });
+
+    it('closes the drawer when the status dialog emits success', async () => {
+      createWrapper();
+
+      await wrapper.find('[data-testid="emit-success"]').trigger('click');
+      await nextTick();
+
+      expect(wrapper.emitted('update:open')).toEqual([[false]]);
     });
   });
 });

--- a/src/components/ConversationsImprovements/__tests__/ImprovementStatusDialog.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementStatusDialog.spec.js
@@ -1,0 +1,153 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import { useImprovementsStore } from '@/store/Improvements';
+
+import ImprovementStatusDialog from '../ImprovementStatusDialog.vue';
+
+describe('ImprovementStatusDialog.vue', () => {
+  let wrapper;
+  let improvementsStore;
+
+  const createWrapper = (props = {}) => {
+    wrapper = mount(ImprovementStatusDialog, {
+      props: {
+        open: true,
+        status: 'ignored',
+        improvementUuid: 'improvement-uuid-1',
+        ...props,
+      },
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+          }),
+        ],
+        stubs: {
+          UnnnicDialogClose: {
+            template: '<div><slot /></div>',
+          },
+        },
+      },
+    });
+
+    improvementsStore = useImprovementsStore();
+  };
+
+  const elements = {
+    title: (status) =>
+      wrapper.find(`[data-testid="improvement-status-dialog-${status}-title"]`),
+    description: (status) =>
+      wrapper.find(
+        `[data-testid="improvement-status-dialog-${status}-description"]`,
+      ),
+    cancelButton: (status) =>
+      wrapper.findComponent(
+        `[data-testid="improvement-status-dialog-${status}-cancel"]`,
+      ),
+    confirmButton: (status) =>
+      wrapper.findComponent(
+        `[data-testid="improvement-status-dialog-${status}-confirm"]`,
+      ),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  describe('ignored dialog', () => {
+    it('renders title and description', () => {
+      createWrapper({ status: 'ignored' });
+
+      expect(elements.title('ignored').text()).toBe(
+        i18n.global.t('audit.improvements.status_dialog.ignored.title'),
+      );
+      expect(elements.description('ignored').text()).toBe(
+        i18n.global.t('audit.improvements.status_dialog.ignored.description'),
+      );
+    });
+
+    it('renders cancel and confirm buttons', () => {
+      createWrapper({ status: 'ignored' });
+
+      const cancelButton = elements.cancelButton('ignored');
+      const confirmButton = elements.confirmButton('ignored');
+
+      expect(cancelButton.props('type')).toBe('tertiary');
+      expect(cancelButton.props('text')).toBe(
+        i18n.global.t('audit.improvements.status_dialog.cancel'),
+      );
+      expect(confirmButton.props('type')).toBe('primary');
+      expect(confirmButton.props('text')).toBe(
+        i18n.global.t('audit.improvements.drawer.ignore_improvement'),
+      );
+    });
+  });
+
+  describe('resolved dialog', () => {
+    it('renders title and description', () => {
+      createWrapper({ status: 'resolved' });
+
+      expect(elements.title('resolved').text()).toBe(
+        i18n.global.t('audit.improvements.status_dialog.resolved.title'),
+      );
+      expect(elements.description('resolved').text()).toBe(
+        i18n.global.t('audit.improvements.status_dialog.resolved.description'),
+      );
+    });
+
+    it('renders confirm button with mark as resolved label', () => {
+      createWrapper({ status: 'resolved' });
+
+      expect(elements.confirmButton('resolved').props('text')).toBe(
+        i18n.global.t('audit.improvements.drawer.mark_as_resolved'),
+      );
+    });
+  });
+
+  describe('actions', () => {
+    it('calls updateImprovementStatus and emits success on confirm', async () => {
+      createWrapper({ status: 'ignored' });
+      improvementsStore.updateImprovementStatus = vi
+        .fn()
+        .mockResolvedValue({ status: 'complete' });
+
+      await elements.confirmButton('ignored').trigger('click');
+      await flushPromises();
+
+      expect(improvementsStore.updateImprovementStatus).toHaveBeenCalledWith(
+        'improvement-uuid-1',
+        'ignored',
+      );
+      expect(wrapper.emitted('success')).toHaveLength(1);
+      expect(wrapper.emitted('update:open')).toEqual([[false]]);
+    });
+
+    it('does not emit success when updateImprovementStatus fails', async () => {
+      createWrapper({ status: 'resolved' });
+      improvementsStore.updateImprovementStatus = vi
+        .fn()
+        .mockResolvedValue({ status: 'error' });
+
+      await elements.confirmButton('resolved').trigger('click');
+      await flushPromises();
+
+      expect(wrapper.emitted('success')).toBeUndefined();
+      expect(wrapper.emitted('update:open')).toBeUndefined();
+    });
+
+    it('closes the dialog when cancel is clicked', async () => {
+      createWrapper();
+
+      await elements.cancelButton('ignored').trigger('click');
+
+      expect(wrapper.emitted('update:open')).toEqual([[false]]);
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -520,6 +520,38 @@
         "description": "This may take a few hours. You can close this screen.",
         "title": "Analyzing {count} conversations from yesterday"
       },
+      "status_dialog": {
+        "cancel": "Cancel",
+        "ignored": {
+          "description": "This issue will be removed from the backlog and will no longer appear in your improvement suggestions.",
+          "title": "Ignore improvement"
+        },
+        "resolved": {
+          "description": "Confirm only after applying the suggested solution. The issue will be removed from the backlog and make room for new improvements.",
+          "title": "Mark as resolved"
+        }
+      },
+      "status_update": {
+        "error": {
+          "ignored": {
+            "description": "Due to a technical issue",
+            "title": "Improvement couldn't be ignored"
+          },
+          "resolved": {
+            "description": "Due to a technical issue",
+            "title": "Improvement couldn't be marked as resolved"
+          }
+        },
+        "success": {
+          "description": "The item was removed from the improvements backlog",
+          "ignored": {
+            "title": "Improvement ignored"
+          },
+          "resolved": {
+            "title": "Improvement marked as resolved"
+          }
+        }
+      },
       "types": {
         "behavior": "Behavior",
         "custom_analysis": "Custom analysis",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -519,6 +519,38 @@
         "description": "Esto puede tardar unas horas. Puedes cerrar esta pantalla.",
         "title": "Analizando {count} conversaciones de ayer"
       },
+      "status_dialog": {
+        "cancel": "Cancelar",
+        "ignored": {
+          "description": "Este problema se eliminará del backlog y ya no aparecerá en las sugerencias de mejora.",
+          "title": "Ignorar mejora"
+        },
+        "resolved": {
+          "description": "Confirma solo después de aplicar la solución sugerida. El problema se eliminará del backlog y abrirá espacio para nuevas mejoras.",
+          "title": "Marcar como resuelta"
+        }
+      },
+      "status_update": {
+        "error": {
+          "ignored": {
+            "description": "Debido a un problema técnico",
+            "title": "No se pudo ignorar la mejora"
+          },
+          "resolved": {
+            "description": "Debido a un problema técnico",
+            "title": "No se pudo marcar como resuelta"
+          }
+        },
+        "success": {
+          "description": "El ítem se eliminó del backlog de mejoras",
+          "ignored": {
+            "title": "Mejora ignorada"
+          },
+          "resolved": {
+            "title": "Mejora marcada como resuelta"
+          }
+        }
+      },
       "types": {
         "behavior": "Comportamiento",
         "custom_analysis": "Análisis personalizado",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -519,6 +519,38 @@
         "description": "Isso pode levar algumas horas. Você pode fechar esta tela.",
         "title": "Analisando {count} conversas de ontem"
       },
+      "status_dialog": {
+        "cancel": "Cancelar",
+        "ignored": {
+          "description": "Este problema será removido do backlog e não aparecerá mais nas sugestões de melhoria.",
+          "title": "Ignorar melhoria"
+        },
+        "resolved": {
+          "description": "Confirme apenas após aplicar a solução sugerida. O problema será removido do backlog e abrirá espaço para novas melhorias.",
+          "title": "Marcar como resolvida"
+        }
+      },
+      "status_update": {
+        "error": {
+          "ignored": {
+            "description": "Devido a um problema técnico",
+            "title": "Não foi possível ignorar a melhoria"
+          },
+          "resolved": {
+            "description": "Devido a um problema técnico",
+            "title": "Não foi possível marcar como resolvida"
+          }
+        },
+        "success": {
+          "description": "O item foi removido do backlog de melhorias",
+          "ignored": {
+            "title": "Melhoria ignorada"
+          },
+          "resolved": {
+            "title": "Melhoria marcada como resolvida"
+          }
+        }
+      },
       "types": {
         "behavior": "Comportamento",
         "custom_analysis": "Análise personalizada",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -518,6 +518,38 @@
         "description": "Acest proces poate dura câteva ore. Poți închide acest ecran.",
         "title": "Se analizează {count} conversații de ieri"
       },
+      "status_dialog": {
+        "cancel": "Anulează",
+        "ignored": {
+          "description": "Această problemă va fi eliminată din backlog și nu va mai apărea în sugestiile de îmbunătățire.",
+          "title": "Ignoră îmbunătățirea"
+        },
+        "resolved": {
+          "description": "Confirmă doar după aplicarea soluției sugerate. Problema va fi eliminată din backlog și va face loc pentru noi îmbunătățiri.",
+          "title": "Marchează ca rezolvată"
+        }
+      },
+      "status_update": {
+        "error": {
+          "ignored": {
+            "description": "Din cauza unei probleme tehnice",
+            "title": "Nu s-a putut ignora îmbunătățirea"
+          },
+          "resolved": {
+            "description": "Din cauza unei probleme tehnice",
+            "title": "Nu s-a putut marca ca rezolvată"
+          }
+        },
+        "success": {
+          "description": "Elementul a fost eliminat din backlog-ul de îmbunătățiri",
+          "ignored": {
+            "title": "Îmbunătățire ignorată"
+          },
+          "resolved": {
+            "title": "Îmbunătățire marcată ca rezolvată"
+          }
+        }
+      },
       "types": {
         "behavior": "Comportament",
         "custom_analysis": "Analiză personalizată",

--- a/src/store/Improvements.ts
+++ b/src/store/Improvements.ts
@@ -10,6 +10,7 @@ import { useAlertStore } from './Alert';
 
 import type {
   Improvement,
+  ImprovementStatus,
   ImprovementsAnalysis,
   ImprovementsStatus,
   ImprovementsTask,
@@ -75,6 +76,24 @@ function notifyAnalysisComplete(
     type: 'success',
     text: alertText,
     description: alertDescription,
+  });
+}
+
+function notifyStatusUpdate(
+  alertStore: ReturnType<typeof useAlertStore>,
+  status: ImprovementStatus,
+  outcome: 'success' | 'error',
+) {
+  const prefix = `audit.improvements.status_update.${outcome}`;
+
+  alertStore.add({
+    type: outcome,
+    text: i18n.global.t(`${prefix}.${status}.title`),
+    description: i18n.global.t(
+      outcome === 'success'
+        ? `${prefix}.description`
+        : `${prefix}.${status}.description`,
+    ),
   });
 }
 
@@ -210,6 +229,31 @@ export const useImprovementsStore = defineStore('Improvements', () => {
     }
   }
 
+  async function updateImprovementStatus(
+    improvementUuid: string,
+    status: ImprovementStatus,
+  ) {
+    try {
+      await supervisorApi.improvements.updateStatus({
+        projectUuid: projectUuid.value,
+        improvementUuid,
+        status,
+      });
+
+      improvements.data = improvements.data.filter(
+        (item) => item.uuid !== improvementUuid,
+      );
+
+      notifyStatusUpdate(alertStore, status, 'success');
+
+      return { status: 'complete' as const };
+    } catch (error) {
+      console.error(error);
+      notifyStatusUpdate(alertStore, status, 'error');
+      return { status: 'error' as const };
+    }
+  }
+
   return {
     analysis,
     improvements,
@@ -217,5 +261,6 @@ export const useImprovementsStore = defineStore('Improvements', () => {
     isRunAnalysisDisabled,
     fetchImprovements,
     runAnalysis,
+    updateImprovementStatus,
   };
 });

--- a/src/store/__tests__/Improvements.unit.spec.js
+++ b/src/store/__tests__/Improvements.unit.spec.js
@@ -14,6 +14,7 @@ vi.mock('@/api/nexusaiAPI', () => ({
         improvements: {
           runAnalysis: vi.fn(),
           getAnalysis: vi.fn(),
+          updateStatus: vi.fn(),
         },
       },
     },
@@ -514,6 +515,89 @@ describe('Improvements Store', () => {
       await store.runAnalysis();
 
       expect(alertStore.add).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('updateImprovementStatus', () => {
+    it('calls updateStatus with ignored status and removes the improvement from the list', async () => {
+      const improvement = buildImprovement();
+      store.improvements.data = [improvement];
+      improvementsApi.updateStatus.mockResolvedValue();
+
+      const result = await store.updateImprovementStatus(
+        improvement.uuid,
+        'ignored',
+      );
+
+      expect(improvementsApi.updateStatus).toHaveBeenCalledWith({
+        projectUuid: 'test-project-uuid',
+        improvementUuid: improvement.uuid,
+        status: 'ignored',
+      });
+      expect(store.improvements.data).toEqual([]);
+      expect(result).toEqual({ status: 'complete' });
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'success',
+        text: i18n.global.t(
+          'audit.improvements.status_update.success.ignored.title',
+        ),
+        description: i18n.global.t(
+          'audit.improvements.status_update.success.description',
+        ),
+      });
+    });
+
+    it('calls updateStatus with resolved status and removes the improvement from the list', async () => {
+      const improvement = buildImprovement({ uuid: 'improvement-uuid-2' });
+      store.improvements.data = [improvement];
+      improvementsApi.updateStatus.mockResolvedValue();
+
+      const result = await store.updateImprovementStatus(
+        improvement.uuid,
+        'resolved',
+      );
+
+      expect(improvementsApi.updateStatus).toHaveBeenCalledWith({
+        projectUuid: 'test-project-uuid',
+        improvementUuid: improvement.uuid,
+        status: 'resolved',
+      });
+      expect(store.improvements.data).toEqual([]);
+      expect(result).toEqual({ status: 'complete' });
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'success',
+        text: i18n.global.t(
+          'audit.improvements.status_update.success.resolved.title',
+        ),
+        description: i18n.global.t(
+          'audit.improvements.status_update.success.description',
+        ),
+      });
+    });
+
+    it('returns error status and keeps the improvement when the request fails', async () => {
+      const improvement = buildImprovement();
+      const error = new Error('update failed');
+      store.improvements.data = [improvement];
+      improvementsApi.updateStatus.mockRejectedValue(error);
+
+      const result = await store.updateImprovementStatus(
+        improvement.uuid,
+        'ignored',
+      );
+
+      expect(store.improvements.data).toEqual([improvement]);
+      expect(result).toEqual({ status: 'error' });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'error',
+        text: i18n.global.t(
+          'audit.improvements.status_update.error.ignored.title',
+        ),
+        description: i18n.global.t(
+          'audit.improvements.status_update.error.ignored.description',
+        ),
+      });
     });
   });
 });

--- a/src/store/types/Improvements.types.ts
+++ b/src/store/types/Improvements.types.ts
@@ -14,6 +14,8 @@ export type RunAnalysisBlockReason =
   | 'already_run_today'
   | null;
 
+export type ImprovementStatus = 'ignored' | 'resolved';
+
 export interface ImprovementsTask {
   isRunning: boolean;
   progress: number;


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

Users needed a way to mark improvements as either ignored or resolved directly from the improvement drawer, removing them from the backlog and providing feedback on the action taken.

### Summary of Changes

- Added a new `ImprovementStatusDialog` component that presents a confirmation dialog before marking an improvement as ignored or resolved, with appropriate titles, descriptions, and action buttons per status.
- Updated `ImprovementDrawer` to wire the "Ignore" and "Mark as Resolved" buttons to open the status dialog with the corresponding status, and to close the drawer automatically on a successful status update.
- Added `updateImprovementStatus` to the Improvements store, which calls the API, removes the improvement from the local list on success, and triggers an alert notification for both success and error outcomes.
- Added `updateStatus` to the Supervisor mock API, which simulates the PATCH request and removes the improvement from the mock state.
- Added the `ImprovementStatus` type (`'ignored' | 'resolved'`) to the shared types.
- Added localization strings for the status dialog and status update notifications (success and error) in English, Spanish, Portuguese, and Romanian.
- Added unit tests for `ImprovementStatusDialog` covering rendering per status, confirm/cancel actions, and success/error outcomes, and extended `ImprovementDrawer` tests to cover dialog open behavior and drawer close on success.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/2a272091-d677-44a7-b717-b806381fd8e7.png)

![image.png](https://app.graphite.com/user-attachments/assets/d99432f5-0075-46a4-a3f7-0cf4dc04be70.png)



![image.png](https://app.graphite.com/user-attachments/assets/ba5634de-871e-4f98-9956-aef1ce7d8441.png)

![image.png](https://app.graphite.com/user-attachments/assets/dba43c60-ad03-41e6-8e65-ea3f42a4d50d.png)

