### PR TITLE
feat: Enhance QuestionAndAnswer component with new props and styling

### DIFF
--- a/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/Message.vue
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/Message.vue
@@ -64,7 +64,13 @@ const props = defineProps({
   scheme: {
     type: String,
     default: 'neutral',
-    validator: (value) => ['neutral', 'success'].includes(value),
+    validator: (value) =>
+      [
+        'neutral',
+        'success',
+        'improvement-incoming',
+        'improvement-outgoing',
+      ].includes(value),
   },
 });
 
@@ -153,13 +159,29 @@ const treatedMessage = computed(() => {
   gap: $unnnic-space-2;
 
   &--neutral {
-    background-color: $unnnic-color-bg-soft;
+    background-color: $unnnic-color-bg-base-soft;
     color: $unnnic-color-fg-emphasized;
   }
 
   &--success {
-    background-color: $unnnic-color-fg-active;
-    color: $unnnic-color-fg-inverted;
+    background-color: $unnnic-color-fg-accent;
+    color: $unnnic-color-fg-on-primary;
+  }
+
+  &--improvement-incoming,
+  &--improvement-outgoing {
+    box-shadow: $unnnic-shadow-1;
+    font: $unnnic-font-caption-2;
+  }
+
+  &--improvement-incoming {
+    background-color: $unnnic-color-bg-base;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &--improvement-outgoing {
+    background-color: $unnnic-color-bg-accent-plain;
+    color: $unnnic-color-fg-emphasized;
   }
 
   .message__image {

--- a/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/__tests__/Message.spec.js
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/__tests__/Message.spec.js
@@ -42,6 +42,14 @@ describe('Message.vue', () => {
   });
 
   describe('Component rendering', () => {
+    it('renders with neutral scheme', () => {
+      createWrapper({ scheme: 'neutral' });
+
+      expect(
+        wrapper.find('.question-and-answer__message--neutral').exists(),
+      ).toBe(true);
+    });
+
     it('renders with success scheme', () => {
       createWrapper({ scheme: 'success' });
 
@@ -51,6 +59,26 @@ describe('Message.vue', () => {
       expect(
         wrapper.find('.question-and-answer__message--neutral').exists(),
       ).toBe(false);
+    });
+
+    it('renders with improvement-incoming scheme', () => {
+      createWrapper({ scheme: 'improvement-incoming' });
+
+      expect(
+        wrapper
+          .find('.question-and-answer__message--improvement-incoming')
+          .exists(),
+      ).toBe(true);
+    });
+
+    it('renders with improvement-outgoing scheme', () => {
+      createWrapper({ scheme: 'improvement-outgoing' });
+
+      expect(
+        wrapper
+          .find('.question-and-answer__message--improvement-outgoing')
+          .exists(),
+      ).toBe(true);
     });
 
     it('renders MessageDisplay when there is text content', () => {
@@ -329,16 +357,19 @@ describe('Message.vue', () => {
     });
 
     it('validates scheme prop correctly', () => {
-      // Test valid schemes
-      createWrapper({ scheme: 'neutral' });
-      expect(
-        wrapper.find('.question-and-answer__message--neutral').exists(),
-      ).toBe(true);
+      const schemes = [
+        'neutral',
+        'success',
+        'improvement-incoming',
+        'improvement-outgoing',
+      ];
 
-      createWrapper({ scheme: 'success' });
-      expect(
-        wrapper.find('.question-and-answer__message--success').exists(),
-      ).toBe(true);
+      schemes.forEach((scheme) => {
+        createWrapper({ scheme });
+        expect(
+          wrapper.find(`.question-and-answer__message--${scheme}`).exists(),
+        ).toBe(true);
+      });
     });
   });
 });

--- a/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/__tests__/index.spec.js
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/__tests__/index.spec.js
@@ -18,6 +18,7 @@ vi.mock('@/utils/formatters', () => ({
 }));
 
 const mockProcessLog = vi.mocked(processLog);
+const mockFormatTimestamp = vi.mocked(formatTimestamp);
 
 describe('QuestionAndAnswer index.vue', () => {
   let wrapper;
@@ -79,7 +80,8 @@ describe('QuestionAndAnswer index.vue', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockProcessLog.mockImplementation((log) => ({
+    mockFormatTimestamp.mockReturnValue('00/00/00 00:00');
+    mockProcessLog.mockImplementation(({ log }) => ({
       ...log,
       config: { currentAgent: 'test-agent' },
     }));
@@ -128,7 +130,7 @@ describe('QuestionAndAnswer index.vue', () => {
         expect(answerSection().exists()).toBe(false);
       });
 
-      it('passes correct props to user Message component', () => {
+      it('passes neutral scheme to user Message by default', () => {
         const userData = {
           id: 'user-message-1',
           type: 'user',
@@ -138,6 +140,36 @@ describe('QuestionAndAnswer index.vue', () => {
         createWrapper({ data: userData });
 
         expect(questionMessage().props('content')).toEqual(userData);
+        expect(questionMessage().props('scheme')).toBe('neutral');
+      });
+
+      it('renders question date when showDate is true', () => {
+        const mockDate = '2021-01-01T00:00:00Z';
+
+        createWrapper({
+          data: {
+            type: 'user',
+            text: 'User question',
+            created_at: mockDate,
+          },
+          showDate: true,
+        });
+
+        expect(questionDate().exists()).toBe(true);
+        expect(questionDate().text()).toBe(formatTimestamp(mockDate));
+      });
+
+      it('does not render question date when showDate is false', () => {
+        createWrapper({
+          data: {
+            type: 'user',
+            text: 'User question',
+            created_at: '2021-01-01T00:00:00Z',
+          },
+          showDate: false,
+        });
+
+        expect(questionDate().exists()).toBe(false);
       });
     });
 
@@ -166,7 +198,7 @@ describe('QuestionAndAnswer index.vue', () => {
         expect(answerMessages()).toHaveLength(1);
       });
 
-      it('passes success scheme to agent Message components', () => {
+      it('passes success scheme to agent Message by default', () => {
         createWrapper({
           data: {
             type: 'agent',
@@ -176,6 +208,100 @@ describe('QuestionAndAnswer index.vue', () => {
 
         expect(answerMessages()[0].props('scheme')).toBe('success');
       });
+
+      it('renders ViewLogsButton in agent messages when showViewLogs is true', () => {
+        createWrapper({
+          data: {
+            type: 'agent',
+            text: 'Agent response',
+          },
+          showViewLogs: true,
+        });
+
+        expect(viewLogsButton().exists()).toBe(true);
+      });
+
+      it('renders answer date when showDate is true', () => {
+        const mockDate = '2021-01-01T00:00:00Z';
+
+        createWrapper({
+          data: {
+            type: 'agent',
+            text: 'Agent response',
+            created_at: mockDate,
+          },
+          showDate: true,
+        });
+
+        expect(answerDate().exists()).toBe(true);
+        expect(answerDate().text()).toBe(formatTimestamp(mockDate));
+      });
+
+      it('does not render answer date when showDate is false', () => {
+        createWrapper({
+          data: {
+            type: 'agent',
+            text: 'Agent response',
+            created_at: '2021-01-01T00:00:00Z',
+          },
+          showDate: false,
+        });
+
+        expect(answerDate().exists()).toBe(false);
+      });
+
+      it('does not render ViewLogsButton when showViewLogs is false', () => {
+        createWrapper({
+          data: {
+            type: 'agent',
+            text: 'Agent response',
+          },
+          showViewLogs: false,
+        });
+
+        expect(viewLogsButton().exists()).toBe(false);
+      });
+
+      it('does not render answer footer when showDate and showViewLogs are false', () => {
+        createWrapper({
+          data: {
+            type: 'agent',
+            text: 'Agent response',
+          },
+          showDate: false,
+          showViewLogs: false,
+        });
+
+        expect(
+          wrapper.find('.question-and-answer__answer-text-footer').exists(),
+        ).toBe(false);
+      });
+    });
+  });
+
+  describe('Scheme prop', () => {
+    it('passes custom scheme to user Message', () => {
+      createWrapper({
+        data: {
+          type: 'user',
+          text: 'User question',
+        },
+        scheme: 'improvement-incoming',
+      });
+
+      expect(questionMessage().props('scheme')).toBe('improvement-incoming');
+    });
+
+    it('passes custom scheme to agent Message', () => {
+      createWrapper({
+        data: {
+          type: 'agent',
+          text: 'Agent response',
+        },
+        scheme: 'improvement-outgoing',
+      });
+
+      expect(answerMessages()[0].props('scheme')).toBe('improvement-outgoing');
     });
   });
 
@@ -243,22 +369,28 @@ describe('QuestionAndAnswer index.vue', () => {
       expect(answerMessages()).toHaveLength(1);
       expect(answerMessages()[0].props('content')).toEqual(originalData);
     });
+
+    it('renders ViewLogsButton on each agent message', () => {
+      const component1 = JSON.stringify({ msg: { text: 'First message' } });
+      const component2 = JSON.stringify({ msg: { text: 'Second message' } });
+      const textWithComponents = `${component1}\n\n${component2}`;
+
+      createWrapper({
+        data: {
+          type: 'agent',
+          text: textWithComponents,
+        },
+      });
+
+      expect(wrapper.findAll('[data-testid="view-logs-button"]')).toHaveLength(
+        2,
+      );
+    });
   });
 
   describe('Logs functionality', () => {
     beforeEach(() => {
       mockSupervisorStore.loadLogs = vi.fn();
-    });
-
-    it('renders ViewLogsButton in agent messages', () => {
-      createWrapper({
-        data: {
-          type: 'agent',
-          text: 'Agent response',
-        },
-      });
-
-      expect(viewLogsButton().exists()).toBe(true);
     });
 
     it('passes correct initial props to ViewLogsButton', () => {
@@ -317,7 +449,7 @@ describe('QuestionAndAnswer index.vue', () => {
       });
 
       it('shows loading state while loading logs', async () => {
-        mockSupervisorStore.loadLogs = vi.fn();
+        mockSupervisorStore.loadLogs.mockReturnValue(new Promise(() => {}));
 
         createWrapper({
           data: {
@@ -331,11 +463,6 @@ describe('QuestionAndAnswer index.vue', () => {
 
         expect(viewLogsButton().props('loading')).toBe(true);
         expect(viewLogsButton().props('disabled')).toBe(true);
-
-        await nextTick();
-
-        expect(viewLogsButton().props('loading')).toBe(false);
-        expect(viewLogsButton().props('disabled')).toBe(false);
       });
 
       it('shows PreviewLogs after successful load', async () => {
@@ -463,34 +590,6 @@ describe('QuestionAndAnswer index.vue', () => {
 
         resolveLoadLogs([]);
         await nextTick();
-      });
-    });
-
-    describe('Message date formatting', () => {
-      it('formats the question date correctly', () => {
-        const mockDate = '2021-01-01T00:00:00Z';
-        createWrapper({
-          data: {
-            type: 'user',
-            text: 'User question',
-            created_at: mockDate,
-          },
-        });
-
-        expect(questionDate().text()).toBe(formatTimestamp(mockDate));
-      });
-
-      it('formats the answer date correctly', () => {
-        const mockDate = '2021-01-01T00:00:00Z';
-        createWrapper({
-          data: {
-            type: 'agent',
-            text: 'Agent response',
-            created_at: mockDate,
-          },
-        });
-
-        expect(answerDate().text()).toBe(formatTimestamp(mockDate));
       });
     });
   });

--- a/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/index.vue
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/index.vue
@@ -28,12 +28,13 @@
         v-if="data?.type === 'user'"
         class="question-and-answer__question"
       >
-        <AvatarLetter :text="data?.username" />
         <Message
           data-testid="question"
+          :scheme="scheme || 'neutral'"
           :content="data"
         >
           <p
+            v-if="showDate"
             class="question-and-answer__question-date"
             data-testid="question-date"
           >
@@ -48,7 +49,7 @@
         data-testid="answer"
       >
         <PreviewLogs
-          v-if="showLogs"
+          v-if="showViewLogs && showLogs"
           :logs="logs"
           logsSide="right"
           data-testid="preview-logs"
@@ -60,17 +61,22 @@
           class="question-and-answer__answer-text"
           data-testid="answer-text"
           :content="content"
-          scheme="success"
+          :scheme="scheme || 'success'"
         >
-          <footer class="question-and-answer__answer-text-footer">
+          <footer
+            v-if="showDate || showViewLogs"
+            class="question-and-answer__answer-text-footer"
+          >
             <p
+              v-if="showDate"
               class="question-and-answer__answer-date"
               data-testid="answer-date"
             >
-              {{ formatTimestamp(content?.created_at) }}
+              {{ formatTimestamp(data.created_at) }}
             </p>
 
             <ViewLogsButton
+              v-if="showViewLogs"
               :disabled="loadingLogs"
               :loading="loadingLogs"
               :active="showLogs"
@@ -94,7 +100,6 @@ import { formatTimestamp } from '@/utils/formatters';
 import Message from './Message.vue';
 import PreviewLogs from '@/components/Preview/PreviewLogs.vue';
 import ForwardedHumanSupport from './ConversationStartFinish.vue';
-import AvatarLetter from '@/components/Supervisor/AvatarLetter.vue';
 import ViewLogsButton from './ViewLogsButton.vue';
 import { processLog } from '@/utils/previewLogs';
 
@@ -106,6 +111,25 @@ const props = defineProps({
   data: {
     type: Object,
     required: true,
+  },
+  scheme: {
+    type: String,
+    default: '',
+    validator: (value) =>
+      [
+        'neutral',
+        'success',
+        'improvement-incoming',
+        'improvement-outgoing',
+      ].includes(value),
+  },
+  showViewLogs: {
+    type: Boolean,
+    default: true,
+  },
+  showDate: {
+    type: Boolean,
+    default: true,
   },
 });
 
@@ -201,7 +225,7 @@ watch(
 
 <style lang="scss" scoped>
 .question-and-answer {
-  margin-bottom: $unnnic-spacing-xs;
+  margin-bottom: $unnnic-space-2;
 
   display: grid;
   grid-template-columns: repeat(3, 1fr);
@@ -241,8 +265,6 @@ watch(
     &-text {
       justify-self: flex-end;
       padding: $unnnic-spacing-ant;
-      background-color: $unnnic-color-weni-600;
-      color: $unnnic-color-neutral-white;
 
       &-footer {
         display: flex;


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [x] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The `Message` and `QuestionAndAnswer` components needed more flexibility to support additional visual schemes for displaying conversation improvements, as well as finer control over which UI elements (dates, logs button) are rendered.

### Summary of Changes

- Added two new scheme variants to the `Message` component: `improvement-incoming` and `improvement-outgoing`, each with distinct styles including box shadow and caption font.
- Updated color tokens for the `neutral` and `success` schemes to align with the current design system (`$unnnic-color-bg-base-soft`, `$unnnic-color-fg-accent`, `$unnnic-color-fg-on-primary`).
- Added `scheme`, `showViewLogs`, and `showDate` props to the `QuestionAndAnswer` component, allowing consumers to control the message appearance and conditionally render the date and view logs button.
- The `scheme` prop is now passed down from `QuestionAndAnswer` to its inner `Message` components, falling back to `neutral` for user messages and `success` for agent messages when not provided.
- `PreviewLogs` is now conditionally rendered based on both `showViewLogs` and `showLogs`.
- Removed the `AvatarLetter` component from the question section.
- Removed hardcoded background and text color styles from the answer text container, delegating styling entirely to the `scheme` prop.
- Expanded test coverage to include rendering with `neutral`, `improvement-incoming`, and `improvement-outgoing` schemes, `showDate` and `showViewLogs` prop behavior, custom scheme propagation, and per-message `ViewLogsButton` rendering.
- Refactored existing tests to use a loop-based scheme validation approach and moved date formatting tests to more appropriate describe blocks.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/4ea0b5d5-8c33-4032-b66f-c27435846cd4.png)

![image.png](https://app.graphite.com/user-attachments/assets/88cff846-0c94-4b0a-abd5-838bc98a30aa.png)



