### PR TITLE
feat: Introduce Affected Conversations feature with API integration and UI components

### DIFF
--- a/src/api/adapters/supervisor/__tests__/affectedConversations.spec.ts
+++ b/src/api/adapters/supervisor/__tests__/affectedConversations.spec.ts
@@ -1,0 +1,169 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  AffectedConversationsAdapter,
+  mapMessageToQuestionAndAnswer,
+} from '../affectedConversations';
+
+describe('Supervisor affected conversations adapter', () => {
+  describe('fromApi', () => {
+    it('transforms API data to frontend format', () => {
+      const result = AffectedConversationsAdapter.fromApi({
+        count: 25,
+        results: [
+          {
+            uuid: 'conversation-uuid-1',
+            contact_urn: 'whatsapp:5511999999999',
+            contact_name: 'Alessandra',
+            messages: [
+              {
+                uuid: 'message-uuid-1',
+                id: '1',
+                text: 'Do you deliver to my ZIP code?',
+                source: 'incoming',
+                created_at: '2026-06-23T09:44:26-03:00',
+              },
+              {
+                uuid: 'message-uuid-2',
+                id: '2',
+                text: 'I need your CPF first.',
+                source: 'outgoing',
+                created_at: '2026-06-23T09:45:00-03:00',
+              },
+            ],
+          },
+        ],
+      });
+
+      expect(result).toEqual({
+        count: 25,
+        results: [
+          {
+            uuid: 'conversation-uuid-1',
+            contactUrn: 'whatsapp:5511999999999',
+            contactName: 'Alessandra',
+            messages: [
+              {
+                uuid: 'message-uuid-1',
+                id: '1',
+                text: 'Do you deliver to my ZIP code?',
+                source: 'incoming',
+                createdAt: '2026-06-23T09:44:26-03:00',
+              },
+              {
+                uuid: 'message-uuid-2',
+                id: '2',
+                text: 'I need your CPF first.',
+                source: 'outgoing',
+                createdAt: '2026-06-23T09:45:00-03:00',
+              },
+            ],
+          },
+        ],
+      });
+    });
+
+    it('returns safe defaults when API fields are missing', () => {
+      expect(AffectedConversationsAdapter.fromApi()).toEqual({
+        count: 0,
+        results: [],
+      });
+    });
+
+    it('filters conversations and messages with invalid or incomplete data', () => {
+      const result = AffectedConversationsAdapter.fromApi({
+        count: 2,
+        results: [
+          {
+            uuid: 'valid-uuid',
+            contact_urn: 'whatsapp:5511999999999',
+            contact_name: 'Renata',
+            messages: [
+              {
+                uuid: 'msg-1',
+                id: '1',
+                text: 'Hello',
+                source: 'incoming',
+                created_at: '2026-06-23T09:44:26-03:00',
+              },
+              {
+                uuid: 'msg-2',
+                id: '2',
+                text: 'Invalid source',
+                source: 'unknown',
+                created_at: '2026-06-23T09:45:00-03:00',
+              },
+            ],
+          },
+          {
+            uuid: 'missing-urn',
+            contact_name: 'Julian',
+          },
+        ],
+      });
+
+      expect(result.results).toEqual([
+        {
+          uuid: 'valid-uuid',
+          contactUrn: 'whatsapp:5511999999999',
+          contactName: 'Renata',
+          messages: [
+            {
+              uuid: 'msg-1',
+              id: '1',
+              text: 'Hello',
+              source: 'incoming',
+              createdAt: '2026-06-23T09:44:26-03:00',
+            },
+          ],
+        },
+      ]);
+    });
+  });
+
+  describe('mapMessageToQuestionAndAnswer', () => {
+    it('maps incoming messages to user type', () => {
+      expect(
+        mapMessageToQuestionAndAnswer(
+          {
+            uuid: 'message-uuid-1',
+            id: '1',
+            text: 'Hello',
+            source: 'incoming',
+            createdAt: '2026-06-23T09:44:26-03:00',
+          },
+          'Alessandra',
+        ),
+      ).toEqual({
+        id: '1',
+        uuid: 'message-uuid-1',
+        text: 'Hello',
+        type: 'user',
+        createdAt: '2026-06-23T09:44:26-03:00',
+        username: 'Alessandra',
+      });
+    });
+
+    it('maps outgoing messages to agent type', () => {
+      expect(
+        mapMessageToQuestionAndAnswer(
+          {
+            uuid: 'message-uuid-2',
+            id: '2',
+            text: 'Hi there',
+            source: 'outgoing',
+            createdAt: '2026-06-23T09:45:00-03:00',
+          },
+          'Alessandra',
+        ),
+      ).toEqual({
+        id: '2',
+        uuid: 'message-uuid-2',
+        text: 'Hi there',
+        type: 'agent',
+        createdAt: '2026-06-23T09:45:00-03:00',
+        username: 'Alessandra',
+      });
+    });
+  });
+});

--- a/src/api/adapters/supervisor/affectedConversations.ts
+++ b/src/api/adapters/supervisor/affectedConversations.ts
@@ -1,0 +1,92 @@
+import type {
+  AffectedConversation,
+  AffectedConversationMessage,
+  AffectedConversationMessageSource,
+  AffectedConversationsResponse,
+} from '@/store/types/Improvements.types';
+
+export interface AffectedConversationMessageApi {
+  uuid?: string;
+  id?: string;
+  text?: string;
+  source?: string;
+  created_at?: string;
+}
+
+export interface AffectedConversationApi {
+  uuid?: string;
+  contact_urn?: string;
+  contact_name?: string;
+  messages?: AffectedConversationMessageApi[];
+}
+
+export interface AffectedConversationsApi {
+  count?: number;
+  results?: AffectedConversationApi[];
+}
+
+function isMessageSource(
+  value: unknown,
+): value is AffectedConversationMessageSource {
+  return value === 'incoming' || value === 'outgoing';
+}
+
+function parseMessage(
+  item: AffectedConversationMessageApi = {},
+): AffectedConversationMessage | null {
+  if (!item.uuid || !item.id || !item.text || !isMessageSource(item.source)) {
+    return null;
+  }
+
+  return {
+    uuid: item.uuid,
+    id: item.id,
+    text: item.text,
+    source: item.source,
+    createdAt: item.created_at ?? '',
+  };
+}
+
+function parseConversation(
+  item: AffectedConversationApi = {},
+): AffectedConversation | null {
+  if (!item.uuid || !item.contact_urn) return null;
+
+  return {
+    uuid: item.uuid,
+    contactUrn: item.contact_urn,
+    contactName: item.contact_name ?? '',
+    messages: (item.messages ?? [])
+      .map(parseMessage)
+      .filter(
+        (message): message is AffectedConversationMessage => message !== null,
+      ),
+  };
+}
+
+export function mapMessageToQuestionAndAnswer(
+  message: AffectedConversationMessage,
+  username: string,
+) {
+  return {
+    id: message.id,
+    uuid: message.uuid,
+    text: message.text,
+    type: message.source === 'incoming' ? 'user' : 'agent',
+    createdAt: message.createdAt,
+    username,
+  };
+}
+
+export const AffectedConversationsAdapter = {
+  fromApi(
+    apiData: AffectedConversationsApi = {},
+  ): AffectedConversationsResponse {
+    return {
+      count: Number(apiData.count) || 0,
+      results: (apiData.results ?? [])
+        .map(parseConversation)
+        .filter((item): item is AffectedConversation => item !== null),
+    };
+  },
+};

--- a/src/api/adapters/supervisor/conversationMessage.ts
+++ b/src/api/adapters/supervisor/conversationMessage.ts
@@ -12,7 +12,7 @@ interface ConversationMessage {
   uuid: string;
   text: string;
   type: 'user' | 'agent';
-  created_at: string;
+  createdAt: string;
 }
 
 interface ConversationMessagesResponseV2 {
@@ -65,7 +65,7 @@ export const ConversationMessageAdapter = {
       text: result.text,
       type:
         result.source_type || (result.source === 'incoming' ? 'user' : 'agent'),
-      created_at: result.created_at,
+      createdAt: result.created_at,
     }));
 
     return { results, next };

--- a/src/api/nexus/Supervisor.js
+++ b/src/api/nexus/Supervisor.js
@@ -3,6 +3,7 @@ import conversationsRequest from '../conversationsRequest';
 import { fetchConversationList } from '../adapters/supervisor/conversationSources';
 import { ConversationMessageAdapter } from '../adapters/supervisor/conversationMessage';
 import { ImprovementsAdapter } from '../adapters/supervisor/improvements';
+import { AffectedConversationsAdapter } from '../adapters/supervisor/affectedConversations';
 
 export const Supervisor = {
   conversations: {
@@ -103,6 +104,20 @@ export const Supervisor = {
       }
 
       return detail;
+    },
+
+    async getAffectedConversations({
+      projectUuid,
+      improvementUuid,
+      page = 1,
+      pageSize = 10,
+    }) {
+      const { data } = await conversationsRequest.$http.get(
+        `/api/v1/projects/${projectUuid}/improvements/${improvementUuid}/affected_conversations`,
+        { params: { page, page_size: pageSize } },
+      );
+
+      return AffectedConversationsAdapter.fromApi(data);
     },
   },
 };

--- a/src/api/nexus/__tests__/Supervisor.spec.js
+++ b/src/api/nexus/__tests__/Supervisor.spec.js
@@ -118,14 +118,14 @@ describe('Supervisor.js', () => {
         uuid: 'msg-1',
         text: 'Hello',
         type: 'user',
-        created_at: '2023-01-15T12:30:00Z',
+        createdAt: '2023-01-15T12:30:00Z',
       });
       expect(result.results[1]).toMatchObject({
         id: 2,
         uuid: 'msg-2',
         text: 'Hi there!',
         type: 'agent',
-        created_at: '2023-01-15T12:31:00Z',
+        createdAt: '2023-01-15T12:31:00Z',
       });
       expect(result.next).toBeNull();
     });
@@ -201,7 +201,7 @@ describe('Supervisor.js', () => {
         uuid: 'msg-1',
         text: 'Hello',
         type: 'user',
-        created_at: '2023-01-15T12:30:00Z',
+        createdAt: '2023-01-15T12:30:00Z',
       });
       expect(result.next).toBeNull();
     });
@@ -367,6 +367,65 @@ describe('Supervisor.js', () => {
           improvementUuid: 'improvement-uuid-1',
         }),
       ).rejects.toThrow('API Error');
+    });
+
+    it('getAffectedConversations calls the endpoint and adapts the response', async () => {
+      const mockAffectedConversationsResponse = {
+        count: 25,
+        next: 'https://api.example.com/page=2',
+        previous: null,
+        results: [
+          {
+            uuid: 'conversation-uuid-1',
+            contact_urn: 'whatsapp:5511999999999',
+            contact_name: 'Alessandra',
+            messages: [
+              {
+                uuid: 'message-uuid-1',
+                id: '1',
+                text: 'Hello',
+                source: 'incoming',
+                created_at: '2026-06-23T09:44:26-03:00',
+              },
+            ],
+          },
+        ],
+      };
+
+      conversationsRequest.$http.get.mockResolvedValue({
+        data: mockAffectedConversationsResponse,
+      });
+
+      const result = await Supervisor.improvements.getAffectedConversations({
+        projectUuid,
+        improvementUuid: 'improvement-uuid-1',
+        page: 2,
+        pageSize: 10,
+      });
+
+      expect(conversationsRequest.$http.get).toHaveBeenCalledWith(
+        `/api/v1/projects/${projectUuid}/improvements/improvement-uuid-1/affected_conversations`,
+        { params: { page: 2, page_size: 10 } },
+      );
+      expect(result).toEqual({
+        count: 25,
+        results: [
+          {
+            uuid: 'conversation-uuid-1',
+            contactUrn: 'whatsapp:5511999999999',
+            contactName: 'Alessandra',
+            messages: [
+              {
+                uuid: 'message-uuid-1',
+                id: '1',
+                text: 'Hello',
+                source: 'incoming',
+                createdAt: '2026-06-23T09:44:26-03:00',
+              },
+            ],
+          },
+        ],
+      });
     });
   });
 });

--- a/src/components/ConversationsImprovements/DrawerDetails/AffectedConversationItem.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/AffectedConversationItem.vue
@@ -1,0 +1,159 @@
+<template>
+  <section
+    class="affected-conversation-item"
+    :class="{
+      'affected-conversation-item--expanded': isExpanded,
+      'affected-conversation-item--first': isFirst,
+      'affected-conversation-item--last': isLast,
+    }"
+    :data-testid="`affected-conversation-item-${conversation.uuid}`"
+  >
+    <button
+      class="affected-conversation-item__header"
+      type="button"
+      :data-testid="`affected-conversation-item-toggle-${conversation.uuid}`"
+      @click="emit('toggle')"
+    >
+      <UnnnicIcon
+        :icon="isExpanded ? 'keyboard_arrow_down' : 'chevron_forward'"
+        size="ant"
+        scheme="fg-emphasized"
+        :data-testid="`affected-conversation-item-icon-${conversation.uuid}`"
+      />
+
+      <p
+        class="affected-conversation-item__label"
+        :data-testid="`affected-conversation-item-label-${conversation.uuid}`"
+      >
+        {{ contactLabel }}
+      </p>
+    </button>
+
+    <section
+      v-if="isExpanded"
+      class="affected-conversation-item__content"
+      :data-testid="`affected-conversation-item-content-${conversation.uuid}`"
+    >
+      <section class="affected-conversation-item__messages">
+        <QuestionAndAnswer
+          v-for="message in conversation.messages"
+          :key="message.uuid"
+          :data="
+            mapMessageToQuestionAndAnswer(message, conversation.contactName)
+          "
+          :isLoading="false"
+          :showViewLogs="false"
+          :showDate="false"
+          :scheme="questionAndAnswerScheme(message)"
+          :data-testid="`affected-conversation-item-message-${conversation.uuid}`"
+        />
+      </section>
+
+      <UnnnicButton
+        class="affected-conversation-item__view-full-button"
+        type="secondary"
+        size="small"
+        :text="$t('audit.improvements.drawer.view_full_conversation')"
+        :data-testid="`affected-conversation-item-view-full-${conversation.uuid}`"
+        @click="emit('view-full')"
+      />
+    </section>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+
+import { mapMessageToQuestionAndAnswer } from '@/api/adapters/supervisor/affectedConversations';
+
+import QuestionAndAnswer from '@/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/index.vue';
+
+import type {
+  AffectedConversation,
+  AffectedConversationMessage,
+} from '@/store/types/Improvements.types';
+
+const props = defineProps<{
+  conversation: AffectedConversation;
+  isExpanded: boolean;
+  isFirst: boolean;
+  isLast: boolean;
+}>();
+
+const emit = defineEmits<{
+  toggle: [];
+  'view-full': [];
+}>();
+
+const contactLabel = computed(
+  () => props.conversation.contactName || props.conversation.contactUrn,
+);
+
+const questionAndAnswerScheme = (message: AffectedConversationMessage) => {
+  return message.source === 'incoming'
+    ? 'improvement-incoming'
+    : 'improvement-outgoing';
+};
+</script>
+
+<style scoped lang="scss">
+.affected-conversation-item {
+  border: 1px solid $unnnic-color-border-soft;
+  margin-bottom: -1px;
+
+  &--first {
+    border-top-left-radius: $unnnic-radius-2;
+    border-top-right-radius: $unnnic-radius-2;
+  }
+
+  &--last {
+    border-bottom-left-radius: $unnnic-radius-2;
+    border-bottom-right-radius: $unnnic-radius-2;
+  }
+
+  &__header {
+    width: 100%;
+    padding: $unnnic-space-3 $unnnic-space-4;
+
+    display: flex;
+    align-items: center;
+    gap: $unnnic-space-2;
+
+    text-align: left;
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+
+  &--expanded &__header {
+    padding-bottom: $unnnic-space-2;
+  }
+
+  &__label {
+    @include unnnic-font-action;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__content {
+    padding: 0 $unnnic-space-4 $unnnic-space-4;
+
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+  }
+
+  &__messages {
+    background-color: $unnnic-color-bg-base-soft;
+    border-radius: $unnnic-radius-2;
+    padding: $unnnic-space-4;
+
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+  }
+
+  &__view-full-button {
+    align-self: flex-start;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/DrawerDetails/AffectedConversationsSection.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/AffectedConversationsSection.vue
@@ -1,0 +1,167 @@
+<template>
+  <ImprovementDrawerSection
+    testId="affected-conversations"
+    :title="$t('audit.improvements.drawer.affected_conversations_title')"
+  >
+    <template v-if="status === 'loading'">
+      <UnnnicSkeletonLoading
+        v-for="index in 3"
+        :key="index"
+        tag="div"
+        width="100%"
+        height="42px"
+        :data-testid="`affected-conversations-skeleton-${index}`"
+      />
+    </template>
+
+    <template v-else>
+      <section
+        class="affected-conversations-section__list"
+        data-testid="affected-conversations-list"
+      >
+        <AffectedConversationItem
+          v-for="(conversation, index) in results"
+          :key="conversation.uuid"
+          :conversation="conversation"
+          :isExpanded="expandedConversationUuid === conversation.uuid"
+          :isFirst="index === 0"
+          :isLast="index === results.length - 1"
+          @toggle="handleToggle(conversation.uuid)"
+          @view-full="handleViewFullConversation(conversation)"
+        />
+      </section>
+    </template>
+
+    <UnnnicPagination
+      class="affected-conversations-section__pagination"
+      data-testid="affected-conversations-pagination"
+      :disabled="status === 'loading'"
+      :max="pageLimit"
+      :modelValue="page"
+      @update:model-value="handlePageUpdate"
+    />
+  </ImprovementDrawerSection>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useRoute, useRouter } from 'vue-router';
+import { storeToRefs } from 'pinia';
+
+import {
+  AFFECTED_CONVERSATIONS_PAGE_SIZE,
+  useImprovementsStore,
+} from '@/store/Improvements';
+import { useSupervisorStore } from '@/store/Supervisor';
+
+import ImprovementDrawerSection from './ImprovementDrawerSection.vue';
+import AffectedConversationItem from './AffectedConversationItem.vue';
+
+import type { AffectedConversation } from '@/store/types/Improvements.types';
+
+const props = defineProps<{
+  open: boolean;
+  improvementUuid: string | null;
+}>();
+
+const emit = defineEmits<{
+  'close-drawer': [];
+}>();
+
+const route = useRoute();
+const router = useRouter();
+const improvementsStore = useImprovementsStore();
+const supervisorStore = useSupervisorStore();
+
+const { affectedConversations } = storeToRefs(improvementsStore);
+
+const expandedConversationUuid = ref<string | null>(null);
+
+const status = computed(() => affectedConversations.value.status);
+const page = computed(() => affectedConversations.value.page);
+const count = computed(() => affectedConversations.value.data.count);
+const results = computed(() => affectedConversations.value.data.results);
+const pageLimit = computed(() =>
+  Math.ceil(count.value / AFFECTED_CONVERSATIONS_PAGE_SIZE),
+);
+
+function resetExpandedConversation() {
+  expandedConversationUuid.value = results.value[0]?.uuid ?? null;
+}
+
+function fetchConversations(pageNumber = 1) {
+  if (!props.improvementUuid) return;
+
+  improvementsStore.fetchAffectedConversations(
+    props.improvementUuid,
+    pageNumber,
+  );
+}
+
+function handleToggle(conversationUuid: string) {
+  expandedConversationUuid.value =
+    expandedConversationUuid.value === conversationUuid
+      ? null
+      : conversationUuid;
+}
+
+function handlePageUpdate(newPage: number) {
+  fetchConversations(newPage);
+}
+
+async function handleViewFullConversation(conversation: AffectedConversation) {
+  supervisorStore.selectedConversation = {
+    uuid: conversation.uuid,
+    urn: conversation.contactUrn,
+    username: conversation.contactName,
+    source: 'v2',
+    data: { status: null },
+  };
+
+  emit('close-drawer');
+
+  await router.replace({
+    name: 'conversations',
+  });
+
+  supervisorStore.queryConversationUuid = conversation.uuid;
+}
+
+watch(
+  () => [props.open, props.improvementUuid] as const,
+  ([open, improvementUuid]) => {
+    if (open && improvementUuid) {
+      fetchConversations(1);
+      return;
+    }
+
+    if (!open) {
+      improvementsStore.resetAffectedConversations();
+      expandedConversationUuid.value = null;
+    }
+  },
+  { immediate: true },
+);
+
+watch(
+  () => affectedConversations.value.status,
+  (newStatus, oldStatus) => {
+    if (newStatus === 'complete' && oldStatus === 'loading') {
+      resetExpandedConversation();
+    }
+  },
+);
+</script>
+
+<style scoped lang="scss">
+.affected-conversations-section {
+  &__list {
+    display: flex;
+    flex-direction: column;
+  }
+
+  &__pagination {
+    margin-top: $unnnic-space-4;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/DrawerDetails/ImprovementDrawer.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/ImprovementDrawer.vue
@@ -45,9 +45,10 @@
 
         <SuggestedSolutionSection />
 
-        <ImprovementDrawerSection
-          testId="affected-conversations"
-          :title="$t('audit.improvements.drawer.affected_conversations_title')"
+        <AffectedConversationsSection
+          :open="drawerOpen"
+          :improvementUuid="improvement?.uuid ?? null"
+          @close-drawer="drawerOpen = false"
         />
       </section>
 
@@ -85,6 +86,7 @@ import { getImprovementTypeTag } from '@/utils/improvements/getImprovementTypeTa
 
 import ImprovementStatusDialog from './ImprovementStatusDialog.vue';
 import SuggestedSolutionSection from './SuggestedSolutionSection.vue';
+import AffectedConversationsSection from './AffectedConversationsSection.vue';
 import ImprovementDrawerSection from './ImprovementDrawerSection.vue';
 
 import type {

--- a/src/components/ConversationsImprovements/DrawerDetails/__tests__/AffectedConversationItem.spec.js
+++ b/src/components/ConversationsImprovements/DrawerDetails/__tests__/AffectedConversationItem.spec.js
@@ -1,0 +1,165 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+
+import AffectedConversationItem from '../AffectedConversationItem.vue';
+import QuestionAndAnswer from '@/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/index.vue';
+
+describe('AffectedConversationItem.vue', () => {
+  let wrapper;
+
+  const baseConversation = {
+    uuid: 'conversation-uuid-1',
+    contactUrn: 'whatsapp:5511999999999',
+    contactName: 'Alessandra',
+    messages: [
+      {
+        uuid: 'message-uuid-1',
+        id: '1',
+        text: 'Do you deliver to my ZIP code?',
+        source: 'incoming',
+        createdAt: '2026-06-23T09:44:26-03:00',
+      },
+      {
+        uuid: 'message-uuid-2',
+        id: '2',
+        text: 'I need your CPF first.',
+        source: 'outgoing',
+        createdAt: '2026-06-23T09:45:00-03:00',
+      },
+    ],
+  };
+
+  const createWrapper = (props = {}) => {
+    wrapper = mount(AffectedConversationItem, {
+      props: {
+        conversation: baseConversation,
+        isExpanded: false,
+        isFirst: true,
+        isLast: false,
+        ...props,
+      },
+      global: {
+        plugins: [createTestingPinia()],
+      },
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  const elements = {
+    label: () =>
+      wrapper.find(
+        '[data-testid="affected-conversation-item-label-conversation-uuid-1"]',
+      ),
+    icon: () =>
+      wrapper.findComponent(
+        '[data-testid="affected-conversation-item-icon-conversation-uuid-1"]',
+      ),
+    toggle: () =>
+      wrapper.find(
+        '[data-testid="affected-conversation-item-toggle-conversation-uuid-1"]',
+      ),
+    content: () =>
+      wrapper.find(
+        '[data-testid="affected-conversation-item-content-conversation-uuid-1"]',
+      ),
+    questionAndAnswerMessages: () =>
+      wrapper.findAllComponents(QuestionAndAnswer),
+    viewFullButton: () =>
+      wrapper.findComponent(
+        '[data-testid="affected-conversation-item-view-full-conversation-uuid-1"]',
+      ),
+  };
+
+  it('renders the contact name as the row label', () => {
+    createWrapper();
+
+    expect(elements.label().text()).toBe('Alessandra');
+  });
+
+  it('falls back to contact urn when contact name is empty', () => {
+    createWrapper({
+      conversation: {
+        ...baseConversation,
+        contactName: '',
+      },
+    });
+
+    expect(elements.label().text()).toBe('whatsapp:5511999999999');
+  });
+
+  it('renders chevron_forward when collapsed', () => {
+    createWrapper({ isExpanded: false });
+
+    expect(elements.icon().props('icon')).toBe('chevron_forward');
+    expect(elements.content().exists()).toBe(false);
+  });
+
+  it('renders QuestionAndAnswer messages and view full button when expanded', () => {
+    createWrapper({ isExpanded: true });
+
+    const messages = elements.questionAndAnswerMessages();
+
+    expect(elements.icon().props('icon')).toBe('keyboard_arrow_down');
+    expect(elements.content().exists()).toBe(true);
+    expect(messages).toHaveLength(2);
+    expect(messages[0].props('data')).toEqual({
+      id: '1',
+      uuid: 'message-uuid-1',
+      text: 'Do you deliver to my ZIP code?',
+      type: 'user',
+      createdAt: '2026-06-23T09:44:26-03:00',
+      username: 'Alessandra',
+    });
+    expect(messages[1].props('data')).toEqual({
+      id: '2',
+      uuid: 'message-uuid-2',
+      text: 'I need your CPF first.',
+      type: 'agent',
+      createdAt: '2026-06-23T09:45:00-03:00',
+      username: 'Alessandra',
+    });
+    expect(
+      messages.every((message) => message.props('isLoading') === false),
+    ).toBe(true);
+    expect(
+      messages.every((message) => message.props('showViewLogs') === false),
+    ).toBe(true);
+    expect(
+      messages.every((message) => message.props('showDate') === false),
+    ).toBe(true);
+    expect(messages[0].props('scheme')).toBe('improvement-incoming');
+    expect(messages[1].props('scheme')).toBe('improvement-outgoing');
+    expect(wrapper.find('[data-testid="view-logs-button"]').exists()).toBe(
+      false,
+    );
+    expect(elements.viewFullButton().props('text')).toBe(
+      i18n.global.t('audit.improvements.drawer.view_full_conversation'),
+    );
+  });
+
+  it('emits toggle when the header is clicked', async () => {
+    createWrapper();
+
+    await elements.toggle().trigger('click');
+
+    expect(wrapper.emitted('toggle')).toEqual([[]]);
+  });
+
+  it('emits view-full when the view full button is clicked', async () => {
+    createWrapper({ isExpanded: true });
+
+    await elements.viewFullButton().trigger('click');
+
+    expect(wrapper.emitted('view-full')).toEqual([[]]);
+  });
+});

--- a/src/components/ConversationsImprovements/DrawerDetails/__tests__/AffectedConversationsSection.spec.js
+++ b/src/components/ConversationsImprovements/DrawerDetails/__tests__/AffectedConversationsSection.spec.js
@@ -1,0 +1,237 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { nextTick } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import { useImprovementsStore } from '@/store/Improvements';
+import { useSupervisorStore } from '@/store/Supervisor';
+
+import AffectedConversationsSection from '../AffectedConversationsSection.vue';
+
+const mockReplace = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal();
+
+  return {
+    ...actual,
+    useRouter: () => ({
+      replace: mockReplace,
+    }),
+    useRoute: () => ({
+      query: {},
+    }),
+  };
+});
+
+describe('AffectedConversationsSection.vue', () => {
+  let wrapper;
+  let improvementsStore;
+  let supervisorStore;
+
+  const baseConversation = {
+    uuid: 'conversation-uuid-1',
+    contactUrn: 'whatsapp:5511999999999',
+    contactName: 'Alessandra',
+    messages: [
+      {
+        uuid: 'message-uuid-1',
+        id: '1',
+        text: 'Hello',
+        source: 'incoming',
+        createdAt: '2026-06-23T09:44:26-03:00',
+      },
+    ],
+  };
+
+  const createWrapper = (props = {}) => {
+    const pinia = createTestingPinia({
+      stubActions: true,
+    });
+
+    improvementsStore = useImprovementsStore(pinia);
+    supervisorStore = useSupervisorStore(pinia);
+
+    vi.spyOn(improvementsStore, 'fetchAffectedConversations');
+    vi.spyOn(improvementsStore, 'resetAffectedConversations');
+
+    wrapper = mount(AffectedConversationsSection, {
+      props: {
+        open: true,
+        improvementUuid: 'improvement-uuid-1',
+        ...props,
+      },
+      global: {
+        plugins: [pinia],
+        stubs: {
+          AffectedConversationItem: {
+            template:
+              '<div data-testid="affected-conversation-item-stub" :data-uuid="conversation.uuid" @click="$emit(\'view-full\')" />',
+            props: ['conversation', 'isExpanded', 'isFirst', 'isLast'],
+            emits: ['toggle', 'view-full'],
+          },
+        },
+      },
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  const elements = {
+    section: () =>
+      wrapper.find(
+        '[data-testid="improvement-drawer-affected-conversations-section"]',
+      ),
+    title: () =>
+      wrapper.find(
+        '[data-testid="improvement-drawer-affected-conversations-title"]',
+      ),
+    skeletons: () =>
+      wrapper.findAll('[data-testid^="affected-conversations-skeleton-"]'),
+    list: () => wrapper.find('[data-testid="affected-conversations-list"]'),
+    items: () =>
+      wrapper.findAll('[data-testid="affected-conversation-item-stub"]'),
+    pagination: () =>
+      wrapper.find('[data-testid="affected-conversations-pagination"]'),
+  };
+
+  it('renders the section title', () => {
+    createWrapper();
+
+    expect(elements.section().exists()).toBe(true);
+    expect(elements.title().text()).toBe(
+      i18n.global.t('audit.improvements.drawer.affected_conversations_title'),
+    );
+  });
+
+  it('fetches affected conversations when the drawer opens', async () => {
+    createWrapper();
+
+    await nextTick();
+
+    expect(improvementsStore.fetchAffectedConversations).toHaveBeenCalledWith(
+      'improvement-uuid-1',
+      1,
+    );
+  });
+
+  it('resets affected conversations when the drawer closes', async () => {
+    createWrapper();
+
+    await wrapper.setProps({ open: false });
+    await nextTick();
+
+    expect(improvementsStore.resetAffectedConversations).toHaveBeenCalled();
+  });
+
+  it('renders loading skeletons while fetching', async () => {
+    createWrapper();
+
+    improvementsStore.affectedConversations.status = 'loading';
+    await nextTick();
+
+    expect(elements.skeletons()).toHaveLength(3);
+  });
+
+  it('renders the conversation list when status is error', async () => {
+    createWrapper();
+
+    improvementsStore.affectedConversations.status = 'error';
+    await nextTick();
+
+    expect(elements.list().exists()).toBe(true);
+  });
+
+  it('renders an empty conversation list when there are no conversations', async () => {
+    createWrapper();
+
+    improvementsStore.affectedConversations.status = 'complete';
+    improvementsStore.affectedConversations.data = {
+      count: 0,
+      results: [],
+    };
+    await nextTick();
+
+    expect(elements.list().exists()).toBe(true);
+    expect(elements.items()).toHaveLength(0);
+  });
+
+  it('renders the conversation list and pagination when data is available', async () => {
+    createWrapper();
+
+    improvementsStore.affectedConversations.status = 'complete';
+    improvementsStore.affectedConversations.page = 1;
+    improvementsStore.affectedConversations.data = {
+      count: 25,
+      results: [baseConversation],
+    };
+    await nextTick();
+
+    expect(elements.list().exists()).toBe(true);
+    expect(elements.items()).toHaveLength(1);
+    expect(elements.pagination().exists()).toBe(true);
+  });
+
+  it('fetches the selected page when pagination changes', async () => {
+    createWrapper();
+
+    improvementsStore.affectedConversations.status = 'complete';
+    improvementsStore.affectedConversations.page = 1;
+    improvementsStore.affectedConversations.data = {
+      count: 25,
+      results: [baseConversation],
+    };
+    await nextTick();
+
+    const paginationComponent = wrapper.findComponent(
+      '[data-testid="affected-conversations-pagination"]',
+    );
+
+    expect(paginationComponent.props('max')).toBe(3);
+    expect(paginationComponent.props('modelValue')).toBe(1);
+
+    vi.mocked(improvementsStore.fetchAffectedConversations).mockClear();
+
+    await paginationComponent.vm.$emit('update:model-value', 2);
+    await nextTick();
+
+    expect(improvementsStore.fetchAffectedConversations).toHaveBeenCalledWith(
+      'improvement-uuid-1',
+      2,
+    );
+  });
+
+  it('navigates to conversations and closes the drawer on view full', async () => {
+    createWrapper();
+
+    improvementsStore.affectedConversations.status = 'complete';
+    improvementsStore.affectedConversations.data = {
+      count: 1,
+      results: [baseConversation],
+    };
+    await nextTick();
+
+    await elements.items()[0].trigger('click');
+    await nextTick();
+
+    expect(supervisorStore.selectedConversation).toEqual({
+      uuid: 'conversation-uuid-1',
+      urn: 'whatsapp:5511999999999',
+      username: 'Alessandra',
+      source: 'v2',
+      data: { status: null },
+    });
+    expect(supervisorStore.queryConversationUuid).toBe('conversation-uuid-1');
+    expect(mockReplace).toHaveBeenCalledWith({
+      name: 'conversations',
+    });
+    expect(wrapper.emitted('close-drawer')).toEqual([[]]);
+  });
+});

--- a/src/components/ConversationsImprovements/DrawerDetails/__tests__/ImprovementDrawer.spec.js
+++ b/src/components/ConversationsImprovements/DrawerDetails/__tests__/ImprovementDrawer.spec.js
@@ -58,6 +58,12 @@ describe('ImprovementDrawer.vue', () => {
             props: ['status', 'improvementUuid', 'open'],
             emits: ['success'],
           },
+          AffectedConversationsSection: {
+            template:
+              '<section data-testid="improvement-drawer-affected-conversations-section"><h2 data-testid="improvement-drawer-affected-conversations-title">{{ $t(\'audit.improvements.drawer.affected_conversations_title\') }}</h2><button data-testid="emit-close-drawer" @click="$emit(\'close-drawer\')" /></section>',
+            props: ['open', 'improvementUuid'],
+            emits: ['close-drawer'],
+          },
           UnnnicDrawerContent: {
             template: '<div><slot /></div>',
           },
@@ -361,6 +367,15 @@ describe('ImprovementDrawer.vue', () => {
       createWrapper();
 
       await wrapper.find('[data-testid="emit-success"]').trigger('click');
+      await nextTick();
+
+      expect(wrapper.emitted('update:open')).toEqual([[false]]);
+    });
+
+    it('closes the drawer when affected conversations emits close-drawer', async () => {
+      createWrapper();
+
+      await wrapper.find('[data-testid="emit-close-drawer"]').trigger('click');
       await nextTick();
 
       expect(wrapper.emitted('update:open')).toEqual([[false]]);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -501,7 +501,8 @@
         "suggested_solution_behavior_title": "Add this instruction to the Manager:",
         "suggested_solution_knowledge_title": "New content for Knowledge Base",
         "suggested_solution_technical_issue_title": "Recommended action",
-        "suggested_solution_title": "Suggested solution"
+        "suggested_solution_title": "Suggested solution",
+        "view_full_conversation": "View full conversation"
       },
       "header": {
         "custom_analysis": "Custom analysis",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -500,7 +500,8 @@
         "suggested_solution_behavior_title": "Agrega esta instrucción al Manager:",
         "suggested_solution_knowledge_title": "Nuevo contenido para la base de conocimiento",
         "suggested_solution_technical_issue_title": "Acción recomendada",
-        "suggested_solution_title": "Solución sugerida"
+        "suggested_solution_title": "Solución sugerida",
+        "view_full_conversation": "Ver conversación completa"
       },
       "header": {
         "custom_analysis": "Análisis personalizado",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -500,7 +500,8 @@
         "suggested_solution_behavior_title": "Adicione esta instrução ao Manager:",
         "suggested_solution_knowledge_title": "Novo conteúdo para a base de conhecimento",
         "suggested_solution_technical_issue_title": "Ação recomendada",
-        "suggested_solution_title": "Solução sugerida"
+        "suggested_solution_title": "Solução sugerida",
+        "view_full_conversation": "Ver conversa completa"
       },
       "header": {
         "custom_analysis": "Análise personalizada",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -499,7 +499,8 @@
         "suggested_solution_behavior_title": "Adaugă această instrucțiune la Manager:",
         "suggested_solution_knowledge_title": "Conținut nou pentru baza de cunoștințe",
         "suggested_solution_technical_issue_title": "Acțiune recomandată",
-        "suggested_solution_title": "Soluție sugerată"
+        "suggested_solution_title": "Soluție sugerată",
+        "view_full_conversation": "Vezi conversația completă"
       },
       "header": {
         "custom_analysis": "Analiză personalizată",

--- a/src/store/Improvements.ts
+++ b/src/store/Improvements.ts
@@ -9,6 +9,7 @@ import { useProjectStore } from './Project';
 import { useAlertStore } from './Alert';
 
 import type {
+  AffectedConversationsResponse,
   Improvement,
   ImprovementDetail,
   ImprovementStatus,
@@ -17,6 +18,8 @@ import type {
   RunAnalysisBlockReason,
 } from './types/Improvements.types';
 import { DEFAULT_IMPROVEMENTS_TASK } from './types/Improvements.types';
+
+export const AFFECTED_CONVERSATIONS_PAGE_SIZE = 10;
 
 export const MIN_CONVERSATIONS_FOR_ANALYSIS = 15;
 
@@ -128,6 +131,21 @@ export const useImprovementsStore = defineStore('Improvements', () => {
   }>({
     data: null,
     status: null,
+  });
+
+  const affectedConversations = reactive<{
+    data: AffectedConversationsResponse;
+    status: ImprovementsStatus;
+    page: number;
+    pageSize: number;
+  }>({
+    data: {
+      count: 0,
+      results: [],
+    },
+    status: null,
+    page: 1,
+    pageSize: AFFECTED_CONVERSATIONS_PAGE_SIZE,
   });
 
   function applyAnalysisResponse(response: ImprovementsAnalysis) {
@@ -284,15 +302,46 @@ export const useImprovementsStore = defineStore('Improvements', () => {
     }
   }
 
+  function resetAffectedConversations() {
+    affectedConversations.data = {
+      count: 0,
+      results: [],
+    };
+    affectedConversations.status = null;
+    affectedConversations.page = 1;
+  }
+
+  async function fetchAffectedConversations(improvementUuid: string, page = 1) {
+    affectedConversations.status = 'loading';
+    affectedConversations.page = page;
+
+    try {
+      affectedConversations.data =
+        await supervisorApi.improvements.getAffectedConversations({
+          projectUuid: projectUuid.value,
+          improvementUuid,
+          page,
+          pageSize: affectedConversations.pageSize,
+        });
+      affectedConversations.status = 'complete';
+    } catch (error) {
+      affectedConversations.status = 'error';
+      console.error(error);
+    }
+  }
+
   return {
     analysis,
     improvements,
     improvementDetail,
+    affectedConversations,
     runAnalysisBlockReason,
     isRunAnalysisDisabled,
     fetchImprovements,
     fetchImprovementDetail,
     resetImprovementDetail,
+    fetchAffectedConversations,
+    resetAffectedConversations,
     runAnalysis,
     updateImprovementStatus,
   };

--- a/src/store/__tests__/Improvements.unit.spec.js
+++ b/src/store/__tests__/Improvements.unit.spec.js
@@ -17,6 +17,7 @@ vi.mock('@/api/nexusaiAPI', () => ({
           getAnalysis: vi.fn(),
           getById: vi.fn(),
           updateStatus: vi.fn(),
+          getAffectedConversations: vi.fn(),
         },
       },
     },
@@ -81,6 +82,27 @@ const buildImprovementDetail = (overrides = {}) => ({
       id: 42,
       changeType: 'fix',
       wasChanged: false,
+    },
+  ],
+  ...overrides,
+});
+
+const buildAffectedConversationsResponse = (overrides = {}) => ({
+  count: 25,
+  results: [
+    {
+      uuid: 'conversation-uuid-1',
+      contactUrn: 'whatsapp:5511999999999',
+      contactName: 'Alessandra',
+      messages: [
+        {
+          uuid: 'message-uuid-1',
+          id: '1',
+          text: 'Hello',
+          source: 'incoming',
+          createdAt: '2026-06-23T09:44:26-03:00',
+        },
+      ],
     },
   ],
   ...overrides,
@@ -656,6 +678,52 @@ describe('Improvements Store', () => {
 
       expect(store.improvementDetail.data).toBeNull();
       expect(store.improvementDetail.status).toBeNull();
+    });
+  });
+
+  describe('fetchAffectedConversations', () => {
+    it('loads affected conversations and sets complete status', async () => {
+      const response = buildAffectedConversationsResponse();
+      improvementsApi.getAffectedConversations.mockResolvedValue(response);
+
+      await store.fetchAffectedConversations('improvement-uuid-1', 2);
+
+      expect(improvementsApi.getAffectedConversations).toHaveBeenCalledWith({
+        projectUuid: 'test-project-uuid',
+        improvementUuid: 'improvement-uuid-1',
+        page: 2,
+        pageSize: 10,
+      });
+      expect(store.affectedConversations.status).toBe('complete');
+      expect(store.affectedConversations.page).toBe(2);
+      expect(store.affectedConversations.data).toEqual(response);
+    });
+
+    it('sets error status when the request fails', async () => {
+      const error = new Error('affected conversations failed');
+      improvementsApi.getAffectedConversations.mockRejectedValue(error);
+
+      await store.fetchAffectedConversations('improvement-uuid-1');
+
+      expect(store.affectedConversations.status).toBe('error');
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+    });
+  });
+
+  describe('resetAffectedConversations', () => {
+    it('clears affected conversations state', () => {
+      store.affectedConversations.data = buildAffectedConversationsResponse();
+      store.affectedConversations.status = 'complete';
+      store.affectedConversations.page = 3;
+
+      store.resetAffectedConversations();
+
+      expect(store.affectedConversations.data).toEqual({
+        count: 0,
+        results: [],
+      });
+      expect(store.affectedConversations.status).toBeNull();
+      expect(store.affectedConversations.page).toBe(1);
     });
   });
 });

--- a/src/store/types/Improvements.types.ts
+++ b/src/store/types/Improvements.types.ts
@@ -62,3 +62,25 @@ export interface ImprovementsAnalysis {
   task: ImprovementsTask;
   improvements: Improvement[];
 }
+
+export type AffectedConversationMessageSource = 'incoming' | 'outgoing';
+
+export interface AffectedConversationMessage {
+  uuid: string;
+  id: string;
+  text: string;
+  source: AffectedConversationMessageSource;
+  createdAt: string;
+}
+
+export interface AffectedConversation {
+  uuid: string;
+  contactUrn: string;
+  contactName: string;
+  messages: AffectedConversationMessage[];
+}
+
+export interface AffectedConversationsResponse {
+  count: number;
+  results: AffectedConversation[];
+}

--- a/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/__tests__/index.spec.js
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/__tests__/index.spec.js
@@ -150,7 +150,7 @@ describe('QuestionAndAnswer index.vue', () => {
           data: {
             type: 'user',
             text: 'User question',
-            created_at: mockDate,
+            createdAt: mockDate,
           },
           showDate: true,
         });
@@ -164,7 +164,7 @@ describe('QuestionAndAnswer index.vue', () => {
           data: {
             type: 'user',
             text: 'User question',
-            created_at: '2021-01-01T00:00:00Z',
+            createdAt: '2021-01-01T00:00:00Z',
           },
           showDate: false,
         });
@@ -228,7 +228,7 @@ describe('QuestionAndAnswer index.vue', () => {
           data: {
             type: 'agent',
             text: 'Agent response',
-            created_at: mockDate,
+            createdAt: mockDate,
           },
           showDate: true,
         });
@@ -242,7 +242,7 @@ describe('QuestionAndAnswer index.vue', () => {
           data: {
             type: 'agent',
             text: 'Agent response',
-            created_at: '2021-01-01T00:00:00Z',
+            createdAt: '2021-01-01T00:00:00Z',
           },
           showDate: false,
         });

--- a/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/index.vue
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/QuestionAndAnswer/index.vue
@@ -38,7 +38,7 @@
             class="question-and-answer__question-date"
             data-testid="question-date"
           >
-            {{ formatTimestamp(data.created_at) }}
+            {{ formatTimestamp(data.createdAt) }}
           </p>
         </Message>
       </section>
@@ -72,7 +72,7 @@
               class="question-and-answer__answer-date"
               data-testid="answer-date"
             >
-              {{ formatTimestamp(data.created_at) }}
+              {{ formatTimestamp(data.createdAt) }}
             </p>
 
             <ViewLogsButton


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

The improvement drawer's "Affected Conversations" section was a static placeholder. This change wires it up to a real API endpoint so users can browse the conversations that triggered each improvement, preview their messages inline, and jump directly to the full conversation view.

### Summary of Changes

- Added `AffectedConversation`, `AffectedConversationMessage`, and `AffectedConversationsResponse` TypeScript types to `Improvements.types.ts`.
- Created `AffectedConversationsAdapter` with a `fromApi` method that converts snake_case API fields to camelCase, validates message sources (`incoming` / `outgoing`), and filters out incomplete conversations or messages. Also exports `mapMessageToQuestionAndAnswer` to convert messages into the format expected by the `QuestionAndAnswer` component.
- Added `getAffectedConversations` to `Supervisor.improvements` in the Nexus API layer, calling `/api/v1/projects/{projectUuid}/improvements/{improvementUuid}/affected_conversations` with `page` and `page_size` query parameters.
- Extended `useImprovementsStore` with `affectedConversations` reactive state, `fetchAffectedConversations`, and `resetAffectedConversations` actions. Exported `AFFECTED_CONVERSATIONS_PAGE_SIZE = 10` as a shared constant.
- Replaced the static `ImprovementDrawerSection` placeholder in `ImprovementDrawer.vue` with the new `AffectedConversationsSection` component, which fetches data when the drawer opens, resets state when it closes, and emits `close-drawer` to allow navigation to the full conversation view.
- Added `AffectedConversationItem.vue`, a collapsible row that renders a contact label, previews messages using `QuestionAndAnswer` with `improvement-incoming` / `improvement-outgoing` schemes, and provides a "View full conversation" button.
- Added `AffectedConversationsSection.vue`, which manages pagination, expand/collapse state, and navigation to the supervisor conversations view when a user clicks "View full conversation".
- Added the `view_full_conversation` locale key in English, Spanish, Brazilian Portuguese, and Romanian.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/8f3bcf12-0189-45af-beda-97d331a62e23.png)

