### PR TITLE
feat: Implement Custom Analysis Improvements Adapter with API integration

### DIFF
--- a/src/api/adapters/supervisor/__tests__/customAnalysisImprovements.spec.ts
+++ b/src/api/adapters/supervisor/__tests__/customAnalysisImprovements.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+
+import { CustomAnalysisImprovementsAdapter } from '../customAnalysisImprovements';
+
+describe('Supervisor custom analysis improvements adapter', () => {
+  describe('fromApiList', () => {
+    it('transforms API list data to frontend format', () => {
+      const result = CustomAnalysisImprovementsAdapter.fromApiList([
+        {
+          uuid: 'custom-analysis-uuid-1',
+          title: 'Unrealistic delivery deadlines',
+          conversations_count: 5,
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          uuid: 'custom-analysis-uuid-1',
+          title: 'Unrealistic delivery deadlines',
+          conversationsCount: 5,
+        },
+      ]);
+    });
+
+    it('returns an empty array when API data is missing', () => {
+      expect(CustomAnalysisImprovementsAdapter.fromApiList()).toEqual([]);
+    });
+
+    it('filters items with invalid or incomplete data', () => {
+      const result = CustomAnalysisImprovementsAdapter.fromApiList([
+        {
+          uuid: 'valid-uuid',
+          title: 'Valid custom analysis',
+          conversations_count: 2,
+        },
+        {
+          uuid: 'missing-title',
+          conversations_count: 1,
+        },
+        {
+          title: 'Missing uuid',
+          conversations_count: 3,
+        },
+      ]);
+
+      expect(result).toEqual([
+        {
+          uuid: 'valid-uuid',
+          title: 'Valid custom analysis',
+          conversationsCount: 2,
+        },
+      ]);
+    });
+
+    it('defaults conversationsCount to zero when count is missing', () => {
+      const result = CustomAnalysisImprovementsAdapter.fromApiList([
+        {
+          uuid: 'uuid-1',
+          title: 'Custom analysis without count',
+        },
+      ]);
+
+      expect(result[0].conversationsCount).toBe(0);
+    });
+  });
+
+  describe('fromApiDetail', () => {
+    it('transforms API detail data to frontend format', () => {
+      const result = CustomAnalysisImprovementsAdapter.fromApiDetail({
+        uuid: 'custom-analysis-uuid-1',
+        title: 'Unrealistic delivery deadlines',
+        definition: 'The agent is providing unrealistic delivery deadlines',
+        exclusions: '',
+        slug: 'unrealistic-delivery-deadlines',
+      });
+
+      expect(result).toEqual({
+        uuid: 'custom-analysis-uuid-1',
+        title: 'Unrealistic delivery deadlines',
+        definition: 'The agent is providing unrealistic delivery deadlines',
+        exclusions: '',
+        slug: 'unrealistic-delivery-deadlines',
+      });
+    });
+
+    it('returns null when required fields are missing', () => {
+      expect(
+        CustomAnalysisImprovementsAdapter.fromApiDetail({
+          uuid: 'custom-analysis-uuid-1',
+        }),
+      ).toBeNull();
+    });
+
+    it('defaults optional fields to empty strings', () => {
+      const result = CustomAnalysisImprovementsAdapter.fromApiDetail({
+        uuid: 'custom-analysis-uuid-1',
+        title: 'Unrealistic delivery deadlines',
+      });
+
+      expect(result).toEqual({
+        uuid: 'custom-analysis-uuid-1',
+        title: 'Unrealistic delivery deadlines',
+        definition: '',
+        exclusions: '',
+        slug: '',
+      });
+    });
+  });
+
+  describe('toApiCreate', () => {
+    it('transforms frontend payload to API format', () => {
+      expect(
+        CustomAnalysisImprovementsAdapter.toApiCreate({
+          title: 'Unrealistic delivery deadlines',
+          definition: 'The agent is providing unrealistic delivery deadlines',
+          exclusions: '',
+        }),
+      ).toEqual({
+        title: 'Unrealistic delivery deadlines',
+        definition: 'The agent is providing unrealistic delivery deadlines',
+        exclusions: '',
+      });
+    });
+  });
+});

--- a/src/api/adapters/supervisor/customAnalysisImprovements.ts
+++ b/src/api/adapters/supervisor/customAnalysisImprovements.ts
@@ -1,0 +1,73 @@
+import type {
+  CustomAnalysisCreatePayload,
+  CustomAnalysisImprovement,
+  CustomAnalysisImprovementDetail,
+} from '@/store/types/CustomAnalysisImprovements.types';
+
+export interface CustomAnalysisImprovementApi {
+  uuid?: string;
+  title?: string;
+  conversations_count?: number;
+}
+
+export interface CustomAnalysisImprovementDetailApi {
+  uuid?: string;
+  title?: string;
+  definition?: string;
+  exclusions?: string;
+  slug?: string;
+}
+
+function parseListItem(
+  item: CustomAnalysisImprovementApi = {},
+): CustomAnalysisImprovement | null {
+  if (!item.uuid || !item.title) {
+    return null;
+  }
+
+  return {
+    uuid: item.uuid,
+    title: item.title,
+    conversationsCount: Number(item.conversations_count) || 0,
+  };
+}
+
+function parseDetail(
+  apiData: CustomAnalysisImprovementDetailApi = {},
+): CustomAnalysisImprovementDetail | null {
+  if (!apiData.uuid || !apiData.title) {
+    return null;
+  }
+
+  return {
+    uuid: apiData.uuid,
+    title: apiData.title,
+    definition: apiData.definition ?? '',
+    exclusions: apiData.exclusions ?? '',
+    slug: apiData.slug ?? '',
+  };
+}
+
+export const CustomAnalysisImprovementsAdapter = {
+  fromApiList(
+    apiData: CustomAnalysisImprovementApi[] = [],
+  ): CustomAnalysisImprovement[] {
+    return apiData
+      .map(parseListItem)
+      .filter((item): item is CustomAnalysisImprovement => item !== null);
+  },
+
+  fromApiDetail(
+    apiData: CustomAnalysisImprovementDetailApi = {},
+  ): CustomAnalysisImprovementDetail | null {
+    return parseDetail(apiData);
+  },
+
+  toApiCreate({ title, definition, exclusions }: CustomAnalysisCreatePayload) {
+    return {
+      title,
+      definition,
+      exclusions,
+    };
+  },
+};

--- a/src/api/nexus/Supervisor.js
+++ b/src/api/nexus/Supervisor.js
@@ -4,6 +4,7 @@ import { fetchConversationList } from '../adapters/supervisor/conversationSource
 import { ConversationMessageAdapter } from '../adapters/supervisor/conversationMessage';
 import { ImprovementsAdapter } from '../adapters/supervisor/improvements';
 import { AffectedConversationsAdapter } from '../adapters/supervisor/affectedConversations';
+import { CustomAnalysisImprovementsAdapter } from '../adapters/supervisor/customAnalysisImprovements';
 
 export const Supervisor = {
   conversations: {
@@ -118,6 +119,41 @@ export const Supervisor = {
       );
 
       return AffectedConversationsAdapter.fromApi(data);
+    },
+
+    customAnalysis: {
+      async list({ projectUuid }) {
+        const { data } = await conversationsRequest.$http.get(
+          `/api/v1/projects/${projectUuid}/improvements/custom_analysis/`,
+        );
+
+        return CustomAnalysisImprovementsAdapter.fromApiList(data);
+      },
+
+      async create({ projectUuid, title, definition, exclusions }) {
+        const { data } = await conversationsRequest.$http.post(
+          `/api/v1/projects/${projectUuid}/improvements/custom_analysis/`,
+          CustomAnalysisImprovementsAdapter.toApiCreate({
+            title,
+            definition,
+            exclusions,
+          }),
+        );
+
+        const detail = CustomAnalysisImprovementsAdapter.fromApiDetail(data);
+
+        if (!detail) {
+          throw new Error('Invalid custom analysis response');
+        }
+
+        return detail;
+      },
+
+      async delete({ projectUuid, customAnalysisUuid }) {
+        await conversationsRequest.$http.delete(
+          `/api/v1/projects/${projectUuid}/improvements/custom_analysis/${customAnalysisUuid}/`,
+        );
+      },
     },
   },
 };

--- a/src/api/nexus/__tests__/Supervisor.spec.js
+++ b/src/api/nexus/__tests__/Supervisor.spec.js
@@ -8,6 +8,7 @@ vi.mock('@/api/nexusaiRequest', () => ({
     $http: {
       get: vi.fn(),
       post: vi.fn(),
+      delete: vi.fn(),
     },
   },
 }));
@@ -18,6 +19,7 @@ vi.mock('@/api/conversationsRequest', () => ({
       get: vi.fn(),
       post: vi.fn(),
       patch: vi.fn(),
+      delete: vi.fn(),
     },
   },
 }));
@@ -425,6 +427,115 @@ describe('Supervisor.js', () => {
             ],
           },
         ],
+      });
+    });
+
+    describe('customAnalysis', () => {
+      const mockListResponse = [
+        {
+          uuid: 'custom-analysis-uuid-1',
+          title: 'Unrealistic delivery deadlines',
+          conversations_count: 5,
+        },
+      ];
+
+      const mockDetailResponse = {
+        uuid: 'custom-analysis-uuid-2',
+        title: 'Unrealistic delivery deadlines',
+        definition: 'The agent is providing unrealistic delivery deadlines',
+        exclusions: '',
+        slug: 'unrealistic-delivery-deadlines',
+      };
+
+      it('list calls the custom analysis endpoint and adapts the response', async () => {
+        conversationsRequest.$http.get.mockResolvedValue({
+          data: mockListResponse,
+        });
+
+        const result = await Supervisor.improvements.customAnalysis.list({
+          projectUuid,
+        });
+
+        expect(conversationsRequest.$http.get).toHaveBeenCalledWith(
+          `/api/v1/projects/${projectUuid}/improvements/custom_analysis/`,
+        );
+        expect(nexusRequest.$http.get).not.toHaveBeenCalled();
+        expect(result).toEqual([
+          {
+            uuid: 'custom-analysis-uuid-1',
+            title: 'Unrealistic delivery deadlines',
+            conversationsCount: 5,
+          },
+        ]);
+      });
+
+      it('create calls the custom analysis endpoint and adapts the response', async () => {
+        conversationsRequest.$http.post.mockResolvedValue({
+          data: mockDetailResponse,
+        });
+
+        const result = await Supervisor.improvements.customAnalysis.create({
+          projectUuid,
+          title: 'Unrealistic delivery deadlines',
+          definition: 'The agent is providing unrealistic delivery deadlines',
+          exclusions: '',
+        });
+
+        expect(conversationsRequest.$http.post).toHaveBeenCalledWith(
+          `/api/v1/projects/${projectUuid}/improvements/custom_analysis/`,
+          {
+            title: 'Unrealistic delivery deadlines',
+            definition: 'The agent is providing unrealistic delivery deadlines',
+            exclusions: '',
+          },
+        );
+        expect(result).toEqual({
+          uuid: 'custom-analysis-uuid-2',
+          title: 'Unrealistic delivery deadlines',
+          definition: 'The agent is providing unrealistic delivery deadlines',
+          exclusions: '',
+          slug: 'unrealistic-delivery-deadlines',
+        });
+      });
+
+      it('create throws when custom analysis response is invalid', async () => {
+        conversationsRequest.$http.post.mockResolvedValue({
+          data: {
+            uuid: 'custom-analysis-uuid-2',
+          },
+        });
+
+        await expect(
+          Supervisor.improvements.customAnalysis.create({
+            projectUuid,
+            title: 'Unrealistic delivery deadlines',
+            definition: 'The agent is providing unrealistic delivery deadlines',
+            exclusions: '',
+          }),
+        ).rejects.toThrow('Invalid custom analysis response');
+      });
+
+      it('delete calls the custom analysis endpoint', async () => {
+        conversationsRequest.$http.delete.mockResolvedValue({});
+
+        await Supervisor.improvements.customAnalysis.delete({
+          projectUuid,
+          customAnalysisUuid: 'custom-analysis-uuid-1',
+        });
+
+        expect(conversationsRequest.$http.delete).toHaveBeenCalledWith(
+          `/api/v1/projects/${projectUuid}/improvements/custom_analysis/custom-analysis-uuid-1/`,
+        );
+        expect(nexusRequest.$http.delete).not.toHaveBeenCalled();
+      });
+
+      it('propagates errors from list', async () => {
+        const error = new Error('API Error');
+        conversationsRequest.$http.get.mockRejectedValue(error);
+
+        await expect(
+          Supervisor.improvements.customAnalysis.list({ projectUuid }),
+        ).rejects.toThrow('API Error');
       });
     });
   });

--- a/src/store/CustomAnalysisImprovements.ts
+++ b/src/store/CustomAnalysisImprovements.ts
@@ -1,0 +1,172 @@
+import { computed, reactive } from 'vue';
+import { defineStore } from 'pinia';
+
+import nexusaiAPI from '@/api/nexusaiAPI';
+import i18n from '@/utils/plugins/i18n';
+import { useProjectStore } from './Project';
+import { useAlertStore } from './Alert';
+
+import {
+  MAX_CUSTOM_ANALYSIS,
+  type CustomAnalysisImprovement,
+  type CustomAnalysisImprovementsStatus,
+} from './types/CustomAnalysisImprovements.types';
+
+const I18N_PREFIX = 'audit.improvements.custom_analysis_modal';
+
+function isLimitError(error: unknown) {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'response' in error &&
+    (error as { response?: { status?: number } }).response?.status === 400
+  );
+}
+
+export const useCustomAnalysisImprovementsStore = defineStore(
+  'CustomAnalysisImprovements',
+  () => {
+    const alertStore = useAlertStore();
+
+    const projectUuid = computed(() => useProjectStore().uuid);
+    const customAnalysisApi =
+      nexusaiAPI.agent_builder.supervisor.improvements.customAnalysis;
+
+    const customAnalysis = reactive<{
+      data: CustomAnalysisImprovement[];
+      status: CustomAnalysisImprovementsStatus;
+    }>({
+      data: [],
+      status: 'idle',
+    });
+
+    const createCustomAnalysis = reactive<{
+      status: CustomAnalysisImprovementsStatus;
+    }>({
+      status: 'idle',
+    });
+
+    const deleteCustomAnalysis = reactive<{
+      customAnalysisUuid: string | null;
+      status: CustomAnalysisImprovementsStatus;
+    }>({
+      customAnalysisUuid: null,
+      status: 'idle',
+    });
+
+    async function fetchCustomAnalysis() {
+      customAnalysis.status = 'loading';
+
+      try {
+        customAnalysis.data = await customAnalysisApi.list({
+          projectUuid: projectUuid.value,
+        });
+        customAnalysis.status = 'complete';
+      } catch (error) {
+        customAnalysis.status = 'error';
+        console.error(error);
+      }
+    }
+
+    async function submitCustomAnalysis({
+      title,
+      definition,
+    }: {
+      title: string;
+      definition: string;
+    }) {
+      if (customAnalysis.data.length >= MAX_CUSTOM_ANALYSIS) {
+        return { status: 'error' as const };
+      }
+
+      createCustomAnalysis.status = 'loading';
+
+      try {
+        const detail = await customAnalysisApi.create({
+          projectUuid: projectUuid.value,
+          title,
+          definition,
+          exclusions: '',
+        });
+
+        customAnalysis.data = [
+          {
+            uuid: detail.uuid,
+            title: detail.title,
+            conversationsCount: 0,
+          },
+          ...customAnalysis.data,
+        ];
+        createCustomAnalysis.status = 'complete';
+        alertStore.add({
+          type: 'success',
+          text: i18n.global.t(`${I18N_PREFIX}.create.success.title`),
+          description: i18n.global.t(
+            `${I18N_PREFIX}.create.success.description`,
+          ),
+        });
+
+        return { status: 'complete' as const };
+      } catch (error) {
+        createCustomAnalysis.status = 'error';
+        alertStore.add({
+          type: 'error',
+          text: i18n.global.t(
+            isLimitError(error)
+              ? `${I18N_PREFIX}.create.limit_error`
+              : `${I18N_PREFIX}.create.error`,
+          ),
+        });
+        console.error(error);
+
+        return { status: 'error' as const };
+      }
+    }
+
+    async function submitDeleteCustomAnalysis(customAnalysisUuid: string) {
+      deleteCustomAnalysis.customAnalysisUuid = customAnalysisUuid;
+      deleteCustomAnalysis.status = 'loading';
+
+      try {
+        await customAnalysisApi.delete({
+          projectUuid: projectUuid.value,
+          customAnalysisUuid,
+        });
+
+        customAnalysis.data = customAnalysis.data.filter(
+          (item) => item.uuid !== customAnalysisUuid,
+        );
+        deleteCustomAnalysis.status = 'complete';
+        alertStore.add({
+          type: 'informational',
+          text: i18n.global.t(`${I18N_PREFIX}.delete.success.title`),
+          description: i18n.global.t(
+            `${I18N_PREFIX}.delete.success.description`,
+          ),
+        });
+
+        return { status: 'complete' as const };
+      } catch (error) {
+        deleteCustomAnalysis.status = 'error';
+        alertStore.add({
+          type: 'error',
+          text: i18n.global.t(`${I18N_PREFIX}.delete.error`),
+        });
+        console.error(error);
+
+        return { status: 'error' as const };
+      } finally {
+        deleteCustomAnalysis.customAnalysisUuid = null;
+      }
+    }
+
+    return {
+      customAnalysis,
+      createCustomAnalysis,
+      deleteCustomAnalysis,
+      fetchCustomAnalysis,
+      submitCustomAnalysis,
+      submitDeleteCustomAnalysis,
+    };
+  },
+);

--- a/src/store/__tests__/CustomAnalysisImprovements.spec.ts
+++ b/src/store/__tests__/CustomAnalysisImprovements.spec.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { setActivePinia, createPinia } from 'pinia';
+
+import { useCustomAnalysisImprovementsStore } from '@/store/CustomAnalysisImprovements';
+import { useAlertStore } from '@/store/Alert';
+import nexusaiAPI from '@/api/nexusaiAPI';
+import i18n from '@/utils/plugins/i18n';
+
+vi.mock('@/api/nexusaiAPI', () => ({
+  default: {
+    agent_builder: {
+      supervisor: {
+        improvements: {
+          customAnalysis: {
+            list: vi.fn(),
+            create: vi.fn(),
+            delete: vi.fn(),
+          },
+        },
+      },
+    },
+  },
+}));
+
+vi.mock('@/store/Project', () => ({
+  useProjectStore: vi.fn(() => ({
+    uuid: 'test-project-uuid',
+  })),
+}));
+
+const I18N_PREFIX = 'audit.improvements.custom_analysis_modal';
+
+const buildListItem = (overrides = {}) => ({
+  uuid: 'custom-analysis-uuid-1',
+  title: 'Unrealistic delivery deadlines',
+  conversationsCount: 5,
+  ...overrides,
+});
+
+const buildDetail = (overrides = {}) => ({
+  uuid: 'custom-analysis-uuid-2',
+  title: 'Unrealistic delivery deadlines',
+  definition: 'The agent is providing unrealistic delivery deadlines',
+  exclusions: '',
+  slug: 'unrealistic-delivery-deadlines',
+  ...overrides,
+});
+
+describe('CustomAnalysisImprovements Store', () => {
+  let store;
+  let customAnalysisApi;
+  let alertStore;
+
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    store = useCustomAnalysisImprovementsStore();
+    alertStore = useAlertStore();
+    vi.spyOn(alertStore, 'add');
+    customAnalysisApi =
+      nexusaiAPI.agent_builder.supervisor.improvements.customAnalysis;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('fetchCustomAnalysis', () => {
+    it('loads custom analysis list and sets complete status', async () => {
+      customAnalysisApi.list.mockResolvedValue([buildListItem()]);
+
+      await store.fetchCustomAnalysis();
+
+      expect(customAnalysisApi.list).toHaveBeenCalledWith({
+        projectUuid: 'test-project-uuid',
+      });
+      expect(store.customAnalysis.data).toEqual([buildListItem()]);
+      expect(store.customAnalysis.status).toBe('complete');
+      expect(alertStore.add).not.toHaveBeenCalled();
+    });
+
+    it('sets error status when list request fails', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      customAnalysisApi.list.mockRejectedValue(new Error('API Error'));
+
+      await store.fetchCustomAnalysis();
+
+      expect(store.customAnalysis.status).toBe('error');
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('submitCustomAnalysis', () => {
+    const submitPayload = {
+      title: 'Unrealistic delivery deadlines',
+      definition: 'The agent is providing unrealistic delivery deadlines',
+    };
+
+    it('creates custom analysis, prepends it to the list, and shows success alert', async () => {
+      customAnalysisApi.create.mockResolvedValue(buildDetail());
+
+      const result = await store.submitCustomAnalysis(submitPayload);
+
+      expect(customAnalysisApi.create).toHaveBeenCalledWith({
+        projectUuid: 'test-project-uuid',
+        title: submitPayload.title,
+        definition: submitPayload.definition,
+        exclusions: '',
+      });
+      expect(store.customAnalysis.data).toEqual([
+        {
+          uuid: 'custom-analysis-uuid-2',
+          title: 'Unrealistic delivery deadlines',
+          conversationsCount: 0,
+        },
+      ]);
+      expect(store.createCustomAnalysis.status).toBe('complete');
+      expect(result).toEqual({ status: 'complete' });
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'success',
+        text: i18n.global.t(`${I18N_PREFIX}.create.success.title`),
+        description: i18n.global.t(`${I18N_PREFIX}.create.success.description`),
+      });
+    });
+
+    it('returns error without calling API when the custom analysis limit is reached', async () => {
+      store.customAnalysis.data = Array.from({ length: 10 }, (_, index) =>
+        buildListItem({
+          uuid: `custom-analysis-uuid-${index + 1}`,
+          title: `Custom analysis ${index + 1}`,
+        }),
+      );
+
+      const result = await store.submitCustomAnalysis(submitPayload);
+
+      expect(customAnalysisApi.create).not.toHaveBeenCalled();
+      expect(result).toEqual({ status: 'error' });
+      expect(alertStore.add).not.toHaveBeenCalled();
+    });
+
+    it('shows generic error alert when create request fails', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      customAnalysisApi.create.mockRejectedValue(new Error('API Error'));
+
+      const result = await store.submitCustomAnalysis(submitPayload);
+
+      expect(store.createCustomAnalysis.status).toBe('error');
+      expect(result).toEqual({ status: 'error' });
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'error',
+        text: i18n.global.t(`${I18N_PREFIX}.create.error`),
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+
+    it('shows limit error alert when create request returns 400', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      customAnalysisApi.create.mockRejectedValue({
+        response: { status: 400 },
+      });
+
+      await store.submitCustomAnalysis(submitPayload);
+
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'error',
+        text: i18n.global.t(`${I18N_PREFIX}.create.limit_error`),
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+
+  describe('submitDeleteCustomAnalysis', () => {
+    it('deletes custom analysis, removes it from the list, and shows informational alert', async () => {
+      store.customAnalysis.data = [
+        buildListItem(),
+        buildListItem({
+          uuid: 'custom-analysis-uuid-2',
+          title: 'Another custom analysis',
+        }),
+      ];
+      customAnalysisApi.delete.mockResolvedValue(undefined);
+
+      const result = await store.submitDeleteCustomAnalysis(
+        'custom-analysis-uuid-1',
+      );
+
+      expect(customAnalysisApi.delete).toHaveBeenCalledWith({
+        projectUuid: 'test-project-uuid',
+        customAnalysisUuid: 'custom-analysis-uuid-1',
+      });
+      expect(store.customAnalysis.data).toEqual([
+        buildListItem({
+          uuid: 'custom-analysis-uuid-2',
+          title: 'Another custom analysis',
+        }),
+      ]);
+      expect(store.deleteCustomAnalysis.status).toBe('complete');
+      expect(store.deleteCustomAnalysis.customAnalysisUuid).toBeNull();
+      expect(result).toEqual({ status: 'complete' });
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'informational',
+        text: i18n.global.t(`${I18N_PREFIX}.delete.success.title`),
+        description: i18n.global.t(`${I18N_PREFIX}.delete.success.description`),
+      });
+    });
+
+    it('shows error alert when delete request fails', async () => {
+      const consoleErrorSpy = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      customAnalysisApi.delete.mockRejectedValue(new Error('API Error'));
+
+      const result = await store.submitDeleteCustomAnalysis(
+        'custom-analysis-uuid-1',
+      );
+
+      expect(store.deleteCustomAnalysis.status).toBe('error');
+      expect(store.deleteCustomAnalysis.customAnalysisUuid).toBeNull();
+      expect(result).toEqual({ status: 'error' });
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'error',
+        text: i18n.global.t(`${I18N_PREFIX}.delete.error`),
+      });
+
+      consoleErrorSpy.mockRestore();
+    });
+  });
+});

--- a/src/store/types/CustomAnalysisImprovements.types.ts
+++ b/src/store/types/CustomAnalysisImprovements.types.ts
@@ -1,0 +1,27 @@
+export const MAX_CUSTOM_ANALYSIS = 10;
+
+export type CustomAnalysisImprovementsStatus =
+  | 'idle'
+  | 'loading'
+  | 'complete'
+  | 'error';
+
+export interface CustomAnalysisImprovement {
+  uuid: string;
+  title: string;
+  conversationsCount: number;
+}
+
+export interface CustomAnalysisImprovementDetail {
+  uuid: string;
+  title: string;
+  definition: string;
+  exclusions: string;
+  slug: string;
+}
+
+export interface CustomAnalysisCreatePayload {
+  title: string;
+  definition: string;
+  exclusions: string;
+}


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Supervisor improvements needed support for user-defined custom analysis topics. This adds the ability to list, create, and delete custom analysis improvements scoped to a project, with a hard cap of 10 entries per project.

### Summary of Changes
- Added `CustomAnalysisImprovements.types.ts` defining the `CustomAnalysisImprovement`, `CustomAnalysisImprovementDetail`, and `CustomAnalysisCreatePayload` interfaces, along with the `MAX_CUSTOM_ANALYSIS` constant (10) and a shared status type.
- Added `CustomAnalysisImprovementsAdapter` to handle bidirectional transformation between API snake_case responses and frontend camelCase models, including filtering of incomplete list items and defaulting optional detail fields to empty strings.
- Extended `Supervisor.improvements` in the Nexus API layer with a `customAnalysis` namespace exposing `list`, `create`, and `delete` methods that call the `/api/v1/projects/{projectUuid}/improvements/custom_analysis/` endpoints.
- Added `useCustomAnalysisImprovementsStore` (Pinia) with reactive state for listing, creating, and deleting custom analyses. The store enforces the `MAX_CUSTOM_ANALYSIS` limit client-side before calling the API, distinguishes between generic and 400-status limit errors on create, and dispatches success/error alerts via `useAlertStore`.
- Added unit tests for the adapter, the Nexus API methods, and the Pinia store, covering happy paths, error handling, limit enforcement, and invalid response detection.