### PR TITLE
feat: Implement Custom Analysis Modal and Improvement Row components

### DIFF
--- a/src/components/ConversationsImprovements/CustomAnalysisModal/CustomAnalysisImprovementRow.vue
+++ b/src/components/ConversationsImprovements/CustomAnalysisModal/CustomAnalysisImprovementRow.vue
@@ -1,0 +1,98 @@
+<template>
+  <article
+    class="custom-analysis-improvement-row"
+    data-testid="custom-analysis-improvement-row"
+  >
+    <section class="custom-analysis-improvement-row__content">
+      <h4
+        class="custom-analysis-improvement-row__title"
+        data-testid="custom-analysis-improvement-row-title"
+      >
+        {{ customAnalysis.title }}
+      </h4>
+      <p
+        class="custom-analysis-improvement-row__subtitle"
+        data-testid="custom-analysis-improvement-row-subtitle"
+      >
+        {{ affectedConversationsLabel }}
+      </p>
+    </section>
+
+    <UnnnicButton
+      class="custom-analysis-improvement-row__delete-button"
+      type="tertiary"
+      size="small"
+      iconCenter="delete"
+      data-testid="custom-analysis-improvement-row-delete"
+      @click="emit('delete', customAnalysis.uuid)"
+    />
+  </article>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import type { CustomAnalysisImprovement } from '@/store/types/CustomAnalysisImprovements.types';
+
+const props = defineProps<{
+  customAnalysis: CustomAnalysisImprovement;
+}>();
+
+const emit = defineEmits<{
+  delete: [customAnalysisUuid: string];
+}>();
+
+const { t } = useI18n();
+
+const affectedConversationsLabel = computed(() => {
+  const { conversationsCount } = props.customAnalysis;
+
+  if (conversationsCount === 0) {
+    return t(
+      'audit.improvements.custom_analysis_modal.no_affected_conversations',
+    );
+  }
+
+  return t('audit.improvements.custom_analysis_modal.affected_conversations', {
+    count: conversationsCount,
+  });
+});
+</script>
+
+<style scoped lang="scss">
+.custom-analysis-improvement-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: $unnnic-space-4;
+
+  padding: $unnnic-space-4 0;
+
+  border-bottom: 1px solid $unnnic-color-border-base;
+
+  &__content {
+    display: flex;
+    flex: 1;
+    flex-direction: column;
+    gap: $unnnic-space-1;
+  }
+
+  &__title {
+    font: $unnnic-font-emphasis;
+    color: $unnnic-color-fg-emphasized;
+    word-break: break-word;
+  }
+
+  &__subtitle {
+    font: $unnnic-font-caption-2;
+    color: $unnnic-color-fg-muted;
+  }
+
+  &__delete-button {
+    :deep(.unnnic-icon) {
+      font-size: $unnnic-icon-size-6;
+    }
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/CustomAnalysisModal/CustomAnalysisModal.vue
+++ b/src/components/ConversationsImprovements/CustomAnalysisModal/CustomAnalysisModal.vue
@@ -1,0 +1,345 @@
+<template>
+  <UnnnicDialog
+    data-testid="custom-analysis-modal"
+    :open="open"
+    lazyMount
+    @update:open="handleOpenChange"
+  >
+    <UnnnicDialogContent size="large">
+      <UnnnicDialogHeader>
+        <UnnnicDialogTitle data-testid="custom-analysis-modal-title">
+          {{ t('audit.improvements.custom_analysis_modal.title') }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+
+      <section class="custom-analysis-modal__body">
+        <form class="custom-analysis-modal__form">
+          <p
+            class="custom-analysis-modal__description"
+            data-testid="custom-analysis-modal-description"
+          >
+            {{ t('audit.improvements.custom_analysis_modal.description') }}
+          </p>
+
+          <section
+            class="custom-analysis-modal__form-fields"
+            data-testid="custom-analysis-modal-form"
+          >
+            <UnnnicDisclaimer
+              v-if="isLimitReached"
+              type="attention"
+              :description="
+                t('audit.improvements.custom_analysis_modal.limit_disclaimer')
+              "
+              data-testid="custom-analysis-modal-limit-disclaimer"
+            />
+
+            <UnnnicFormElement
+              :label="t('audit.improvements.custom_analysis_modal.title_label')"
+              :message="
+                t('audit.improvements.custom_analysis_modal.title_helper')
+              "
+            >
+              <UnnnicInput
+                v-model="titleText"
+                data-testid="custom-analysis-modal-title-input"
+                :placeholder="
+                  t(
+                    'audit.improvements.custom_analysis_modal.title_placeholder',
+                  )
+                "
+                :disabled="isLimitReached"
+                :maxlength="TITLE_MAX_LENGTH"
+              />
+              <template #rightMessage
+                >{{ titleText.length }}/{{ TITLE_MAX_LENGTH }}</template
+              >
+            </UnnnicFormElement>
+
+            <UnnnicTextArea
+              v-model="definitionText"
+              data-testid="custom-analysis-modal-definition-textarea"
+              :label="
+                t('audit.improvements.custom_analysis_modal.definition_label')
+              "
+              :placeholder="
+                t(
+                  'audit.improvements.custom_analysis_modal.definition_placeholder',
+                )
+              "
+              :message="
+                t('audit.improvements.custom_analysis_modal.definition_helper')
+              "
+              :disabled="isLimitReached"
+              maxLength="512"
+            />
+
+            <UnnnicButton
+              class="custom-analysis-modal__add-button"
+              data-testid="custom-analysis-modal-add-button"
+              type="secondary"
+              :text="t('audit.improvements.custom_analysis_modal.add')"
+              :disabled="!canSubmit || isLimitReached"
+              :loading="createCustomAnalysis.status === 'loading'"
+              @click="handleAdd"
+            />
+          </section>
+        </form>
+
+        <section
+          class="custom-analysis-modal__list-section"
+          data-testid="custom-analysis-modal-list-section"
+        >
+          <template v-if="customAnalysis.status === 'loading'">
+            <UnnnicSkeletonLoading
+              v-for="index in 3"
+              :key="index"
+              tag="div"
+              width="100%"
+              height="64px"
+              :data-testid="`custom-analysis-modal-skeleton-${index}`"
+            />
+          </template>
+
+          <template v-else-if="hasCustomAnalysisItems">
+            <header class="custom-analysis-modal__list-heading">
+              <h3
+                class="custom-analysis-modal__list-title"
+                data-testid="custom-analysis-modal-list-title"
+              >
+                {{ t('audit.improvements.custom_analysis_modal.list_heading') }}
+              </h3>
+              <UnnnicTag
+                data-testid="custom-analysis-modal-list-heading-count"
+                :text="
+                  t(
+                    'audit.improvements.custom_analysis_modal.list_heading_count',
+                    {
+                      count: customAnalysis.data.length,
+                      max: MAX_CUSTOM_ANALYSIS,
+                    },
+                  )
+                "
+                size="small"
+                scheme="neutral"
+              />
+            </header>
+
+            <CustomAnalysisImprovementRow
+              v-for="item in customAnalysis.data"
+              :key="item.uuid"
+              :customAnalysis="item"
+              data-testid="custom-analysis-modal-row"
+              @delete="openDeleteDialog"
+            />
+          </template>
+
+          <template v-else>
+            <section
+              class="custom-analysis-modal__empty"
+              data-testid="custom-analysis-modal-empty"
+            >
+              <p class="custom-analysis-modal__empty-title">
+                {{ t('audit.improvements.custom_analysis_modal.empty_title') }}
+              </p>
+              <p class="custom-analysis-modal__empty-description">
+                {{
+                  t(
+                    'audit.improvements.custom_analysis_modal.empty_description',
+                  )
+                }}
+              </p>
+            </section>
+          </template>
+        </section>
+      </section>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+
+  <DeleteCustomAnalysisDialog
+    v-if="deleteTarget"
+    v-model:open="isDeleteDialogOpen"
+    data-testid="custom-analysis-modal-delete-dialog"
+    :customAnalysisUuid="deleteTarget.uuid"
+    :customAnalysisTitle="deleteTarget.title"
+  />
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { storeToRefs } from 'pinia';
+
+import { useCustomAnalysisImprovementsStore } from '@/store/CustomAnalysisImprovements';
+import { MAX_CUSTOM_ANALYSIS } from '@/store/types/CustomAnalysisImprovements.types';
+
+import CustomAnalysisImprovementRow from './CustomAnalysisImprovementRow.vue';
+import DeleteCustomAnalysisDialog from './DeleteCustomAnalysisDialog.vue';
+
+const open = defineModel<boolean>('open', {
+  required: true,
+});
+
+const TITLE_MAX_LENGTH = 128;
+
+const { t } = useI18n();
+const customAnalysisImprovementsStore = useCustomAnalysisImprovementsStore();
+const { customAnalysis, createCustomAnalysis } = storeToRefs(
+  customAnalysisImprovementsStore,
+);
+
+const titleText = ref('');
+const definitionText = ref('');
+const deleteTarget = ref<{ uuid: string; title: string } | null>(null);
+const isDeleteDialogOpen = ref(false);
+
+const hasCustomAnalysisItems = computed(
+  () => customAnalysis.value.data.length > 0,
+);
+
+const isLimitReached = computed(
+  () => customAnalysis.value.data.length >= MAX_CUSTOM_ANALYSIS,
+);
+
+const canSubmit = computed(
+  () => titleText.value.trim() && definitionText.value.trim(),
+);
+
+function handleOpenChange(value: boolean) {
+  open.value = value;
+}
+
+function openDeleteDialog(customAnalysisUuid: string) {
+  const item = customAnalysis.value.data.find(
+    (entry) => entry.uuid === customAnalysisUuid,
+  );
+
+  if (!item) return;
+
+  deleteTarget.value = {
+    uuid: item.uuid,
+    title: item.title,
+  };
+  isDeleteDialogOpen.value = true;
+}
+
+async function handleAdd() {
+  const title = titleText.value.trim();
+  const definition = definitionText.value.trim();
+  if (!title || !definition || isLimitReached.value) return;
+
+  const result = await customAnalysisImprovementsStore.submitCustomAnalysis({
+    title,
+    definition,
+  });
+
+  if (result.status === 'complete') {
+    titleText.value = '';
+    definitionText.value = '';
+  }
+}
+
+watch(
+  () => open.value,
+  (isOpen) => {
+    if (isOpen) {
+      customAnalysisImprovementsStore.fetchCustomAnalysis();
+      return;
+    }
+
+    titleText.value = '';
+    definitionText.value = '';
+    deleteTarget.value = null;
+    isDeleteDialogOpen.value = false;
+  },
+);
+
+watch(isDeleteDialogOpen, (isOpen) => {
+  if (!isOpen) {
+    deleteTarget.value = null;
+  }
+});
+</script>
+
+<style scoped lang="scss">
+.custom-analysis-modal {
+  overflow: hidden;
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+
+    overflow-y: auto;
+  }
+
+  &__description {
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+
+  &__form {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-4;
+
+    padding: $unnnic-space-6;
+  }
+
+  &__form-fields {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-3;
+  }
+
+  &__add-button {
+    align-self: flex-start;
+  }
+
+  &__list-section {
+    border-top: 1px solid $unnnic-color-border-base;
+
+    display: flex;
+    flex-direction: column;
+
+    padding: $unnnic-space-6;
+  }
+
+  &__list-heading {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: $unnnic-space-2;
+
+    border-bottom: 1px solid $unnnic-color-border-base;
+    padding-bottom: $unnnic-space-3;
+  }
+
+  &__list-title {
+    font: $unnnic-font-action;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__empty {
+    margin: auto 0;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: $unnnic-space-1;
+
+    text-align: center;
+    min-height: 100px;
+  }
+
+  &__empty-title {
+    font: $unnnic-font-action;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__empty-description {
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-muted;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/CustomAnalysisModal/DeleteCustomAnalysisDialog.vue
+++ b/src/components/ConversationsImprovements/CustomAnalysisModal/DeleteCustomAnalysisDialog.vue
@@ -1,0 +1,112 @@
+<template>
+  <UnnnicDialog
+    data-testid="delete-custom-analysis-dialog"
+    :open="open"
+    lazyMount
+    @update:open="handleOpenChange"
+  >
+    <UnnnicDialogContent size="medium">
+      <UnnnicDialogHeader type="warning">
+        <UnnnicDialogTitle data-testid="delete-custom-analysis-dialog-title">
+          {{ t('audit.improvements.custom_analysis_modal.delete.title') }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+
+      <i18n-t
+        tag="p"
+        class="delete-custom-analysis-dialog__description"
+        keypath="audit.improvements.custom_analysis_modal.delete.description"
+        data-testid="delete-custom-analysis-dialog-description"
+      >
+        <template #name>
+          <b data-testid="delete-custom-analysis-dialog-description-name">
+            "{{ customAnalysisTitle }}"
+          </b>
+        </template>
+      </i18n-t>
+
+      <UnnnicDialogFooter>
+        <UnnnicDialogClose>
+          <UnnnicButton
+            data-testid="delete-custom-analysis-dialog-cancel"
+            :text="t('audit.improvements.custom_analysis_modal.delete.cancel')"
+            type="tertiary"
+            :disabled="isDeleting"
+            @click="close"
+          />
+        </UnnnicDialogClose>
+
+        <UnnnicButton
+          data-testid="delete-custom-analysis-dialog-confirm"
+          :text="t('audit.improvements.custom_analysis_modal.delete.confirm')"
+          :loading="isDeleting"
+          type="warning"
+          @click="onConfirm"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+import { storeToRefs } from 'pinia';
+
+import { useCustomAnalysisImprovementsStore } from '@/store/CustomAnalysisImprovements';
+
+const props = defineProps<{
+  customAnalysisUuid: string;
+  customAnalysisTitle: string;
+}>();
+
+const open = defineModel<boolean>('open', {
+  required: true,
+});
+
+const { t } = useI18n();
+const customAnalysisImprovementsStore = useCustomAnalysisImprovementsStore();
+const { deleteCustomAnalysis } = storeToRefs(customAnalysisImprovementsStore);
+
+const isDeleting = computed(
+  () => deleteCustomAnalysis.value.status === 'loading',
+);
+
+function close() {
+  if (isDeleting.value) return;
+  open.value = false;
+}
+
+function handleOpenChange(value: boolean) {
+  if (isDeleting.value) return;
+  open.value = value;
+}
+
+async function onConfirm() {
+  if (isDeleting.value) return;
+
+  const result =
+    await customAnalysisImprovementsStore.submitDeleteCustomAnalysis(
+      props.customAnalysisUuid,
+    );
+
+  if (result.status === 'complete') {
+    close();
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.delete-custom-analysis-dialog {
+  &__description {
+    margin: $unnnic-space-6;
+
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+
+    :deep(b) {
+      font-weight: $unnnic-font-weight-bold;
+    }
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/ImprovementsHeader.vue
+++ b/src/components/ConversationsImprovements/ImprovementsHeader.vue
@@ -27,11 +27,13 @@
     <RunAnalysisButton
       data-testid="conversations-improvements-header-run-button"
     />
+
+    <CustomAnalysisModal v-model:open="isCustomAnalysisModalOpen" />
   </header>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { isToday } from 'date-fns';
 import { storeToRefs } from 'pinia';
@@ -43,8 +45,10 @@ import {
   getYesterdayFormattedDate,
 } from '@/utils/formatters';
 import RunAnalysisButton from '@/components/ConversationsImprovements/RunAnalysisButton.vue';
+import CustomAnalysisModal from '@/components/ConversationsImprovements/CustomAnalysisModal/CustomAnalysisModal.vue';
 
 const { t } = useI18n();
+const isCustomAnalysisModalOpen = ref(false);
 const improvementsStore = useImprovementsStore();
 const { analysis, improvements } = storeToRefs(improvementsStore);
 
@@ -75,7 +79,7 @@ const headerDescription = computed(() => {
 });
 
 const openCustomAnalysisModal = () => {
-  console.log('openCustomAnalysisModal');
+  isCustomAnalysisModalOpen.value = true;
 };
 </script>
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -487,6 +487,43 @@
         "improvement": "Improvement",
         "type": "Type"
       },
+      "custom_analysis_modal": {
+        "add": "Add",
+        "affected_conversations": "{count, plural, one {# affected conversation} other {# affected conversations}}",
+        "create": {
+          "error": "Custom analysis couldn't be saved due to a technical issue",
+          "limit_error": "Custom analysis couldn't be saved due to the 10 custom analysis limit",
+          "success": {
+            "title": "Custom analysis added",
+            "description": "Issue will be monitored in upcoming analyses"
+          }
+        },
+        "delete": {
+          "cancel": "Cancel",
+          "confirm": "Delete",
+          "description": "The AI will stop searching for {name} in conversations. This action can't be undone.",
+          "error": "Custom analysis couldn't be deleted due to a technical issue",
+          "success": {
+            "description": "This issue won't be monitored in upcoming analyses",
+            "title": "Custom analysis deleted"
+          },
+          "title": "Delete custom analysis"
+        },
+        "definition_helper": "The more specific the description, the better the AI can identify the issue in conversations",
+        "definition_label": "What do you want to monitor?",
+        "definition_placeholder": "For example: Agent is providing unrealistic delivery deadlines",
+        "description": "Describe a behavior or issue that the AI should monitor in conversations. When identified, it automatically appears in the improvement backlog",
+        "empty_description": "Use the field above to start monitoring specific issues",
+        "empty_title": "No custom analysis added",
+        "limit_disclaimer": "The limit of 10 custom analyses has been reached. Delete one to add a new one",
+        "list_heading": "Custom analyses",
+        "list_heading_count": "{count} of {max}",
+        "no_affected_conversations": "No affected conversations",
+        "title": "Custom analysis",
+        "title_helper": "A short label to identify this analysis in the list",
+        "title_label": "Title",
+        "title_placeholder": "For example: Unrealistic delivery deadlines"
+      },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# affected conversation} other {# affected conversations}}",
         "affected_conversations_title": "Affected conversations",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -486,6 +486,43 @@
         "improvement": "Mejora",
         "type": "Tipo"
       },
+      "custom_analysis_modal": {
+        "add": "Agregar",
+        "affected_conversations": "{count, plural, one {# conversación afectada} other {# conversaciones afectadas}}",
+        "create": {
+          "error": "No se pudo guardar el análisis personalizado debido a un problema técnico",
+          "limit_error": "No se pudo guardar el análisis personalizado debido al límite de 10 análisis personalizados",
+          "success": {
+            "title": "Análisis personalizado agregado",
+            "description": "El problema se monitoreará en los próximos análisis"
+          }
+        },
+        "delete": {
+          "cancel": "Cancelar",
+          "confirm": "Eliminar",
+          "description": "La IA dejará de buscar {name} en las conversaciones. Esta acción no se puede deshacer.",
+          "error": "No se pudo eliminar el análisis personalizado debido a un problema técnico",
+          "success": {
+            "description": "Este problema no se monitoreará en los próximos análisis",
+            "title": "Análisis personalizado eliminado"
+          },
+          "title": "Eliminar análisis personalizado"
+        },
+        "definition_helper": "Cuanto más específica sea la descripción, mejor podrá la IA identificar el problema en las conversaciones",
+        "definition_label": "¿Qué deseas monitorear?",
+        "definition_placeholder": "Por ejemplo: Agente proporciona plazos de entrega poco realistas",
+        "description": "Describe un comportamiento o problema que la IA debe monitorear en las conversaciones. Cuando se identifica, aparece automáticamente en el backlog de mejoras",
+        "empty_description": "Usa el campo de arriba para comenzar a monitorear problemas específicos",
+        "empty_title": "Ningún análisis personalizado agregado",
+        "limit_disclaimer": "Se alcanzó el límite de 10 análisis personalizados. Elimina uno para agregar uno nuevo",
+        "list_heading": "Análisis personalizados",
+        "list_heading_count": "{count} de {max}",
+        "no_affected_conversations": "Ninguna conversación afectada",
+        "title": "Análisis personalizado",
+        "title_helper": "Etiqueta breve para identificar este análisis en la lista",
+        "title_label": "Título",
+        "title_placeholder": "Por ejemplo: Plazos de entrega poco realistas"
+      },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# conversación afectada} other {# conversaciones afectadas}}",
         "affected_conversations_title": "Conversaciones afectadas",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -486,6 +486,43 @@
         "improvement": "Melhoria",
         "type": "Tipo"
       },
+      "custom_analysis_modal": {
+        "add": "Adicionar",
+        "affected_conversations": "{count, plural, one {# conversa afetada} other {# conversas afetadas}}",
+        "create": {
+          "error": "Não foi possível salvar a análise personalizada devido a um problema técnico",
+          "limit_error": "Não foi possível salvar a análise personalizada devido ao limite de 10 análises personalizadas",
+          "success": {
+            "title": "Análise personalizada adicionada",
+            "description": "O problema será monitorado nas próximas análises"
+          }
+        },
+        "delete": {
+          "cancel": "Cancelar",
+          "confirm": "Excluir",
+          "description": "A IA deixará de buscar {name} nas conversas. Esta ação não pode ser desfeita.",
+          "error": "Não foi possível excluir a análise personalizada devido a um problema técnico",
+          "success": {
+            "description": "Este problema não será monitorado nas próximas análises",
+            "title": "Análise personalizada excluída"
+          },
+          "title": "Excluir análise personalizada"
+        },
+        "definition_helper": "Quanto mais específica a descrição, melhor a IA poderá identificar o problema nas conversas",
+        "definition_label": "O que você deseja monitorar?",
+        "definition_placeholder": "Por exemplo: Atendente fornece prazos de entrega irreais",
+        "description": "Descreva um comportamento ou problema que a IA deve monitorar nas conversas. Quando identificado, ele aparece automaticamente no backlog de melhorias",
+        "empty_description": "Use o campo acima para começar a monitorar problemas específicos",
+        "empty_title": "Nenhuma análise personalizada adicionada",
+        "limit_disclaimer": "O limite de 10 análises personalizadas foi atingido. Exclua uma para adicionar uma nova",
+        "list_heading": "Análises personalizadas",
+        "list_heading_count": "{count} de {max}",
+        "no_affected_conversations": "Nenhuma conversa afetada",
+        "title": "Análise personalizada",
+        "title_helper": "Rótulo curto para identificar esta análise na lista",
+        "title_label": "Título",
+        "title_placeholder": "Por exemplo: Prazos de entrega irreais"
+      },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# conversa afetada} other {# conversas afetadas}}",
         "affected_conversations_title": "Conversas afetadas",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -485,6 +485,43 @@
         "improvement": "Îmbunătățire",
         "type": "Tip"
       },
+      "custom_analysis_modal": {
+        "add": "Adaugă",
+        "affected_conversations": "{count, plural, one {# conversație afectată} other {# conversații afectate}}",
+        "create": {
+          "error": "Analiza personalizată nu a putut fi salvată din cauza unei probleme tehnice",
+          "limit_error": "Analiza personalizată nu a putut fi salvată din cauza limitei de 10 analize personalizate",
+          "success": {
+            "title": "Analiză personalizată adăugată",
+            "description": "Problema va fi monitorizată în analizele viitoare"
+          }
+        },
+        "delete": {
+          "cancel": "Anulează",
+          "confirm": "Șterge",
+          "description": "AI-ul va înceta să caute {name} în conversații. Această acțiune nu poate fi anulată.",
+          "error": "Analiza personalizată nu a putut fi ștearsă din cauza unei probleme tehnice",
+          "success": {
+            "description": "Această problemă nu va fi monitorizată în analizele viitoare",
+            "title": "Analiză personalizată ștearsă"
+          },
+          "title": "Șterge analiza personalizată"
+        },
+        "definition_helper": "Cu cât descrierea este mai specifică, cu atât mai bine poate AI-ul să identifice problema în conversații",
+        "definition_label": "Ce dorești să monitorizezi?",
+        "definition_placeholder": "De exemplu: Agentul oferă termene de livrare nerealiste",
+        "description": "Descrie un comportament sau o problemă pe care AI-ul ar trebui să o monitorizeze în conversații. Când este identificată, apare automat în backlog-ul de îmbunătățiri",
+        "empty_description": "Folosește câmpul de mai sus pentru a începe să monitorizezi probleme specifice",
+        "empty_title": "Nicio analiză personalizată adăugată",
+        "limit_disclaimer": "Limita de 10 analize personalizate a fost atinsă. Șterge una pentru a adăuga una nouă",
+        "list_heading": "Analize personalizate",
+        "list_heading_count": "{count} din {max}",
+        "no_affected_conversations": "Nicio conversație afectată",
+        "title": "Analiză personalizată",
+        "title_helper": "Etichetă scurtă pentru a identifica această analiză în listă",
+        "title_label": "Titlu",
+        "title_placeholder": "De exemplu: Termene de livrare nerealiste"
+      },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# instrucțiune actualizată de la analiză} few {# instrucțiuni actualizate de la analiză} other {# de instrucțiuni actualizate de la analiză}}",
         "affected_conversations_title": "Conversații afectate",


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

Users need a way to define custom AI-monitored analyses that automatically surface issues in the improvements backlog. Previously, the "Custom Analysis" button in the improvements header had no functional implementation.

### Summary of Changes

- Added `CustomAnalysisModal` component that allows users to create custom analyses by providing a title and a definition. The modal fetches and lists existing custom analyses, enforces a maximum limit of 10, and resets form state on open/close.
- Added `CustomAnalysisImprovementRow` component to display each custom analysis entry with its title, affected conversations count, and a delete button.
- Added `DeleteCustomAnalysisDialog` component that presents a confirmation dialog before removing a custom analysis, preventing accidental deletions and blocking interaction while the deletion is in progress.
- Wired up `CustomAnalysisModal` into `ImprovementsHeader`, replacing the placeholder `console.log` with the actual modal open trigger.
- Added all required i18n strings for the custom analysis modal (create, delete, empty state, limit disclaimer, list heading, and form labels) in English, Spanish, Portuguese, and Romanian.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/5546b22d-6dc3-49f2-9381-810ce7d9a8c2.png)

![image.png](https://app.graphite.com/user-attachments/assets/9c45d43e-ac60-4410-8161-69685d130f3b.png)

