### PR TITLE
docs: Add spec, plan, data model, and tasks for project safety guardrails configuration

### DIFF
--- a/specs/001-project-guardrails-config/contracts/guardrails-config-api.md
+++ b/specs/001-project-guardrails-config/contracts/guardrails-config-api.md
@@ -1,0 +1,103 @@
+# API Contract: Guardrails Configuration
+
+**Feature**: `001-project-guardrails-config`  
+**Owner**: Backend Nexus (consumed by frontend)  
+**Base path**: `api/{projectUuid}/guardrails-config/`
+
+> **Note**: Exact field names MUST be confirmed with backend before implementation. Shapes below reflect the engineering spec and clarification session.
+
+**Resource model**: `GET` and `PATCH` operate on the **same endpoint** (`/guardrails-config/`). `GET` is the single source for all drawer content (topic catalog, blocked states, block message). `PATCH` persists the full configuration in one request.
+
+## GET — Load drawer configuration
+
+**When called**: On **Configure** click (drawer open). May also be called on retry after error.
+
+**Request**
+
+```http
+GET /api/{projectUuid}/guardrails-config/
+```
+
+**Response `200`**
+
+```json
+{
+  "topics": [
+    {
+      "id": "politics",
+      "name": "Politics",
+      "description": "Political opinions, parties, elections, or partisan topics",
+      "blocked": true
+    }
+  ],
+  "block_message": "I'm not able to help with that topic.",
+  "is_default_message": true,
+  "project_type": "new"
+}
+```
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `topics` | `array` | yes | Full fixed catalog with current blocked state |
+| `topics[].id` | `string` | yes | Stable topic key |
+| `topics[].name` | `string` | yes | Display name (may be localized server-side or via i18n key) |
+| `topics[].description` | `string` | yes | Short scope description |
+| `topics[].blocked` | `boolean` | yes | `true` = topic blocked |
+| `block_message` | `string` | yes | Current or default refusal message |
+| `is_default_message` | `boolean` | no | Whether project never customized the message |
+| `project_type` | `string` | no | `new` or `existing` — informational for defaults |
+
+**Error responses**: Standard Nexus error envelope; frontend shows error state + retry per FR-015.
+
+---
+
+## PATCH — Save configuration
+
+**Request**
+
+```http
+PATCH /api/{projectUuid}/guardrails-config/
+Content-Type: application/json
+```
+
+```json
+{
+  "topics": [
+    { "id": "politics", "blocked": false },
+    { "id": "hate", "blocked": true }
+  ],
+  "block_message": "I can't discuss that subject."
+}
+```
+
+| Field | Type | Required | Description |
+| --- | --- | --- | --- |
+| `topics` | `array` | yes | All topics with updated `blocked` state |
+| `topics[].id` | `string` | yes | Topic identifier |
+| `topics[].blocked` | `boolean` | yes | Desired blocked state |
+| `block_message` | `string` | yes | Refusal message (≤ 240 chars) |
+
+**Response `200`**: Same shape as GET (updated config).
+
+**Validation errors `400`**: e.g. message too long, empty message — surface via Alert store.
+
+---
+
+## User details extension
+
+**Request**
+
+```http
+GET /api/users/details/
+```
+
+**New field** (name TBD with backend — placeholder `can_edit_guardrails`):
+
+```json
+{
+  "email": "operator@example.com",
+  "can_edit_guardrails": true
+}
+```
+
+Frontend maps to `useUserStore` computed `canEditGuardrails`.

--- a/specs/001-project-guardrails-config/data-model.md
+++ b/specs/001-project-guardrails-config/data-model.md
@@ -1,0 +1,78 @@
+# Data Model: Project Safety Guardrails Configuration
+
+**Feature**: `001-project-guardrails-config`  
+**Date**: 2026-07-06
+
+## Entities
+
+### GuardrailTopic
+
+Fixed platform catalog entry displayed in the drawer.
+
+| Field | Type | Source | Notes |
+| --- | --- | --- | --- |
+| `id` | `string` | API | Stable topic identifier (e.g. `politics`, `hate`) |
+| `name` | `string` | API or i18n | Display name |
+| `description` | `string` | API or i18n | Short scope description |
+| `blocked` | `boolean` | API / draft | `true` = toggle on = topic blocked |
+
+**Validation**: Read-only catalog; operator cannot create/edit/delete topics.
+
+### GuardrailsConfig (project-scoped)
+
+| Field | Type | Source | Notes |
+| --- | --- | --- | --- |
+| `topics` | `GuardrailTopic[]` | API | Full catalog with current blocked state |
+| `blockMessage` | `string` | API / draft | ≤ 240 chars; platform default when never customized |
+| `isDefaultMessage` | `boolean` | API (optional) | Whether message is still platform default |
+| `projectType` | `'new' \| 'existing'` | API (optional) | Drives first-load defaults when no prior config |
+
+### GuardrailsDraft (UI-only)
+
+Working copy while drawer is open.
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `topics` | `GuardrailTopic[]` | Cloned from saved config on drawer open |
+| `blockMessage` | `string` | Editable textarea value |
+| `isDirty` | `boolean` | Derived: draft ≠ saved snapshot |
+
+**Lifecycle**:
+1. **Configure** clicked → `GET /guardrails-config/` → clone response into draft.
+2. User edits → `isDirty = true`.
+3. Save → validate → confirm if blocking turned off → PATCH → refresh saved snapshot.
+4. Cancel / close drawer → discard draft silently (no prompt).
+
+### UserPermission (extension)
+
+| Field | Type | Source | Notes |
+| --- | --- | --- | --- |
+| `canEditGuardrails` | `boolean` | `GET api/users/details/` | New backend field; gates edit controls |
+
+## State transitions (store)
+
+```text
+idle → loading (fetch config)
+loading → ready | error
+ready → saving (PATCH after validation + confirm)
+saving → ready | error
+error → loading (retry)
+```
+
+## Validation rules
+
+| Rule | Trigger | UI feedback |
+| --- | --- | --- |
+| Block message required | Save | Prevent save; inline validation message |
+| Block message ≤ 240 chars | Save / input | Character counter + error at limit |
+| No whitespace-only message | Save | Prevent save |
+| Turn blocking off | Save | Warning modal (enhanced if all off) |
+| No admin permission | Always | Disabled switches, textarea, Save |
+
+## Relationships
+
+```text
+Project (1) ── has ── (1) GuardrailsConfig
+GuardrailsConfig (1) ── contains ── (N) GuardrailTopic
+User (1) ── permission ── canEditGuardrails → UI editability
+```

--- a/specs/001-project-guardrails-config/plan.md
+++ b/specs/001-project-guardrails-config/plan.md
@@ -1,0 +1,181 @@
+# Implementation Plan: Project Safety Guardrails Configuration
+
+**Branch**: `001-project-guardrails-config` | **Date**: 2026-07-06 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `/specs/001-project-guardrails-config/spec.md`
+
+**Planning note**: Tasks are grouped for human implementation — not split into micro-steps. A developer can complete each phase as one cohesive unit of work.
+
+## Summary
+
+Add a **Safety guardrails** section to the Instructions page (below category groups) with a **Configure** button that opens a drawer. **Configure** triggers `GET /guardrails-config/` to load topics, blocked states, and block message into the drawer. Admin users edit and save atomically via `PATCH /guardrails-config/` (same resource). Turning blocking off requires a confirmation modal (enhanced when all topics are unblocked). Non-admin users see read-only controls based on a new field from `GET api/users/details/`.
+
+**Technical approach**: New `Guardrails` Pinia store + Nexus API client + adapter; UI components under `components/Instructions/SafetyGuardrails/` using `UnnnicDrawerNext` and `UnnnicDialog` patterns already established in Instructions.
+
+## Technical Context
+
+**Language/Version**: TypeScript (preferred) / JavaScript — Vue 3.5 Composition API  
+**Primary Dependencies**: Vue 3.5, Pinia 3, `@weni/unnnic-system`, vue-i18n, Axios via `httpClientFactory`  
+**Storage**: N/A (server state via Nexus API)  
+**Testing**: Vitest 3 + `@vue/test-utils` + `@pinia/testing`  
+**Target Platform**: Agent Builder webapp (Rspack, Module Federation micro-frontend)  
+**Project Type**: Federated Vue SPA  
+**Performance Goals**: Standard config UI — no special latency targets; drawer load < 2s perceived on typical network  
+**Constraints**: VTEX Content Guide (240-char message), 4-locale i18n, Figma node `7773:7142`, constitution layering  
+**Scale/Scope**: 1 new section, 1 drawer, 11 fixed topics, 2 API endpoints (+ user details field), ~8–10 new files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | How addressed |
+| --- | --- | --- |
+| I. Purpose & scope (frontend only) | ✅ PASS | UI + API consumption; no LLM/persistence logic reimplemented |
+| II. Architecture (layering) | ✅ PASS | `api/nexus` → adapter → `store/Guardrails` → components |
+| III. Componentization | ✅ PASS | Feature folder `SafetyGuardrails/`; reuse Unnnic drawer/dialog |
+| IV. State & data | ✅ PASS | Dedicated Pinia setup store; async loading/saving states |
+| V. UX, i18n, a11y | ✅ PASS | Loading/error states; 4 locales; `data-testid` on interactive elements |
+| VI. Design system | ✅ PASS | Unnnic components + SCSS tokens |
+| VII. Product spec binding | ✅ PASS | Implements FDD + clarified engineering spec |
+| VIII. Testing | ✅ PASS | Store + component behavior tests planned |
+| IX. Code review rules | ✅ PASS | Scoped diff; conventional commits |
+| Federation intact | ✅ PASS | No changes to `src/exports/` |
+
+**Post-design re-check**: ✅ All gates pass. No Complexity Tracking entries required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/001-project-guardrails-config/
+├── plan.md              # This file
+├── research.md          # Phase 0
+├── data-model.md        # Phase 1
+├── quickstart.md        # Phase 1 validation guide
+├── contracts/
+│   └── guardrails-config-api.md
+└── tasks.md             # (/speckit-tasks — optional, use phases below if preferred)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── api/
+│   ├── nexus/
+│   │   └── Guardrails.js                    # GET/PATCH client
+│   ├── adapters/
+│   │   └── guardrails/
+│   │       └── guardrailsConfig.ts          # API ↔ domain mapping
+│   └── nexusaiAPI.js                        # register Guardrails module
+├── store/
+│   ├── Guardrails.ts                        # domain + drawer state
+│   └── User.js                              # extend with canEditGuardrails
+├── components/
+│   └── Instructions/
+│       ├── InstructionsCategorization/
+│       │   └── index.vue                    # mount SafetyGuardrailsSection
+│       └── SafetyGuardrails/
+│           ├── SafetyGuardrailsSection.vue  # card + Configure button
+│           ├── SafetyGuardrailsDrawer.vue   # drawer shell + save/cancel
+│           ├── SafetyGuardrailsTopicList.vue
+│           ├── SafetyGuardrailsBlockMessage.vue
+│           ├── ModalConfirmDisableTopics.vue
+│           └── __tests__/                   # component specs
+└── locales/
+    ├── en.json
+    ├── pt_br.json
+    ├── es.json
+    └── ro.json
+```
+
+**Structure Decision**: Single federated Vue frontend. Feature colocated under `Instructions/` because entry point is the Instructions page. Domain state isolated in `Guardrails` store per constitution.
+
+## Implementation Phases
+
+> **Guidance**: Each phase is one PR-sized chunk. Do not split further unless blocked.
+
+### Phase 1 — API layer & store foundation
+
+**Goal**: Data flows from Nexus to Pinia with correct shapes and permission gating.
+
+**Deliverables**:
+- `api/nexus/Guardrails.js` — `read({ projectUuid })` → `GET /guardrails-config/` (drawer data), `update({ projectUuid, data })` → `PATCH /guardrails-config/`
+- `api/adapters/guardrails/guardrailsConfig.ts` — map `blocked` ↔ toggle, message field
+- Register on `nexusaiAPI` (project-scoped path: `api/${projectUuid}/guardrails-config/`)
+- `store/Guardrails.ts` — load/save actions, `status` (loading/ready/error/saving), draft vs saved snapshot
+- Extend `store/User.js` — `canEditGuardrails` from `api/users/details/` new field
+- Unit tests: adapter + store (mock API, fresh Pinia)
+
+**Done when**: Store loads config, holds draft, PATCH saves, permission computed works in tests.
+
+---
+
+### Phase 2 — UI section + drawer (happy path)
+
+**Goal**: Visible section and fully functional drawer for admin users.
+
+**Deliverables**:
+- `SafetyGuardrailsSection.vue` — bordered card per Figma `7773:7142` (title, description, Configure)
+- `SafetyGuardrailsDrawer.vue` — `UnnnicDrawerNext`, topic list, block message textarea, Save/Cancel footer
+- `SafetyGuardrailsTopicList.vue` — switch per topic (on = blocked), disabled when `!canEditGuardrails`
+- `SafetyGuardrailsBlockMessage.vue` — textarea, 240-char counter, validation
+- Wire into `InstructionsCategorization/index.vue` below categories/list views
+- i18n keys in all 4 locale files (`agents.instructions.safety_guardrails.*`)
+- Component + integration tests with `data-testid` maps
+
+**Done when**: Admin can open drawer, edit topics/message, save via PATCH, see success feedback.
+
+---
+
+### Phase 3 — Confirmation modals, validation & edge cases
+
+**Goal**: Complete FDD flows for disable confirmation, all-off warnings, and discard rules.
+
+**Deliverables**:
+- `ModalConfirmDisableTopics.vue` — intercept Save when any topic goes blocked→allowed; enhanced copy when all off
+- Client validation: empty/whitespace message, > 240 chars (block save + inline error)
+- Silent discard on drawer close (overlay, X, ESC) — reset draft to saved snapshot
+- Read-only mode: disabled switches, textarea, Save for non-admin
+- Loading skeleton in section/drawer; error state with retry
+- Tests covering modal branches, validation, permission, discard
+
+**Done when**: All spec acceptance scenarios and edge cases pass in tests + manual quickstart.
+
+---
+
+### Phase 4 — Polish & merge readiness
+
+**Goal**: Production-ready quality gates.
+
+**Deliverables**:
+- Run `npm run lint` on touched files
+- Run targeted Vitest suites (store, adapter, components)
+- Manual pass of [quickstart.md](./quickstart.md)
+- Coordinate with backend on final API field names (`can_edit_guardrails`, topic ids)
+
+**Done when**: Constitution Check IX satisfied; ready for QA.
+
+## Complexity Tracking
+
+> No violations requiring justification.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+| --- | --- | --- |
+| — | — | — |
+
+## Artifacts Generated
+
+| Artifact | Path |
+| --- | --- |
+| Research | [research.md](./research.md) |
+| Data model | [data-model.md](./data-model.md) |
+| API contract | [contracts/guardrails-config-api.md](./contracts/guardrails-config-api.md) |
+| Quickstart | [quickstart.md](./quickstart.md) |
+
+## Next Steps
+
+1. **Implement** — start with Phase 1 (`/speckit-implement` or manual)
+2. **Optional** — `/speckit-tasks` if you want a formal `tasks.md` (can mirror the 4 phases above without further splitting)
+3. **Optional** — `/speckit-analyze` before implement to cross-check spec ↔ plan alignment

--- a/specs/001-project-guardrails-config/quickstart.md
+++ b/specs/001-project-guardrails-config/quickstart.md
@@ -1,0 +1,91 @@
+# Quickstart: Validate Safety Guardrails Configuration
+
+**Feature**: `001-project-guardrails-config`
+
+## Prerequisites
+
+- Node.js ≥ 22.12.0
+- Backend stubs or dev environment exposing:
+  - `GET/PATCH api/{projectUuid}/guardrails-config/`
+  - `can_edit_guardrails` (or equivalent) on `GET api/users/details/`
+- Agent Builder running locally with Instructions categorization enabled
+
+## Setup
+
+```bash
+npm install
+npm run dev
+```
+
+Navigate to **Agents → Instructions** for a project with categorization feature flag on.
+
+## Manual validation checklist
+
+### Section & drawer (US-1)
+
+- [ ] Safety guardrails section appears below instruction categories
+- [ ] Section shows title, description, and **Configure** button (Figma `7773:7142`)
+- [ ] **Configure** triggers `GET /guardrails-config/` and opens drawer with 11 fixed topics (name, description, toggle)
+- [ ] Toggle on = blocked; toggle off = allowed
+
+### Save & confirmation (US-1, FR-006/007)
+
+- [ ] Turning any topic off and clicking **Save** opens confirmation modal
+- [ ] Turning all topics off shows enhanced risk warnings in modal
+- [ ] After confirm, PATCH succeeds and drawer reflects saved state
+- [ ] Turning topic on saves without extra confirmation (after any required off-confirm flow)
+
+### Block message (US-2)
+
+- [ ] Textarea shows current message or platform default
+- [ ] Message > 240 chars blocked with feedback
+- [ ] Empty/whitespace-only message blocked on save
+- [ ] Valid message persists with topics in single PATCH
+
+### Permissions (FR-013)
+
+- [ ] User without admin: switches, textarea, and Save disabled
+- [ ] User with admin: full edit capability
+
+### Discard behavior (FR-008)
+
+- [ ] Close drawer (X, overlay, ESC) with unsaved edits → silent discard
+- [ ] Reopen drawer → shows last saved config
+
+### States (FR-015)
+
+- [ ] Loading skeleton/spinner while fetching config
+- [ ] Error state with retry on API failure
+- [ ] Success toast/feedback after save (Alert store pattern)
+
+### i18n (FR-016)
+
+- [ ] Switch locale (EN, PT-BR, ES, RO) — all new strings present, no hardcoded copy
+
+## Automated tests
+
+```bash
+# Guardrails store
+npx vitest run src/store/__tests__/Guardrails.unit.spec.js
+
+# Safety guardrails components
+npx vitest run src/components/Instructions/SafetyGuardrails
+
+# API adapter
+npx vitest run src/api/adapters/guardrails
+
+# Lint touched files
+npm run lint
+```
+
+## Expected outcomes
+
+- All Vitest suites green
+- Manual checklist passes against spec acceptance scenarios
+- No constitution violations (HTTP via `api/`, i18n complete, loading/error states)
+
+## References
+
+- Spec: [spec.md](./spec.md)
+- Data model: [data-model.md](./data-model.md)
+- API contract: [contracts/guardrails-config-api.md](./contracts/guardrails-config-api.md)

--- a/specs/001-project-guardrails-config/research.md
+++ b/specs/001-project-guardrails-config/research.md
@@ -1,0 +1,77 @@
+# Research: Project Safety Guardrails Configuration
+
+**Feature**: `001-project-guardrails-config`  
+**Date**: 2026-07-06
+
+## R1 — Drawer pattern for Instructions
+
+**Decision**: Reuse `UnnnicDrawerNext` + `UnnnicDrawerContent` + footer Save/Cancel, mirroring `NewInstructionDrawer`.
+
+**Rationale**: Established Instructions pattern; same lazy mount, footer actions, and `@update:open` close handler. Spec requires silent discard on close — match `NewInstructionDrawer` (`onOpenChange` → reset without prompt).
+
+**Alternatives considered**:
+- Legacy `UnnnicDrawer` (Supervisor filters): rejected — newer drawer API already used in Instructions.
+- Inline panel without drawer: rejected — contradicts clarified UX.
+
+## R2 — State ownership
+
+**Decision**: Dedicated Pinia setup store `useGuardrailsStore` in `src/store/Guardrails.ts`.
+
+**Rationale**: Constitution mandates one store per domain. Guardrails has its own API, loading/saving lifecycle, and drawer state — separate from `Instructions` store avoids coupling.
+
+**Alternatives considered**:
+- Extend `useInstructionsStore`: rejected — different API surface and lifecycle; violates single-responsibility.
+
+## R3 — API layer placement
+
+**Decision**: `src/api/nexus/Guardrails.js` + `src/api/adapters/guardrails/guardrailsConfig.ts`; register on `nexusaiAPI`. `GET /guardrails-config/` loads drawer data; `PATCH /guardrails-config/` saves on the same resource.
+
+**Rationale**: Matches existing `Instructions` client + adapter pattern. Single endpoint for read/write keeps store logic simple. Raw payloads never reach components.
+
+**Alternatives considered**:
+- Direct Axios in store: rejected — constitution forbids cross-layer shortcuts.
+
+## R4 — Admin permission source
+
+**Decision**: New boolean (or equivalent) on `GET api/users/details/` response; expose `canEditGuardrails` computed on `useUserStore`.
+
+**Rationale**: Clarified in spec session; backend owns authorization truth. Frontend only disables switches, textarea, and Save.
+
+**Alternatives considered**:
+- Client-side role inference: rejected — no reliable project-role pattern exists in codebase today.
+
+## R5 — Confirmation modal for turning blocking off
+
+**Decision**: `UnnnicDialog` with `type="warning"` before PATCH when any topic transitions from blocked → allowed; enhanced copy when all topics become allowed.
+
+**Rationale**: Matches `ModalRemoveCategory` and FDD US-1 scenarios 2 and 5. Intercept on Save click, not on individual toggle.
+
+**Alternatives considered**:
+- Confirm on each toggle flip: rejected — worse UX; FDD confirms on save.
+
+## R6 — Section placement
+
+**Decision**: Render `SafetyGuardrailsSection` at the bottom of `InstructionsCategorization/index.vue`, after `CategoriesView` / `ListView`.
+
+**Rationale**: Clarified placement below category groups; section remains visible regardless of active segmented view (categories vs list).
+
+**Alternatives considered**:
+- Inside `CategoriesView` only: rejected — would hide section in list view.
+
+## R7 — i18n key namespace
+
+**Decision**: Keys under `agents.instructions.safety_guardrails.*` in all four locale files.
+
+**Rationale**: Feature lives in Instructions area; follows existing `agents.instructions.*` convention.
+
+**Alternatives considered**:
+- Top-level `guardrails.*`: rejected — breaks contextual namespacing rule.
+
+## R8 — Toggle semantics mapping
+
+**Decision**: UI switch `on` = `blocked: true` in API payload; `off` = `blocked: false`.
+
+**Rationale**: Product spec defines toggle on = blocked. Adapter maps API field names to UI model.
+
+**Alternatives considered**:
+- Invert in UI labels only: rejected — increases confusion vs FDD.

--- a/specs/001-project-guardrails-config/spec.md
+++ b/specs/001-project-guardrails-config/spec.md
@@ -1,0 +1,171 @@
+# Feature Specification: Project Safety Guardrails Configuration
+
+**Feature Branch**: `001-project-guardrails-config`
+
+**Created**: 2026-07-06
+
+**Status**: Draft
+
+**Input**: User description: "Etapa 6 — Engineering Spec e implementação. Fixa o commit da Product Spec. Divergência vira emenda no repo de produto — nunca desvio silencioso. Resultado: Engineering Spec no submodule + implementação iniciada."
+
+**Product Spec Reference**: FDD · Configuração de tópicos de guardrails por projeto (V2) — binding source of truth for *what* and *why*.
+
+## Governance
+
+This Engineering Spec defines *how* the frontend delivers the Product Spec. It MUST NOT redefine product scope, behavior, or acceptance criteria.
+
+| Rule | Requirement |
+| --- | --- |
+| Product Spec is binding | All functional behavior, defaults, and edge cases come from the FDD unless formally amended in the product repository |
+| No silent divergence | Any implementation conflict with the FDD MUST be resolved by amending the Product Spec first, then updating this spec |
+| Engineering scope | This repository owns operator UI, validation, persistence calls, and read-only enforcement for non-admin roles |
+| Out of scope here | LLM refusal logic, session injection of block messages, and project-level persistence contracts are backend/model dependencies consumed via API |
+
+## Clarifications
+
+### Session 2026-07-06
+
+- Q: How is Safety guardrails accessed within Instructions? → A: Dedicated section on the Instructions page, positioned below the instruction category groups (`CategoriesView`), with a right-aligned **Configure** action that opens a drawer containing all guardrail topics and a textarea for the block message.
+- Q: How does the frontend determine edit permission for guardrails? → A: A new permission field on `GET /api/users/details/`; topic switches (and other editable controls) MUST be disabled for users without admin permission.
+- Q: What happens when the drawer is closed with unsaved changes? → A: Discard silently and close the drawer; no confirmation prompt.
+- Q: What does the Safety guardrails section show before opening the drawer? → A: Per Figma (`Instructions` file, node `7773:7142`): section title **Safety guardrails**, short description **Sensitive topics that Manager refuses to discuss**, and right-aligned **Configure** button in a bordered card row.
+- Q: How does save work in the drawer? → A: Single **Save** action persists topic states and block message together via `PATCH /guardrails-config/` (categories and message may be sent together or as separate fields in the same request body).
+- Q: Which endpoint loads drawer data (topics + block message)? → A: `GET /guardrails-config/` — same resource as save; opening the drawer fetches the full configuration from this endpoint.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Manage project guardrail topics (Priority: P1)
+
+As a project operator (owner/admin), I want to turn individual sensitive guardrail topics on or off for my project so I can control which subjects AI agents may discuss with end customers.
+
+**Why this priority**: Core value of the feature — without per-topic control, operators remain dependent on support/engineering for guardrail adjustments.
+
+**Independent Test**: On the Instructions page, locate the Safety guardrails section below the instruction categories, click **Configure**, and verify the drawer shows the fixed platform topic list with names, short descriptions, and current on/off state; toggle one topic, save, and confirm persisted behavior matches the toggle semantics (on = blocked, off = allowed).
+
+**Acceptance Scenarios**:
+
+1. **Given** the operator is on the Instructions page, **When** they view the Safety guardrails section below the instruction categories, **Then** they see the section title, the description "Sensitive topics that Manager refuses to discuss", and a right-aligned **Configure** action
+2. **Given** the operator is on the Instructions page, **When** they click **Configure**, **Then** the system loads configuration via `GET /guardrails-config/` and opens a drawer showing all fixed platform topics with name, short description, and current state (on or off)
+3. **Given** a topic has blocking turned on, **When** the operator turns blocking off and saves the configuration, **Then** the system shows a confirmation modal, **And** after confirmation agents in the project treat that topic normally in customer conversations
+4. **Given** a topic has blocking turned off, **When** the operator turns blocking on and saves the configuration, **Then** agents in the project refuse that topic and display the block message
+5. **Given** the operator changed topic states in the drawer without saving, **When** they use an explicit cancel action, **Then** no changes are persisted, **And** the previous configuration remains in effect
+6. **Given** the operator changed topic or message values in the drawer without saving, **When** they close the drawer (overlay click, close control, or ESC), **Then** changes are discarded silently, **And** no confirmation prompt is shown
+7. **Given** the operator turned blocking off for all topics, **When** they confirm save in the confirmation modal, **Then** the modal shows warnings about the action and summarizes consequences of disabling guardrails, **And** the system persists the configuration after confirmation
+
+---
+
+### User Story 2 - Configure block message (Priority: P2)
+
+As a project operator (owner/admin), I want to define the message shown to the customer when a blocked topic is triggered so the refusal tone aligns with brand policy.
+
+**Why this priority**: Enables brand-aligned refusals but depends on topic toggles (P1) being in place first.
+
+**Independent Test**: Open the Safety guardrails drawer via **Configure**, view or edit the block message textarea (max 240 characters), save, and verify validation rejects over-limit or whitespace-only input.
+
+**Acceptance Scenarios**:
+
+1. **Given** the operator opens the Safety guardrails drawer via **Configure**, **When** they view the block message field, **Then** they see the current project message or the platform default if never edited
+2. **Given** at least one topic has blocking turned on, **When** a customer requests content related to that topic, **Then** the agent refuses and displays the project's configured block message
+3. **Given** the operator edits the block message within the 240-character limit, **When** they click **Save** in the drawer, **Then** topic states and block message are persisted together in a single save operation
+4. **Given** the operator enters a message exceeding 240 characters, **When** they attempt to save, **Then** the system prevents saving and indicates the character limit was exceeded
+
+---
+
+### User Story 3 - Uniform application across all project agents (Priority: P1)
+
+As a project operator, I want guardrail configuration to apply at the project level so all agents in the agent team behave consistently.
+
+**Why this priority**: Consistency across agents is a primary product promise; misconfiguration per agent would undermine trust.
+
+**Independent Test**: Verify defaults on first open differ for new vs existing projects; confirm no per-agent configuration surface exists.
+
+**Acceptance Scenarios**:
+
+1. **Given** a new or recently created project with no prior guardrails configuration, **When** the operator opens the Safety guardrails drawer for the first time, **Then** all topics appear with blocking on by default, **And** the block message uses the platform default
+2. **Given** an existing project with no prior guardrails configuration, **When** the operator opens the Safety guardrails drawer for the first time, **Then** all topics appear with blocking off by default, **And** the block message uses the platform default
+
+---
+
+### Edge Cases
+
+- When multiple blocked topics could apply to the same customer message, the agent refuses once and displays the project's single block message (no per-topic message variants)
+- When the block message is empty or contains only whitespace, saving is prevented and the operator is prompted for valid content
+- When guardrails change while conversations are in progress, the new configuration applies to messages processed after save; already answered conversations are not rewritten retroactively
+- When the platform adds a new fixed topic, it appears on next configuration open with the default for the project type (on for new projects, off for existing projects)
+- When the operator lacks admin permission (per `GET /api/users/details/`), they can open the drawer but topic switches, block message textarea, and save are disabled
+- When the operator closes the drawer with unsaved changes (overlay, close control, or ESC), changes are discarded silently without a confirmation prompt; reopening the drawer shows the last saved configuration
+- When two owner/admin operators edit simultaneously, last write wins — the latest save overwrites the prior configuration without conflict warning
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST expose a dedicated Safety guardrails section on the Instructions page, positioned below the instruction category groups
+- **FR-001a**: The section MUST display title **Safety guardrails**, description **Sensitive topics that Manager refuses to discuss**, and a right-aligned **Configure** action in a bordered card layout (Figma reference: `Instructions` · node `7773:7142`)
+- **FR-001b**: The **Configure** action MUST open a drawer for editing
+- **FR-001c**: The drawer MUST contain the full guardrail topic list (toggles) and a single block message textarea, populated from `GET /guardrails-config/`
+- **FR-002**: System MUST display the fixed platform topic catalog (Politics, Physical health, Sexual content, Bias, Hate, Religion, Suicide, Self-harm, Beliefs, Gender identity, Sexual relations) with name, short description, and on/off state per topic
+- **FR-003**: System MUST use toggle semantics where **on = topic blocked** (agent refuses and shows block message) and **off = topic allowed** (agent treats normally)
+- **FR-004**: System MUST initialize topic defaults by project type: all topics **on** for new projects, all topics **off** for existing projects, when no prior configuration exists
+- **FR-005**: System MUST apply new platform topics automatically with the same project-type default, without operator action to create, rename, or delete topics
+- **FR-006**: System MUST provide a single **Save** action in the drawer that persists topic states and block message together in one operation; turning blocking **off** MUST require confirmation via modal before the save request is sent
+- **FR-007**: System MUST show additional risk warnings in the confirmation modal when the operator turns blocking off for **all** topics
+- **FR-008**: System MUST support discarding unsaved edits: explicit cancel reverts without persisting; closing the drawer (overlay, close control, or ESC) discards silently with no confirmation prompt
+- **FR-009**: System MUST provide a single block message field per project, shared by all blocked topics, with a maximum of 240 characters
+- **FR-010**: System MUST display the platform default block message when the project has never customized the message
+- **FR-011**: System MUST prevent saving a block message that is empty, whitespace-only, or exceeds 240 characters, with clear validation feedback
+- **FR-012**: System MUST NOT offer per-agent guardrail configuration or per-topic block messages in this release
+- **FR-013**: System MUST read admin permission from a new field on `GET /api/users/details/` and enforce read-only access for users without admin permission: topic switches disabled, block message textarea disabled, save unavailable
+- **FR-014**: System MUST apply project-level configuration uniformly to all agents in the project's agent team via backend persistence (frontend consumes and reflects saved state)
+- **FR-015**: System MUST handle loading, empty, and error states for the configuration surface per product quality standards
+- **FR-016**: All user-facing copy MUST be localized in EN, PT-BR, ES, and RO following the VTEX Content Guide
+- **FR-017**: Operators MUST NOT be able to create, rename, delete, or reorder guardrail topics
+- **FR-018**: Load MUST call `GET /guardrails-config/` to populate the drawer (topics, blocked states, block message); save MUST call `PATCH /guardrails-config/` on the same resource with topic categories and block message in the same request body; partial per-field saves are NOT supported in the UI
+
+### Key Entities
+
+- **Guardrail topic**: A fixed sensitive subject from the platform catalog; attributes include identifier, display name, short description, and blocked state (on/off)
+- **Project guardrails configuration**: Project-scoped settings comprising per-topic blocked states and one block message; applies to all agents in the project
+- **Block message**: Single refusal text (≤ 240 characters) shown to end customers when any blocked topic is triggered; operator-customized or platform default
+- **Project type context**: Classification used only for initial defaults (new vs existing project) when no prior configuration exists
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Owner/admin operators can view and update all fixed guardrail topics and the block message without support or engineering intervention
+- **SC-002**: 100% of acceptance scenarios in this spec and the binding FDD pass in QA before release
+- **SC-003**: Users without admin permission cannot persist changes (verified by disabled switches, textarea, and save; permission sourced from `GET /api/users/details/`)
+- **SC-004**: Saving an invalid block message (empty, whitespace-only, or > 240 characters) is blocked in 100% of attempts with actionable feedback
+- **SC-005**: Turning blocking off for one or all topics always requires explicit confirmation; turning all topics off surfaces risk warnings before persistence
+- **SC-006**: After configuration save, agent behavior in customer conversations reflects the new settings for subsequent messages (no retroactive rewrite of past responses)
+- **SC-007**: Support tickets requesting guardrail topic or block-message changes decrease after release (tracked post-launch)
+
+## Assumptions
+
+- Backend Nexus exposes `GET /guardrails-config/` (load drawer: topics + block message) and `PATCH /guardrails-config/` (save) as the same project-scoped resource
+- AI model layer enforces refusal for blocked topics and injects the configured block message into the customer session per backend contract
+- "New project" vs "existing project" classification is determined by backend/platform rules and exposed to the frontend for default initialization
+- Admin edit permission is supplied by a new field on `GET /api/users/details/` (not inferred client-side from project role)
+- Block message customized by the operator is not auto-translated; UI copy (labels, modals, validation, section title/description) is localized in four languages per Figma intent
+- Concurrent edits use last-write-wins with no optimistic locking or merge UI in this release
+- Detailed change history/audit of guardrails configuration is out of scope for this release (planned P3)
+
+## Dependencies
+
+| Dependency | Owner | Impact on frontend |
+| --- | --- | --- |
+| Admin permission field on user details | Backend Nexus | New field on `GET /api/users/details/` gates disabled state for switches, textarea, and save |
+| Guardrails config API | Backend Nexus | `GET /guardrails-config/` loads drawer data (topics + message); `PATCH /guardrails-config/` saves both in one request body |
+| Topic refusal behavior | AI Models team | Frontend reflects saved config; does not implement refusal logic |
+| Project-level persistence and session message injection | Backend Nexus | Frontend calls API to load/save; block message delivery to customers is backend-owned |
+| UI localization (EN, PT-BR, ES, RO) | VTEX Localization / engineering | All new strings in four locale files before release |
+| Content Guide (240-char limit, tone) | VTEX Documentation | Block message and modal copy comply with guide |
+
+## Out of Scope (This Release)
+
+- Operator-created, edited, or deleted guardrail topics
+- Per-agent guardrail configuration
+- Different block messages per topic
+- Automatic translation of operator-customized block messages
+- Detailed configuration change history or audit trail (P3)

--- a/specs/001-project-guardrails-config/tasks.md
+++ b/specs/001-project-guardrails-config/tasks.md
@@ -1,0 +1,184 @@
+---
+description: "Task list for Project Safety Guardrails Configuration"
+---
+
+# Tasks: Project Safety Guardrails Configuration
+
+**Input**: Design documents from `/specs/001-project-guardrails-config/`
+
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/guardrails-config-api.md](./contracts/guardrails-config-api.md)
+
+**Organization**: Tasks grouped for human implementation (~1 PR per phase). Each task has a single clear deliverable with file paths.
+
+**API contract**: `GET /guardrails-config/` loads drawer data; `PATCH /guardrails-config/` saves (same resource).
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no blocking dependency)
+- **[Story]**: US1, US2, US3 per spec.md
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Scaffold folders and i18n namespace before implementation.
+
+- [ ] T001 Create `src/components/Instructions/SafetyGuardrails/` folder and `src/api/adapters/guardrails/` folder per plan.md structure
+- [ ] T002 [P] Add `agents.instructions.safety_guardrails` i18n keys (section, drawer, modals, validation) in `src/locales/en.json`, `src/locales/pt_br.json`, `src/locales/es.json`, and `src/locales/ro.json`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: API client, adapter, Pinia store, and admin permission — **must complete before UI stories**.
+
+**⚠️ CRITICAL**: No user story UI work until this phase is done.
+
+- [ ] T003 Implement `GET`/`PATCH` Nexus client in `src/api/nexus/Guardrails.js` targeting `api/${projectUuid}/guardrails-config/`
+- [ ] T004 Implement request/response mapping in `src/api/adapters/guardrails/guardrailsConfig.ts` (`blocked` ↔ toggle on, `block_message` field)
+- [ ] T005 Register Guardrails module on `src/api/nexusaiAPI.js`
+- [ ] T006 Implement `useGuardrailsStore` in `src/store/Guardrails.ts` (load via GET, draft snapshot, save via PATCH, status: loading/ready/error/saving)
+- [ ] T007 Extend `src/store/User.js` with `canEditGuardrails` computed from new `api/users/details/` field
+- [ ] T008 [P] Add adapter unit tests in `src/api/adapters/guardrails/__tests__/guardrailsConfig.spec.ts`
+- [ ] T009 [P] Add store unit tests in `src/store/__tests__/Guardrails.unit.spec.js` (load, draft, save, permission gating)
+
+**Checkpoint**: Store loads drawer data from `GET /guardrails-config/` and persists via `PATCH /guardrails-config/`
+
+---
+
+## Phase 3: User Story 1 — Manage guardrail topics (Priority: P1) 🎯 MVP
+
+**Goal**: Section on Instructions page, drawer with topic toggles, confirmation when turning blocking off, save/cancel/discard flows.
+
+**Independent Test**: Open Instructions → Safety guardrails section → **Configure** → `GET /guardrails-config/` → toggle topics → **Save** → confirmation when disabling → PATCH succeeds.
+
+### Implementation for User Story 1
+
+- [ ] T010 [US1] Build `SafetyGuardrailsSection.vue` in `src/components/Instructions/SafetyGuardrails/SafetyGuardrailsSection.vue` (Figma `7773:7142`: title, description, **Configure** button)
+- [ ] T011 [US1] Build drawer shell in `src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue` (`UnnnicDrawerNext`, Save/Cancel footer, open triggers store `load()` → GET)
+- [ ] T012 [US1] Build topic list in `src/components/Instructions/SafetyGuardrails/SafetyGuardrailsTopicList.vue` (switch on = blocked, disabled when `!canEditGuardrails`)
+- [ ] T013 [US1] Build confirmation modal in `src/components/Instructions/SafetyGuardrails/ModalConfirmDisableTopics.vue` (warn on any blocked→allowed; enhanced copy when all off)
+- [ ] T014 [US1] Mount section in `src/components/Instructions/InstructionsCategorization/index.vue` below `CategoriesView`/`ListView` and wire drawer open/close/save/cancel/discard-silent-close in store
+- [ ] T015 [P] [US1] Add component tests in `src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsSection.spec.js` and `SafetyGuardrailsDrawer.spec.js`
+
+**Checkpoint**: MVP — admin can view section, open drawer, toggle topics, confirm disable, save via PATCH
+
+---
+
+## Phase 4: User Story 2 — Configure block message (Priority: P2)
+
+**Goal**: Block message textarea in drawer with 240-char validation; persisted atomically with topics on Save.
+
+**Independent Test**: Open drawer → edit block message → save within limit succeeds; empty/over-limit blocked with feedback.
+
+### Implementation for User Story 2
+
+- [ ] T016 [US2] Build `SafetyGuardrailsBlockMessage.vue` in `src/components/Instructions/SafetyGuardrails/SafetyGuardrailsBlockMessage.vue` (textarea, char counter, show default from GET)
+- [ ] T017 [US2] Add block message validation and atomic PATCH payload in `src/store/Guardrails.ts` and `SafetyGuardrailsDrawer.vue` save flow (empty/whitespace/>240 blocked)
+- [ ] T018 [P] [US2] Add tests in `src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsBlockMessage.spec.js` and extend `Guardrails.unit.spec.js` for message validation
+
+**Checkpoint**: Block message edits persist with topics in single PATCH
+
+---
+
+## Phase 5: User Story 3 — Uniform project-level application (Priority: P1)
+
+**Goal**: Drawer reflects project-level config from API; defaults differ for new vs existing projects (no per-agent UI).
+
+**Independent Test**: Mock GET for new/existing project types → drawer shows correct default topic states and platform default message.
+
+### Implementation for User Story 3
+
+- [ ] T019 [US3] Ensure `src/store/Guardrails.ts` and drawer components render API-returned defaults without client-side override (new = all blocked, existing = all allowed, default message)
+- [ ] T020 [P] [US3] Add store tests in `src/store/__tests__/Guardrails.unit.spec.js` for new vs existing project GET response shapes per `contracts/guardrails-config-api.md`
+
+**Checkpoint**: First-open defaults match spec; no per-agent configuration surface exists
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Permissions, loading/error states, lint, manual validation.
+
+- [ ] T021 Enforce read-only mode (disabled switches, textarea, Save) for non-admin across `SafetyGuardrailsDrawer.vue` and child components using `useUserStore().canEditGuardrails`
+- [ ] T022 Add loading skeleton and error+retry states in `SafetyGuardrailsSection.vue` and `SafetyGuardrailsDrawer.vue` per FR-015
+- [ ] T023 Run `npm run lint` on touched files and execute Vitest suites for `Guardrails`, `guardrailsConfig`, and `SafetyGuardrails/__tests__/`
+- [ ] T024 Validate manually against `specs/001-project-guardrails-config/quickstart.md` checklist
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+```text
+Phase 1 (Setup) → Phase 2 (Foundational) → Phase 3 (US1) → Phase 4 (US2)
+                                         ↘ Phase 5 (US3) — after Phase 2, can parallel with Phase 3/4
+Phase 6 (Polish) — after Phases 3–5
+```
+
+### User Story Dependencies
+
+| Story | Depends on | Notes |
+| --- | --- | --- |
+| US1 (P1) | Foundational | MVP — section + drawer + topics |
+| US2 (P2) | US1 drawer shell | Block message lives inside same drawer |
+| US3 (P1) | Foundational | Defaults come from GET response; verify display |
+
+### Parallel Opportunities
+
+**After Phase 2 completes:**
+
+```bash
+# Developer A — US1 UI
+T010 → T011 → T012 → T013 → T014 → T015
+
+# Developer B — US2 (after T011 drawer exists)
+T016 → T017 → T018
+
+# Developer C — US3 verification (independent of UI polish)
+T019 → T020
+```
+
+**Within Phase 2:**
+
+```bash
+T008 + T009  # tests parallel after T003–T007
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1)
+
+1. Phase 1: Setup (T001–T002)
+2. Phase 2: Foundational (T003–T009)
+3. Phase 3: US1 (T010–T015)
+4. **STOP and VALIDATE** — topic toggles + save + disable confirmation
+
+### Incremental Delivery
+
+1. Setup + Foundational → data layer ready
+2. US1 → MVP demo (topics only, block message can show read-only initially)
+3. US2 → block message editing + validation
+4. US3 → defaults verification
+5. Polish → permissions, states, QA
+
+### Suggested PR slices
+
+| PR | Tasks | Scope |
+| --- | --- | --- |
+| PR1 | T001–T009 | API + store + tests |
+| PR2 | T010–T015 | US1 UI + MVP |
+| PR3 | T016–T018 | US2 block message |
+| PR4 | T019–T024 | US3 + polish |
+
+---
+
+## Notes
+
+- Toggle semantics: **on = blocked** (`blocked: true` in PATCH body)
+- Drawer close (overlay/X/ESC): silent discard — no confirmation modal
+- Do not split tasks further unless blocked; each phase is one human-sized chunk
+- Commit convention: `feat(guardrails): <description>`


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

Operators currently have no self-service way to control which sensitive topics AI agents may discuss with end customers, nor to customize the refusal message shown when a blocked topic is triggered. This requires support or engineering intervention for every guardrail adjustment. This spec introduces the full engineering design for a project-level Safety Guardrails configuration surface so that owner/admin operators can manage these settings independently.

### Summary of Changes

Adds the complete engineering specification for the `001-project-guardrails-config` feature under `specs/001-project-guardrails-config/`, covering:

- **`spec.md`**: Engineering spec binding the frontend implementation to the product FDD. Defines 18 functional requirements across three user stories — managing guardrail topics (P1), configuring the block message (P2), and ensuring uniform project-level application (P1). Includes governance rules, clarified session decisions, acceptance scenarios, edge cases, success criteria, assumptions, and dependencies.
- **`data-model.md`**: Defines `GuardrailTopic`, `GuardrailsConfig`, `GuardrailsDraft` (UI-only working copy), and `UserPermission` entities. Documents the store state machine (`idle → loading → ready/error → saving`), validation rules (240-char limit, required non-whitespace message, disable confirmation), and entity relationships.
- **`contracts/guardrails-config-api.md`**: API contract for `GET /api/{projectUuid}/guardrails-config/` (load drawer data) and `PATCH /api/{projectUuid}/guardrails-config/` (atomic save of topic states and block message). Also documents the new `can_edit_guardrails` field extension on `GET /api/users/details/` that gates edit controls.
- **`research.md`**: Documents eight architectural decisions — drawer pattern reuse (`UnnnicDrawerNext`), dedicated Pinia store (`useGuardrailsStore`), API layer placement (`api/nexus/Guardrails.js` + adapter), admin permission source, confirmation modal approach (`UnnnicDialog` on Save), section placement in `InstructionsCategorization`, i18n namespace (`agents.instructions.safety_guardrails.*`), and toggle semantics (`on = blocked: true`).
- **`plan.md`**: Four-phase implementation plan. Phase 1 covers the Nexus API client, adapter, and Pinia store. Phase 2 covers the section card and drawer UI for the happy path. Phase 3 covers confirmation modals, validation, read-only mode, and error/loading states. Phase 4 covers lint, test runs, and backend field name coordination.
- **`tasks.md`**: Twenty-four tasks organized across six phases with explicit parallel opportunities, PR slice suggestions (PR1: API + store; PR2: US1 UI; PR3: block message; PR4: defaults + polish), and an MVP-first delivery strategy.
- **`quickstart.md`**: Manual validation checklist covering section visibility, drawer load, topic toggle semantics, save confirmation flows, block message validation, permission enforcement, discard behavior, loading/error states, and i18n; plus the exact Vitest commands for the store, adapter, and component test suites.