### PR TITLE
fix: Update ImprovementsTask handling and default values

### DIFF
--- a/src/api/adapters/supervisor/__tests__/improvements.spec.ts
+++ b/src/api/adapters/supervisor/__tests__/improvements.spec.ts
@@ -45,8 +45,32 @@ describe('Supervisor improvements adapter', () => {
     it('returns safe defaults when API fields are missing', () => {
       expect(ImprovementsAdapter.fromApi()).toEqual({
         yesterdayConversationsCount: 0,
-        task: null,
+        task: {
+          isRunning: false,
+          progress: 0,
+          total: 0,
+          createdAt: null,
+        },
         improvements: [],
+      });
+    });
+
+    it('maps null created_at when no analysis has been performed', () => {
+      const result = ImprovementsAdapter.fromApi({
+        yesterday_conversations_count: 10,
+        improvements_task: {
+          is_running: false,
+          progress: 0,
+          total: 0,
+          created_at: null,
+        },
+      });
+
+      expect(result.task).toEqual({
+        isRunning: false,
+        progress: 0,
+        total: 0,
+        createdAt: null,
       });
     });
 

--- a/src/api/adapters/supervisor/improvements.ts
+++ b/src/api/adapters/supervisor/improvements.ts
@@ -8,12 +8,13 @@ import type {
   ImprovementsTask,
   InstructionChangeType,
 } from '@/store/types/Improvements.types';
+import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
 
 export interface ImprovementsTaskApi {
   is_running?: boolean;
   progress?: number;
   total?: number;
-  created_at?: string;
+  created_at?: string | null;
 }
 
 export interface ImprovementApi {
@@ -59,9 +60,9 @@ function isImprovementType(value: unknown): value is ImprovementType {
   return IMPROVEMENT_TYPES.includes(value as ImprovementType);
 }
 
-function parseTask(task?: ImprovementsTaskApi | null): ImprovementsTask | null {
+function parseTask(task?: ImprovementsTaskApi | null): ImprovementsTask {
   if (!task) {
-    return null;
+    return { ...DEFAULT_IMPROVEMENTS_TASK };
   }
 
   return {

--- a/src/components/ConversationsImprovements/__tests__/AnalysisInProgressDisclaimer.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/AnalysisInProgressDisclaimer.spec.js
@@ -4,6 +4,7 @@ import { createTestingPinia } from '@pinia/testing';
 
 import i18n from '@/utils/plugins/i18n';
 import { useImprovementsStore } from '@/store/Improvements';
+import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
 
 import AnalysisInProgressDisclaimer from '../AnalysisInProgressDisclaimer.vue';
 
@@ -101,12 +102,12 @@ describe('AnalysisInProgressDisclaimer.vue', () => {
       expect(findDisclaimer().exists()).toBe(false);
     });
 
-    it('does not render the disclaimer when there is no analysis task', () => {
+    it('does not render the disclaimer when no analysis was performed', () => {
       wrapper.unmount();
       createWrapper({
         analysis: {
           status: null,
-          task: null,
+          task: { ...DEFAULT_IMPROVEMENTS_TASK },
         },
       });
 

--- a/src/components/ConversationsImprovements/__tests__/InsufficientConversationsVolume.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/InsufficientConversationsVolume.spec.js
@@ -4,6 +4,7 @@ import { createTestingPinia } from '@pinia/testing';
 
 import i18n from '@/utils/plugins/i18n';
 import { MIN_CONVERSATIONS_FOR_ANALYSIS } from '@/store/Improvements';
+import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
 
 import InsufficientConversationsVolume from '../InsufficientConversationsVolume.vue';
 import RunAnalysisButton from '../RunAnalysisButton.vue';
@@ -26,7 +27,7 @@ describe('InsufficientConversationsVolume.vue', () => {
         Improvements: {
           analysis: {
             status: 'complete',
-            task: null,
+            task: { ...DEFAULT_IMPROVEMENTS_TASK },
             yesterdayConversationsCount: 10,
           },
         },

--- a/src/components/ConversationsImprovements/__tests__/NoAnalysisPerformed.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/NoAnalysisPerformed.spec.js
@@ -4,6 +4,7 @@ import { createTestingPinia } from '@pinia/testing';
 
 import i18n from '@/utils/plugins/i18n';
 import { useImprovementsStore } from '@/store/Improvements';
+import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
 
 import NoAnalysisPerformed from '../NoAnalysisPerformed.vue';
 import RunAnalysisButton from '../RunAnalysisButton.vue';
@@ -25,7 +26,7 @@ describe('NoAnalysisPerformed.vue', () => {
         Improvements: {
           analysis: {
             status: 'complete',
-            task: null,
+            task: { ...DEFAULT_IMPROVEMENTS_TASK },
             yesterdayConversationsCount: 20,
           },
         },
@@ -93,7 +94,7 @@ describe('NoAnalysisPerformed.vue', () => {
           Improvements: {
             analysis: {
               status: 'complete',
-              task: null,
+              task: { ...DEFAULT_IMPROVEMENTS_TASK },
               yesterdayConversationsCount: 20,
             },
           },

--- a/src/components/ConversationsImprovements/__tests__/RunAnalysisButton.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/RunAnalysisButton.spec.js
@@ -7,6 +7,7 @@ import {
   MIN_CONVERSATIONS_FOR_ANALYSIS,
   useImprovementsStore,
 } from '@/store/Improvements';
+import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
 
 import RunAnalysisButton from '../RunAnalysisButton.vue';
 import RunAnalysisDialog from '../RunAnalysisDialog.vue';
@@ -25,7 +26,7 @@ describe('RunAnalysisButton.vue', () => {
         Improvements: {
           analysis: {
             status: 'complete',
-            task: null,
+            task: { ...DEFAULT_IMPROVEMENTS_TASK },
             yesterdayConversationsCount: 20,
             ...(stateOverrides.analysis || {}),
           },
@@ -101,7 +102,7 @@ describe('RunAnalysisButton.vue', () => {
         analysis: {
           status: 'complete',
           yesterdayConversationsCount: 10,
-          task: null,
+          task: { ...DEFAULT_IMPROVEMENTS_TASK },
         },
       });
 
@@ -146,7 +147,7 @@ describe('RunAnalysisButton.vue', () => {
         analysis: {
           status: 'loading',
           yesterdayConversationsCount: 20,
-          task: null,
+          task: { ...DEFAULT_IMPROVEMENTS_TASK },
         },
       });
 
@@ -192,7 +193,7 @@ describe('RunAnalysisButton.vue', () => {
         analysis: {
           status: 'complete',
           yesterdayConversationsCount: 10,
-          task: null,
+          task: { ...DEFAULT_IMPROVEMENTS_TASK },
         },
       });
 

--- a/src/components/ConversationsImprovements/__tests__/RunningAnalysis.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/RunningAnalysis.spec.js
@@ -4,6 +4,7 @@ import { createTestingPinia } from '@pinia/testing';
 
 import i18n from '@/utils/plugins/i18n';
 import { useImprovementsStore } from '@/store/Improvements';
+import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
 
 import RunningAnalysis from '../RunningAnalysis.vue';
 
@@ -82,12 +83,12 @@ describe('RunningAnalysis.vue', () => {
       );
     });
 
-    it('renders the title with zero when there is no analysis task', () => {
+    it('renders the title with zero when task total is missing', () => {
       wrapper.unmount();
       createWrapper({
         analysis: {
           status: 'loading',
-          task: null,
+          task: { ...DEFAULT_IMPROVEMENTS_TASK },
         },
       });
 

--- a/src/store/Improvements.ts
+++ b/src/store/Improvements.ts
@@ -14,9 +14,9 @@ import type {
   ImprovementStatus,
   ImprovementsAnalysis,
   ImprovementsStatus,
-  ImprovementsTask,
   RunAnalysisBlockReason,
 } from './types/Improvements.types';
+import { DEFAULT_IMPROVEMENTS_TASK } from './types/Improvements.types';
 
 export const MIN_CONVERSATIONS_FOR_ANALYSIS = 15;
 
@@ -106,11 +106,11 @@ export const useImprovementsStore = defineStore('Improvements', () => {
 
   const analysis = reactive<{
     status: ImprovementsStatus;
-    task: ImprovementsTask | null;
+    task: typeof DEFAULT_IMPROVEMENTS_TASK;
     yesterdayConversationsCount: number;
   }>({
     status: null,
-    task: null,
+    task: { ...DEFAULT_IMPROVEMENTS_TASK },
     yesterdayConversationsCount: 0,
   });
 
@@ -141,7 +141,7 @@ export const useImprovementsStore = defineStore('Improvements', () => {
       return null;
     }
 
-    const createdAt = analysis.task?.createdAt;
+    const createdAt = analysis.task.createdAt;
 
     if (createdAt && isToday(new Date(createdAt))) {
       return 'already_run_today';
@@ -157,7 +157,7 @@ export const useImprovementsStore = defineStore('Improvements', () => {
   const isRunAnalysisDisabled = computed(
     () =>
       analysis.status === 'loading' ||
-      Boolean(analysis.task?.isRunning) ||
+      analysis.task.isRunning ||
       runAnalysisBlockReason.value !== null,
   );
 
@@ -167,7 +167,7 @@ export const useImprovementsStore = defineStore('Improvements', () => {
   }
 
   function resetAnalysisState() {
-    analysis.task = null;
+    analysis.task = { ...DEFAULT_IMPROVEMENTS_TASK };
     analysis.yesterdayConversationsCount = 0;
     improvements.data = [];
   }
@@ -178,7 +178,7 @@ export const useImprovementsStore = defineStore('Improvements', () => {
     let response = initialResponse;
     let pollCount = 0;
 
-    while (response.task?.isRunning && pollCount < POLL_PHASE_LIMITS.minute) {
+    while (response.task.isRunning && pollCount < POLL_PHASE_LIMITS.minute) {
       await wait(getPollIntervalMs(pollCount));
 
       response = await supervisorApi.improvements.getAnalysis({
@@ -199,7 +199,7 @@ export const useImprovementsStore = defineStore('Improvements', () => {
 
     applyAnalysisResponse(response);
 
-    if (response.task?.isRunning) {
+    if (response.task.isRunning) {
       await pollAnalysisUntilComplete(response);
     } else {
       setStatus('complete');

--- a/src/store/__tests__/Improvements.unit.spec.js
+++ b/src/store/__tests__/Improvements.unit.spec.js
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { setActivePinia, createPinia } from 'pinia';
 
 import { useImprovementsStore } from '@/store/Improvements';
+import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
 import { useAlertStore } from '@/store/Alert';
 import nexusaiAPI from '@/api/nexusaiAPI';
 import i18n from '@/utils/plugins/i18n';
@@ -119,7 +120,7 @@ describe('Improvements Store', () => {
     it('starts with empty analysis and improvements state', () => {
       expect(store.analysis).toEqual({
         status: null,
-        task: null,
+        task: { ...DEFAULT_IMPROVEMENTS_TASK },
         yesterdayConversationsCount: 0,
       });
       expect(store.improvements).toEqual({
@@ -211,7 +212,7 @@ describe('Improvements Store', () => {
     it('returns insufficient_volume when yesterday count is below minimum', () => {
       store.analysis.status = 'complete';
       store.analysis.yesterdayConversationsCount = 14;
-      store.analysis.task = null;
+      store.analysis.task = { ...DEFAULT_IMPROVEMENTS_TASK };
 
       expect(store.runAnalysisBlockReason).toBe('insufficient_volume');
     });
@@ -219,7 +220,7 @@ describe('Improvements Store', () => {
     it('returns null when yesterday count meets minimum', () => {
       store.analysis.status = 'complete';
       store.analysis.yesterdayConversationsCount = 15;
-      store.analysis.task = null;
+      store.analysis.task = { ...DEFAULT_IMPROVEMENTS_TASK };
 
       expect(store.runAnalysisBlockReason).toBeNull();
     });
@@ -305,7 +306,7 @@ describe('Improvements Store', () => {
 
       expect(store.analysis.status).toBe('loading');
       expect(store.improvements.status).toBe('loading');
-      expect(store.analysis.task).toBeNull();
+      expect(store.analysis.task).toEqual({ ...DEFAULT_IMPROVEMENTS_TASK });
       expect(store.analysis.yesterdayConversationsCount).toBe(0);
       expect(store.improvements.data).toEqual([]);
 

--- a/src/store/types/Improvements.types.ts
+++ b/src/store/types/Improvements.types.ts
@@ -43,6 +43,13 @@ export interface ImprovementsTask {
   createdAt: string | null;
 }
 
+export const DEFAULT_IMPROVEMENTS_TASK: ImprovementsTask = {
+  isRunning: false,
+  progress: 0,
+  total: 0,
+  createdAt: null,
+};
+
 export interface Improvement {
   uuid: string;
   text: string;
@@ -52,6 +59,6 @@ export interface Improvement {
 
 export interface ImprovementsAnalysis {
   yesterdayConversationsCount: number;
-  task: ImprovementsTask | null;
+  task: ImprovementsTask;
   improvements: Improvement[];
 }

--- a/src/views/Supervisor/Improvements/__tests__/index.spec.js
+++ b/src/views/Supervisor/Improvements/__tests__/index.spec.js
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
 import { useImprovementsStore } from '@/store/Improvements';
+import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
 
 import AnalysisInProgressDisclaimer from '@/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue';
 import ImprovementsHeader from '@/components/ConversationsImprovements/ImprovementsHeader.vue';
@@ -37,7 +38,7 @@ describe('Improvements view', () => {
         Improvements: {
           analysis: {
             status: null,
-            task: null,
+            task: { ...DEFAULT_IMPROVEMENTS_TASK },
             yesterdayConversationsCount: 0,
             ...(stateOverrides.analysis || {}),
           },
@@ -77,12 +78,12 @@ describe('Improvements view', () => {
   });
 
   describe('InsufficientConversationsVolume state', () => {
-    it('renders InsufficientConversationsVolume when volume is below minimum and there is no task', () => {
+    it('renders InsufficientConversationsVolume when volume is below minimum and no analysis was performed', () => {
       wrapper.unmount();
       createWrapper({
         analysis: {
           status: 'complete',
-          task: null,
+          task: { ...DEFAULT_IMPROVEMENTS_TASK },
           yesterdayConversationsCount: 10,
         },
       });
@@ -96,7 +97,7 @@ describe('Improvements view', () => {
       createWrapper({
         analysis: {
           status: 'complete',
-          task: null,
+          task: { ...DEFAULT_IMPROVEMENTS_TASK },
           yesterdayConversationsCount: 15,
         },
       });
@@ -111,30 +112,35 @@ describe('Improvements view', () => {
       expect(findSection().exists()).toBe(true);
     });
 
-    it('renders NoAnalysisPerformed when there is no analysis task', () => {
+    it('renders NoAnalysisPerformed when no analysis was performed', () => {
       expect(findNoAnalysisPerformed().exists()).toBe(true);
     });
 
-    it('does not render NoAnalysisPerformed when an analysis task exists', () => {
+    it('does not render NoAnalysisPerformed when analysis was performed', () => {
       wrapper.unmount();
       createWrapper({
         analysis: {
           status: 'complete',
-          task: { isRunning: false, progress: 5, total: 5, createdAt: null },
+          task: {
+            isRunning: false,
+            progress: 5,
+            total: 5,
+            createdAt: '2026-06-18T08:00:00Z',
+          },
         },
       });
 
       expect(findNoAnalysisPerformed().exists()).toBe(false);
     });
 
-    it('hides NoAnalysisPerformed after the analysis task is set', async () => {
+    it('hides NoAnalysisPerformed after analysis is performed', async () => {
       expect(findNoAnalysisPerformed().exists()).toBe(true);
 
       improvementsStore.analysis.task = {
         isRunning: true,
         progress: 0,
         total: 3,
-        createdAt: null,
+        createdAt: '2026-06-18T08:00:00Z',
       };
 
       await wrapper.vm.$nextTick();
@@ -149,7 +155,12 @@ describe('Improvements view', () => {
       createWrapper({
         analysis: {
           status: 'loading',
-          task: { isRunning: true, progress: 0, total: 437, createdAt: null },
+          task: {
+            isRunning: true,
+            progress: 0,
+            total: 437,
+            createdAt: '2026-06-18T08:00:00Z',
+          },
         },
       });
 
@@ -157,7 +168,7 @@ describe('Improvements view', () => {
       expect(findNoAnalysisPerformed().exists()).toBe(false);
     });
 
-    it('does not render RunningAnalysis when there is no analysis task', () => {
+    it('does not render RunningAnalysis when no analysis was performed', () => {
       expect(findRunningAnalysis().exists()).toBe(false);
     });
 
@@ -170,7 +181,7 @@ describe('Improvements view', () => {
             isRunning: false,
             progress: 437,
             total: 437,
-            createdAt: null,
+            createdAt: '2026-06-18T08:00:00Z',
           },
         },
       });
@@ -183,7 +194,12 @@ describe('Improvements view', () => {
       createWrapper({
         analysis: {
           status: 'loading',
-          task: { isRunning: true, progress: 10, total: 437, createdAt: null },
+          task: {
+            isRunning: true,
+            progress: 10,
+            total: 437,
+            createdAt: '2026-06-18T08:00:00Z',
+          },
         },
         improvements: {
           data: [
@@ -201,14 +217,12 @@ describe('Improvements view', () => {
       expect(findRunningAnalysis().exists()).toBe(false);
     });
 
-    it('shows RunningAnalysis after the analysis task starts running', async () => {
-      expect(findRunningAnalysis().exists()).toBe(false);
-
+    it('shows RunningAnalysis after the analysis starts running', async () => {
       improvementsStore.analysis.task = {
         isRunning: true,
         progress: 0,
         total: 437,
-        createdAt: null,
+        createdAt: '2026-06-18T08:00:00Z',
       };
 
       await wrapper.vm.$nextTick();
@@ -235,7 +249,7 @@ describe('Improvements view', () => {
             isRunning: false,
             progress: 437,
             total: 437,
-            createdAt: null,
+            createdAt: '2026-06-18T08:00:00Z',
           },
         },
         improvements: {
@@ -255,7 +269,12 @@ describe('Improvements view', () => {
       createWrapper({
         analysis: {
           status: 'loading',
-          task: { isRunning: true, progress: 10, total: 437, createdAt: null },
+          task: {
+            isRunning: true,
+            progress: 10,
+            total: 437,
+            createdAt: '2026-06-18T08:00:00Z',
+          },
         },
         improvements: {
           data: [improvementItem],
@@ -278,7 +297,7 @@ describe('Improvements view', () => {
             isRunning: false,
             progress: 437,
             total: 437,
-            createdAt: null,
+            createdAt: '2026-06-18T08:00:00Z',
           },
         },
         improvements: {
@@ -301,7 +320,7 @@ describe('Improvements view', () => {
         isRunning: true,
         progress: 5,
         total: 437,
-        createdAt: null,
+        createdAt: '2026-06-18T08:00:00Z',
       };
       improvementsStore.improvements.data = [improvementItem];
 

--- a/src/views/Supervisor/Improvements/index.vue
+++ b/src/views/Supervisor/Improvements/index.vue
@@ -4,15 +4,18 @@
     data-testid="conversations-improvements"
   >
     <InsufficientConversationsVolume
-      v-if="!analysis.task && runAnalysisBlockReason === 'insufficient_volume'"
+      v-if="
+        !analysis.task.createdAt &&
+        runAnalysisBlockReason === 'insufficient_volume'
+      "
     />
-    <NoAnalysisPerformed v-else-if="!analysis.task" />
+    <NoAnalysisPerformed v-else-if="!analysis.task.createdAt" />
     <RunningAnalysis
-      v-else-if="analysis.task?.isRunning && !improvements.data.length"
+      v-else-if="analysis.task.isRunning && !improvements.data.length"
     />
 
     <template v-else-if="improvements.data.length">
-      <AnalysisInProgressDisclaimer v-if="analysis.task?.isRunning" />
+      <AnalysisInProgressDisclaimer v-if="analysis.task.isRunning" />
 
       <ImprovementsHeader v-else />
 


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Previously, `analysis.task` could be `null` when no analysis had been performed, requiring optional chaining (`?.`) throughout the codebase and making null checks inconsistent. This created ambiguity between "no analysis has ever been run" and "an analysis task exists but has no `createdAt`". The presence or absence of a `createdAt` value is a more semantically accurate signal for whether an analysis has been performed.

### Summary of Changes
A `DEFAULT_IMPROVEMENTS_TASK` constant was introduced in `Improvements.types.ts` to represent the initial task state (`isRunning: false`, `progress: 0`, `total: 0`, `createdAt: null`). The `analysis.task` field is now always an `ImprovementsTask` object instead of `ImprovementsTask | null`, initialized with this default value.

The `parseTask` function in the API adapter now returns `DEFAULT_IMPROVEMENTS_TASK` instead of `null` when no task data is present, and `created_at` is explicitly typed to accept `null` from the API.

Conditional rendering in the Improvements view was updated to use `analysis.task.createdAt` as the indicator of whether an analysis has been performed, replacing the previous `!analysis.task` null checks. Optional chaining on `analysis.task` properties was removed throughout the store and view layer.

All related tests were updated to use `DEFAULT_IMPROVEMENTS_TASK` instead of `null` for the task state, and test descriptions were revised to better reflect the intent of each case (e.g., "no analysis was performed" instead of "there is no analysis task").