### PR TITLE
feat: Add diagnosis, suggested solution, and affected conversations sections to ImprovementDrawer

### DIFF
--- a/src/components/ConversationsImprovements/ImprovementDrawer.vue
+++ b/src/components/ConversationsImprovements/ImprovementDrawer.vue
@@ -34,7 +34,24 @@
         class="improvement-drawer"
         data-testid="improvement-drawer-content"
       >
-        <!-- TODO: Implement improvement detail drawer in next branch -->
+        <ImprovementDrawerSection
+          testId="diagnosis"
+          :title="$t('audit.improvements.drawer.diagnosis_title')"
+        >
+          <p data-testid="improvement-drawer-diagnosis-description">
+            {{ improvementDetail?.description }}
+          </p>
+        </ImprovementDrawerSection>
+
+        <ImprovementDrawerSection
+          testId="suggested-solution"
+          :title="$t('audit.improvements.drawer.suggested_solution_title')"
+        />
+
+        <ImprovementDrawerSection
+          testId="affected-conversations"
+          :title="$t('audit.improvements.drawer.affected_conversations_title')"
+        />
       </section>
 
       <UnnnicDrawerFooter>
@@ -66,6 +83,7 @@
 import { computed, ref, watch } from 'vue';
 import { useI18n } from 'vue-i18n';
 
+import ImprovementDrawerSection from '@/components/ConversationsImprovements/ImprovementDrawerSection.vue';
 import ImprovementStatusDialog from '@/components/ConversationsImprovements/ImprovementStatusDialog.vue';
 import { useImprovementsStore } from '@/store/Improvements';
 import { getImprovementTypeTag } from '@/utils/improvements/getImprovementTypeTag';
@@ -85,6 +103,9 @@ const props = defineProps<{
 
 const { t } = useI18n();
 const improvementsStore = useImprovementsStore();
+const improvementDetail = computed(
+  () => improvementsStore.improvementDetail.data,
+);
 
 const isStatusDialogOpen = ref(false);
 const statusDialogStatus = ref<ImprovementStatus>('ignored');
@@ -125,6 +146,14 @@ const typeTag = computed(() => {
 
 <style scoped lang="scss">
 .improvement-drawer {
+  padding: $unnnic-space-6;
+
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-6;
+
+  overflow-y: auto;
+
   &__header-info {
     margin-top: $unnnic-space-1;
 
@@ -135,6 +164,11 @@ const typeTag = computed(() => {
 
   &__conversations-count {
     @include unnnic-font-caption-1;
+    color: $unnnic-color-fg-base;
+  }
+
+  &__section-description {
+    @include unnnic-font-body;
     color: $unnnic-color-fg-base;
   }
 }

--- a/src/components/ConversationsImprovements/ImprovementDrawerSection.vue
+++ b/src/components/ConversationsImprovements/ImprovementDrawerSection.vue
@@ -1,0 +1,35 @@
+<template>
+  <section
+    class="improvement-drawer-section"
+    :data-testid="`improvement-drawer-${testId}-section`"
+  >
+    <h2
+      class="improvement-drawer-section__title"
+      :data-testid="`improvement-drawer-${testId}-title`"
+    >
+      {{ title }}
+    </h2>
+
+    <slot />
+  </section>
+</template>
+
+<script setup lang="ts">
+defineProps<{
+  testId: string;
+  title: string;
+}>();
+</script>
+
+<style scoped lang="scss">
+.improvement-drawer-section {
+  @include unnnic-font-body;
+  color: $unnnic-color-fg-base;
+
+  &__title {
+    @include unnnic-font-display-3;
+    color: $unnnic-color-fg-emphasized;
+    margin-bottom: $unnnic-space-2;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/__tests__/ImprovementDrawer.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementDrawer.spec.js
@@ -19,7 +19,17 @@ describe('ImprovementDrawer.vue', () => {
     conversationsCount: 18,
   };
 
-  const createWrapper = (props = {}) => {
+  const baseImprovementDetail = {
+    uuid: 'improvement-uuid-1',
+    text: baseImprovement.text,
+    type: baseImprovement.type,
+    description: 'The agent tone does not match the configured brand voice.',
+    suggestedChange: 'Update the tone instruction in refund conversations.',
+    status: 'pending',
+    affectedInstructions: [],
+  };
+
+  const createWrapper = (props = {}, { improvementDetail = null } = {}) => {
     const pinia = createTestingPinia({
       stubActions: false,
     });
@@ -27,6 +37,11 @@ describe('ImprovementDrawer.vue', () => {
     improvementsStore = useImprovementsStore(pinia);
     vi.spyOn(improvementsStore, 'fetchImprovementDetail').mockResolvedValue();
     vi.spyOn(improvementsStore, 'resetImprovementDetail');
+
+    if (improvementDetail) {
+      improvementsStore.improvementDetail.data = improvementDetail;
+      improvementsStore.improvementDetail.status = 'complete';
+    }
 
     wrapper = mount(ImprovementDrawer, {
       props: {
@@ -81,6 +96,29 @@ describe('ImprovementDrawer.vue', () => {
     footer: () => wrapper.find('[data-testid="improvement-drawer-footer"]'),
     statusDialog: () =>
       wrapper.find('[data-testid="improvement-status-dialog-stub"]'),
+    content: () => wrapper.find('[data-testid="improvement-drawer-content"]'),
+    diagnosisSection: () =>
+      wrapper.find('[data-testid="improvement-drawer-diagnosis-section"]'),
+    diagnosisTitle: () =>
+      wrapper.find('[data-testid="improvement-drawer-diagnosis-title"]'),
+    diagnosisDescription: () =>
+      wrapper.find('[data-testid="improvement-drawer-diagnosis-description"]'),
+    suggestedSolutionSection: () =>
+      wrapper.find(
+        '[data-testid="improvement-drawer-suggested-solution-section"]',
+      ),
+    suggestedSolutionTitle: () =>
+      wrapper.find(
+        '[data-testid="improvement-drawer-suggested-solution-title"]',
+      ),
+    affectedConversationsSection: () =>
+      wrapper.find(
+        '[data-testid="improvement-drawer-affected-conversations-section"]',
+      ),
+    affectedConversationsTitle: () =>
+      wrapper.find(
+        '[data-testid="improvement-drawer-affected-conversations-title"]',
+      ),
   };
 
   afterEach(() => {
@@ -211,6 +249,57 @@ describe('ImprovementDrawer.vue', () => {
           );
         },
       );
+    });
+  });
+
+  describe('content sections', () => {
+    it('renders the drawer content container', () => {
+      createWrapper();
+
+      expect(elements.content().exists()).toBe(true);
+    });
+
+    it.each([
+      {
+        section: 'diagnosis',
+        findSection: () => elements.diagnosisSection(),
+        findTitle: () => elements.diagnosisTitle(),
+        localeKey: 'audit.improvements.drawer.diagnosis_title',
+      },
+      {
+        section: 'suggested solution',
+        findSection: () => elements.suggestedSolutionSection(),
+        findTitle: () => elements.suggestedSolutionTitle(),
+        localeKey: 'audit.improvements.drawer.suggested_solution_title',
+      },
+      {
+        section: 'affected conversations',
+        findSection: () => elements.affectedConversationsSection(),
+        findTitle: () => elements.affectedConversationsTitle(),
+        localeKey: 'audit.improvements.drawer.affected_conversations_title',
+      },
+    ])(
+      'renders the $section section title',
+      ({ findSection, findTitle, localeKey }) => {
+        createWrapper();
+
+        expect(findSection().exists()).toBe(true);
+        expect(findTitle().text()).toBe(i18n.global.t(localeKey));
+      },
+    );
+
+    it('renders the diagnosis description from improvement detail', () => {
+      createWrapper({}, { improvementDetail: baseImprovementDetail });
+
+      expect(elements.diagnosisDescription().text()).toBe(
+        baseImprovementDetail.description,
+      );
+    });
+
+    it('renders an empty diagnosis description when improvement detail is unavailable', () => {
+      createWrapper();
+
+      expect(elements.diagnosisDescription().text()).toBe('');
     });
   });
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -489,8 +489,11 @@
       },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# affected conversation} other {# affected conversations}}",
+        "affected_conversations_title": "Affected conversations",
+        "diagnosis_title": "Diagnosis",
         "ignore_improvement": "Ignore improvement",
-        "mark_as_resolved": "Mark as resolved"
+        "mark_as_resolved": "Mark as resolved",
+        "suggested_solution_title": "Suggested solution"
       },
       "header": {
         "custom_analysis": "Custom analysis",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -488,8 +488,11 @@
       },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# conversación afectada} other {# conversaciones afectadas}}",
+        "affected_conversations_title": "Conversaciones afectadas",
+        "diagnosis_title": "Diagnóstico",
         "ignore_improvement": "Ignorar mejora",
-        "mark_as_resolved": "Marcar como resuelta"
+        "mark_as_resolved": "Marcar como resuelta",
+        "suggested_solution_title": "Solución sugerida"
       },
       "header": {
         "custom_analysis": "Análisis personalizado",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -488,8 +488,11 @@
       },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# conversa afetada} other {# conversas afetadas}}",
+        "affected_conversations_title": "Conversas afetadas",
+        "diagnosis_title": "Diagnóstico",
         "ignore_improvement": "Ignorar melhoria",
-        "mark_as_resolved": "Marcar como resolvida"
+        "mark_as_resolved": "Marcar como resolvida",
+        "suggested_solution_title": "Solução sugerida"
       },
       "header": {
         "custom_analysis": "Análise personalizada",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -487,8 +487,11 @@
       },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# conversație afectată} few {# conversații afectate} other {# conversații afectate}}",
+        "affected_conversations_title": "Conversații afectate",
+        "diagnosis_title": "Diagnostic",
         "ignore_improvement": "Ignoră îmbunătățirea",
-        "mark_as_resolved": "Marchează ca rezolvată"
+        "mark_as_resolved": "Marchează ca rezolvată",
+        "suggested_solution_title": "Soluție sugerată"
       },
       "header": {
         "custom_analysis": "Analiză personalizată",


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

The improvement detail drawer previously had no content implemented. This change introduces the initial content sections to display structured information about a selected improvement.

### Summary of Changes

- Created a new `ImprovementDrawerSection` component that renders a titled section with a slot for content, used as a reusable building block inside the drawer.
- Added three sections to the drawer: **Diagnosis**, **Suggested Solution**, and **Affected Conversations**.
- The Diagnosis section displays the `description` field from `improvementsStore.improvementDetail.data`.
- Added locale keys for the three section titles (`diagnosis_title`, `suggested_solution_title`, `affected_conversations_title`) across all supported languages (English, Spanish, Portuguese, and Romanian).
- Added tests covering the rendering of each section and its title, the diagnosis description when detail data is available, and the fallback when it is not.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/67ca2e66-8469-456b-b955-cecce04aebe3.png)

