### PR TITLE
feat: Enhance improvements management with detailed API integration

### DIFF
--- a/src/api/adapters/supervisor/__tests__/improvements.spec.ts
+++ b/src/api/adapters/supervisor/__tests__/improvements.spec.ts
@@ -102,4 +102,93 @@ describe('Supervisor improvements adapter', () => {
       expect(result.improvements[0].conversationsCount).toBe(0);
     });
   });
+
+  describe('fromDetailApi', () => {
+    it('transforms API detail data to frontend format', () => {
+      const result = ImprovementsAdapter.fromDetailApi({
+        uuid: 'improvement-uuid-1',
+        text: 'Sample improvement text',
+        type: 'personality_deviation',
+        description: 'Sample diagnosis',
+        suggested_change: 'Update the tone instruction',
+        status: 'pending',
+        affected_instructions: [
+          {
+            instruction_id: 42,
+            change_type: 'fix',
+            was_changed: true,
+          },
+        ],
+      });
+
+      expect(result).toEqual({
+        uuid: 'improvement-uuid-1',
+        text: 'Sample improvement text',
+        type: 'personality_deviation',
+        description: 'Sample diagnosis',
+        suggestedChange: 'Update the tone instruction',
+        status: 'pending',
+        affectedInstructions: [
+          {
+            instructionId: 42,
+            changeType: 'fix',
+            wasChanged: true,
+          },
+        ],
+      });
+    });
+
+    it('returns null when required fields are missing', () => {
+      expect(
+        ImprovementsAdapter.fromDetailApi({
+          uuid: 'improvement-uuid-1',
+          type: 'personality_deviation',
+        }),
+      ).toBeNull();
+    });
+
+    it('defaults status to pending and filters invalid affected instructions', () => {
+      const result = ImprovementsAdapter.fromDetailApi({
+        uuid: 'improvement-uuid-1',
+        text: 'Sample improvement text',
+        type: 'personality_deviation',
+        description: 'Sample diagnosis',
+        suggested_change: null,
+        status: 'unknown',
+        affected_instructions: [
+          {
+            instruction_id: 42,
+            change_type: 'fix',
+            was_changed: false,
+          },
+          {
+            instruction_id: 0,
+            change_type: 'fix',
+            was_changed: false,
+          },
+          {
+            instruction_id: 43,
+            change_type: 'invalid',
+            was_changed: false,
+          },
+        ],
+      });
+
+      expect(result).toEqual({
+        uuid: 'improvement-uuid-1',
+        text: 'Sample improvement text',
+        type: 'personality_deviation',
+        description: 'Sample diagnosis',
+        suggestedChange: null,
+        status: 'pending',
+        affectedInstructions: [
+          {
+            instructionId: 42,
+            changeType: 'fix',
+            wasChanged: false,
+          },
+        ],
+      });
+    });
+  });
 });

--- a/src/api/adapters/supervisor/improvements.ts
+++ b/src/api/adapters/supervisor/improvements.ts
@@ -1,8 +1,12 @@
 import type {
+  AffectedInstruction,
   Improvement,
+  ImprovementDetail,
+  ImprovementDetailStatus,
   ImprovementType,
   ImprovementsAnalysis,
   ImprovementsTask,
+  InstructionChangeType,
 } from '@/store/types/Improvements.types';
 
 export interface ImprovementsTaskApi {
@@ -23,6 +27,22 @@ export interface ImprovementsAnalysisApi {
   yesterday_conversations_count?: number;
   improvements_task?: ImprovementsTaskApi;
   improvements?: ImprovementApi[];
+}
+
+export interface AffectedInstructionApi {
+  instruction_id?: number;
+  change_type?: string;
+  was_changed?: boolean;
+}
+
+export interface ImprovementDetailApi {
+  uuid?: string;
+  text?: string;
+  type?: string;
+  description?: string;
+  suggested_change?: string | null;
+  status?: string;
+  affected_instructions?: AffectedInstructionApi[];
 }
 
 const IMPROVEMENT_TYPES: ImprovementType[] = [
@@ -65,6 +85,68 @@ function parseImprovement(item: ImprovementApi = {}): Improvement | null {
   };
 }
 
+const IMPROVEMENT_DETAIL_STATUSES: ImprovementDetailStatus[] = [
+  'pending',
+  'resolved',
+  'ignored',
+];
+
+const INSTRUCTION_CHANGE_TYPES: InstructionChangeType[] = [
+  'fix',
+  'add',
+  'remove',
+];
+
+function isImprovementDetailStatus(
+  value: unknown,
+): value is ImprovementDetailStatus {
+  return IMPROVEMENT_DETAIL_STATUSES.includes(value as ImprovementDetailStatus);
+}
+
+function isInstructionChangeType(
+  value: unknown,
+): value is InstructionChangeType {
+  return INSTRUCTION_CHANGE_TYPES.includes(value as InstructionChangeType);
+}
+
+function parseAffectedInstruction(
+  item: AffectedInstructionApi = {},
+): AffectedInstruction | null {
+  const instructionId = Number(item.instruction_id);
+
+  if (!instructionId || !isInstructionChangeType(item.change_type)) {
+    return null;
+  }
+
+  return {
+    instructionId,
+    changeType: item.change_type,
+    wasChanged: Boolean(item.was_changed),
+  };
+}
+
+function parseImprovementDetail(
+  apiData: ImprovementDetailApi = {},
+): ImprovementDetail | null {
+  if (!apiData.uuid || !apiData.text || !isImprovementType(apiData.type)) {
+    return null;
+  }
+
+  return {
+    uuid: apiData.uuid,
+    text: apiData.text,
+    type: apiData.type,
+    description: apiData.description ?? '',
+    suggestedChange: apiData.suggested_change ?? null,
+    status: isImprovementDetailStatus(apiData.status)
+      ? apiData.status
+      : 'pending',
+    affectedInstructions: (apiData.affected_instructions ?? [])
+      .map(parseAffectedInstruction)
+      .filter((item): item is AffectedInstruction => item !== null),
+  };
+}
+
 export const ImprovementsAdapter = {
   fromApi(apiData: ImprovementsAnalysisApi = {}): ImprovementsAnalysis {
     const improvements = (apiData.improvements ?? [])
@@ -77,5 +159,9 @@ export const ImprovementsAdapter = {
       task: parseTask(apiData.improvements_task),
       improvements,
     };
+  },
+
+  fromDetailApi(apiData: ImprovementDetailApi = {}): ImprovementDetail | null {
+    return parseImprovementDetail(apiData);
   },
 };

--- a/src/api/nexus/Supervisor.js
+++ b/src/api/nexus/Supervisor.js
@@ -90,5 +90,19 @@ export const Supervisor = {
         { status },
       );
     },
+
+    async getById({ projectUuid, improvementUuid }) {
+      const { data } = await conversationsRequest.$http.get(
+        `/api/v1/projects/${projectUuid}/improvements/${improvementUuid}/`,
+      );
+
+      const detail = ImprovementsAdapter.fromDetailApi(data);
+
+      if (!detail) {
+        throw new Error('Invalid improvement detail response');
+      }
+
+      return detail;
+    },
   },
 };

--- a/src/api/nexus/__tests__/Supervisor.spec.js
+++ b/src/api/nexus/__tests__/Supervisor.spec.js
@@ -17,6 +17,7 @@ vi.mock('@/api/conversationsRequest', () => ({
     $http: {
       get: vi.fn(),
       post: vi.fn(),
+      patch: vi.fn(),
     },
   },
 }));
@@ -289,6 +290,82 @@ describe('Supervisor.js', () => {
 
       await expect(
         Supervisor.improvements.getAnalysis({ projectUuid }),
+      ).rejects.toThrow('API Error');
+    });
+
+    it('getById calls the detail endpoint and adapts the response', async () => {
+      const mockDetailApiResponse = {
+        uuid: 'improvement-uuid-1',
+        text: 'The agent tone does not match the configured brand voice in refund conversations.',
+        type: 'personality_deviation',
+        description:
+          'In refund conversations, the agent uses informal language that conflicts with the configured brand voice.',
+        suggested_change:
+          'Update the tone instruction to reinforce formal and empathetic language during refund interactions.',
+        status: 'pending',
+        affected_instructions: [
+          {
+            instruction_id: 12,
+            change_type: 'fix',
+            was_changed: false,
+          },
+        ],
+      };
+
+      conversationsRequest.$http.get.mockResolvedValue({
+        data: mockDetailApiResponse,
+      });
+
+      const result = await Supervisor.improvements.getById({
+        projectUuid,
+        improvementUuid: 'improvement-uuid-1',
+      });
+
+      expect(conversationsRequest.$http.get).toHaveBeenCalledWith(
+        `/api/v1/projects/${projectUuid}/improvements/improvement-uuid-1/`,
+      );
+      expect(nexusRequest.$http.get).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        uuid: 'improvement-uuid-1',
+        text: 'The agent tone does not match the configured brand voice in refund conversations.',
+        type: 'personality_deviation',
+        description:
+          'In refund conversations, the agent uses informal language that conflicts with the configured brand voice.',
+        suggestedChange:
+          'Update the tone instruction to reinforce formal and empathetic language during refund interactions.',
+        status: 'pending',
+        affectedInstructions: [
+          {
+            instructionId: 12,
+            changeType: 'fix',
+            wasChanged: false,
+          },
+        ],
+      });
+    });
+
+    it('getById throws when the response is invalid', async () => {
+      conversationsRequest.$http.get.mockResolvedValue({
+        data: { uuid: 'unknown-uuid' },
+      });
+
+      await expect(
+        Supervisor.improvements.getById({
+          projectUuid,
+          improvementUuid: 'unknown-uuid',
+        }),
+      ).rejects.toThrow('Invalid improvement detail response');
+    });
+
+    it('propagates errors from getById', async () => {
+      const error = new Error('API Error');
+      conversationsRequest.$http.get.mockRejectedValue(error);
+
+      await expect(
+        Supervisor.improvements.getById({
+          projectUuid,
+          improvementUuid: 'improvement-uuid-1',
+        }),
       ).rejects.toThrow('API Error');
     });
   });

--- a/src/components/ConversationsImprovements/ImprovementDrawer.vue
+++ b/src/components/ConversationsImprovements/ImprovementDrawer.vue
@@ -63,10 +63,11 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
 import ImprovementStatusDialog from '@/components/ConversationsImprovements/ImprovementStatusDialog.vue';
+import { useImprovementsStore } from '@/store/Improvements';
 import { getImprovementTypeTag } from '@/utils/improvements/getImprovementTypeTag';
 
 import type {
@@ -83,6 +84,7 @@ const props = defineProps<{
 }>();
 
 const { t } = useI18n();
+const improvementsStore = useImprovementsStore();
 
 const isStatusDialogOpen = ref(false);
 const statusDialogStatus = ref<ImprovementStatus>('ignored');
@@ -95,6 +97,21 @@ function openStatusDialog(status: ImprovementStatus) {
 function handleStatusUpdateSuccess() {
   drawerOpen.value = false;
 }
+
+watch(
+  () => [drawerOpen.value, props.improvement?.uuid] as const,
+  ([open, improvementUuid]) => {
+    if (open && improvementUuid) {
+      improvementsStore.fetchImprovementDetail(improvementUuid);
+      return;
+    }
+
+    if (!open) {
+      improvementsStore.resetImprovementDetail();
+    }
+  },
+  { immediate: true },
+);
 
 const typeTag = computed(() => {
   const { category, scheme } = getImprovementTypeTag(props.improvement?.type);

--- a/src/components/ConversationsImprovements/__tests__/ImprovementDrawer.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementDrawer.spec.js
@@ -1,13 +1,16 @@
 import { mount } from '@vue/test-utils';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
 
 import i18n from '@/utils/plugins/i18n';
+import { useImprovementsStore } from '@/store/Improvements';
 
 import ImprovementDrawer from '../ImprovementDrawer.vue';
 
 describe('ImprovementDrawer.vue', () => {
   let wrapper;
+  let improvementsStore;
 
   const baseImprovement = {
     uuid: 'improvement-uuid-1',
@@ -17,6 +20,14 @@ describe('ImprovementDrawer.vue', () => {
   };
 
   const createWrapper = (props = {}) => {
+    const pinia = createTestingPinia({
+      stubActions: false,
+    });
+
+    improvementsStore = useImprovementsStore(pinia);
+    vi.spyOn(improvementsStore, 'fetchImprovementDetail').mockResolvedValue();
+    vi.spyOn(improvementsStore, 'resetImprovementDetail');
+
     wrapper = mount(ImprovementDrawer, {
       props: {
         open: true,
@@ -24,6 +35,7 @@ describe('ImprovementDrawer.vue', () => {
         ...props,
       },
       global: {
+        plugins: [pinia],
         stubs: {
           ImprovementStatusDialog: {
             template:
@@ -49,6 +61,10 @@ describe('ImprovementDrawer.vue', () => {
     });
   };
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   const elements = {
     drawer: () => wrapper.find('[data-testid="improvement-drawer"]'),
     title: () => wrapper.find('[data-testid="improvement-drawer-title"]'),
@@ -69,6 +85,35 @@ describe('ImprovementDrawer.vue', () => {
 
   afterEach(() => {
     wrapper?.unmount();
+  });
+
+  describe('detail loading', () => {
+    it('fetches improvement detail when the drawer opens', async () => {
+      createWrapper();
+
+      await nextTick();
+
+      expect(improvementsStore.fetchImprovementDetail).toHaveBeenCalledWith(
+        baseImprovement.uuid,
+      );
+    });
+
+    it('resets improvement detail when the drawer closes', async () => {
+      createWrapper();
+
+      await wrapper.setProps({ open: false });
+      await nextTick();
+
+      expect(improvementsStore.resetImprovementDetail).toHaveBeenCalled();
+    });
+
+    it('does not fetch improvement detail when improvement is null', async () => {
+      createWrapper({ improvement: null });
+
+      await nextTick();
+
+      expect(improvementsStore.fetchImprovementDetail).not.toHaveBeenCalled();
+    });
   });
 
   describe('header', () => {

--- a/src/store/Improvements.ts
+++ b/src/store/Improvements.ts
@@ -10,6 +10,7 @@ import { useAlertStore } from './Alert';
 
 import type {
   Improvement,
+  ImprovementDetail,
   ImprovementStatus,
   ImprovementsAnalysis,
   ImprovementsStatus,
@@ -118,6 +119,14 @@ export const useImprovementsStore = defineStore('Improvements', () => {
     status: ImprovementsStatus;
   }>({
     data: [],
+    status: null,
+  });
+
+  const improvementDetail = reactive<{
+    data: ImprovementDetail | null;
+    status: ImprovementsStatus;
+  }>({
+    data: null,
     status: null,
   });
 
@@ -254,12 +263,36 @@ export const useImprovementsStore = defineStore('Improvements', () => {
     }
   }
 
+  function resetImprovementDetail() {
+    improvementDetail.data = null;
+    improvementDetail.status = null;
+  }
+
+  async function fetchImprovementDetail(improvementUuid: string) {
+    improvementDetail.status = 'loading';
+    improvementDetail.data = null;
+
+    try {
+      improvementDetail.data = await supervisorApi.improvements.getById({
+        projectUuid: projectUuid.value,
+        improvementUuid,
+      });
+      improvementDetail.status = 'complete';
+    } catch (error) {
+      improvementDetail.status = 'error';
+      console.error(error);
+    }
+  }
+
   return {
     analysis,
     improvements,
+    improvementDetail,
     runAnalysisBlockReason,
     isRunAnalysisDisabled,
     fetchImprovements,
+    fetchImprovementDetail,
+    resetImprovementDetail,
     runAnalysis,
     updateImprovementStatus,
   };

--- a/src/store/__tests__/Improvements.unit.spec.js
+++ b/src/store/__tests__/Improvements.unit.spec.js
@@ -14,6 +14,7 @@ vi.mock('@/api/nexusaiAPI', () => ({
         improvements: {
           runAnalysis: vi.fn(),
           getAnalysis: vi.fn(),
+          getById: vi.fn(),
           updateStatus: vi.fn(),
         },
       },
@@ -64,6 +65,23 @@ const buildImprovement = (overrides = {}) => ({
   text: 'Sample improvement',
   type: 'personality_deviation',
   conversationsCount: 10,
+  ...overrides,
+});
+
+const buildImprovementDetail = (overrides = {}) => ({
+  uuid: 'improvement-uuid-1',
+  text: 'Sample improvement',
+  type: 'personality_deviation',
+  description: 'Sample diagnosis',
+  suggestedChange: 'Update the tone instruction',
+  status: 'pending',
+  affectedInstructions: [
+    {
+      instructionId: 42,
+      changeType: 'fix',
+      wasChanged: false,
+    },
+  ],
   ...overrides,
 });
 
@@ -598,6 +616,45 @@ describe('Improvements Store', () => {
           'audit.improvements.status_update.error.ignored.description',
         ),
       });
+    });
+  });
+
+  describe('fetchImprovementDetail', () => {
+    it('loads improvement detail and sets complete status', async () => {
+      const detail = buildImprovementDetail();
+      improvementsApi.getById.mockResolvedValue(detail);
+
+      await store.fetchImprovementDetail(detail.uuid);
+
+      expect(improvementsApi.getById).toHaveBeenCalledWith({
+        projectUuid: 'test-project-uuid',
+        improvementUuid: detail.uuid,
+      });
+      expect(store.improvementDetail.status).toBe('complete');
+      expect(store.improvementDetail.data).toEqual(detail);
+    });
+
+    it('sets error status when the request fails', async () => {
+      const error = new Error('detail failed');
+      improvementsApi.getById.mockRejectedValue(error);
+
+      await store.fetchImprovementDetail('improvement-uuid-1');
+
+      expect(store.improvementDetail.status).toBe('error');
+      expect(store.improvementDetail.data).toBeNull();
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('resetImprovementDetail', () => {
+    it('clears improvement detail state', () => {
+      store.improvementDetail.data = buildImprovementDetail();
+      store.improvementDetail.status = 'complete';
+
+      store.resetImprovementDetail();
+
+      expect(store.improvementDetail.data).toBeNull();
+      expect(store.improvementDetail.status).toBeNull();
     });
   });
 });

--- a/src/store/types/Improvements.types.ts
+++ b/src/store/types/Improvements.types.ts
@@ -16,6 +16,26 @@ export type RunAnalysisBlockReason =
 
 export type ImprovementStatus = 'ignored' | 'resolved';
 
+export type ImprovementDetailStatus = 'pending' | 'resolved' | 'ignored';
+
+export type InstructionChangeType = 'fix' | 'add' | 'remove';
+
+export interface AffectedInstruction {
+  instructionId: number;
+  changeType: InstructionChangeType;
+  wasChanged: boolean;
+}
+
+export interface ImprovementDetail {
+  uuid: string;
+  text: string;
+  type: ImprovementType;
+  description: string;
+  suggestedChange: string | null;
+  status: ImprovementDetailStatus;
+  affectedInstructions: AffectedInstruction[];
+}
+
 export interface ImprovementsTask {
   isRunning: boolean;
   progress: number;


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
When a user opens the improvement drawer, the application needs to fetch and display detailed information about the selected improvement, including its status, suggested change, and the list of affected instructions. Previously, there was no mechanism to retrieve or manage this data.

### Summary of Changes
- Added `ImprovementDetail`, `AffectedInstruction`, `ImprovementDetailStatus`, and `InstructionChangeType` types to the improvements type definitions.
- Implemented `ImprovementsAdapter.fromDetailApi` to parse and transform the improvement detail API response into the frontend format, including validation of statuses, change types, and filtering of invalid affected instructions.
- Added `Supervisor.improvements.getById` API method that fetches a single improvement by UUID and returns the parsed detail.
- Added `improvementDetail` reactive state, `fetchImprovementDetail`, and `resetImprovementDetail` actions to the improvements store.
- Updated `ImprovementDrawer` to automatically fetch the improvement detail when the drawer opens and reset it when the drawer closes.