### PR TITLE
feat: Add Contact Technical Support dialog and API integration

### DIFF
--- a/src/api/nexus/Supervisor.js
+++ b/src/api/nexus/Supervisor.js
@@ -93,6 +93,12 @@ export const Supervisor = {
       );
     },
 
+    async contactSupport({ projectUuid, improvementUuid }) {
+      await conversationsRequest.$http.post(
+        `/api/v1/projects/${projectUuid}/improvements/${improvementUuid}/contact_support`,
+      );
+    },
+
     async getById({ projectUuid, improvementUuid }) {
       const { data } = await conversationsRequest.$http.get(
         `/api/v1/projects/${projectUuid}/improvements/${improvementUuid}/`,

--- a/src/api/nexus/__tests__/Supervisor.spec.js
+++ b/src/api/nexus/__tests__/Supervisor.spec.js
@@ -256,6 +256,20 @@ describe('Supervisor.js', () => {
       expect(nexusRequest.$http.post).not.toHaveBeenCalled();
     });
 
+    it('contactSupport calls the contact support endpoint', async () => {
+      conversationsRequest.$http.post.mockResolvedValue({ data: {} });
+
+      await Supervisor.improvements.contactSupport({
+        projectUuid,
+        improvementUuid: 'improvement-uuid-1',
+      });
+
+      expect(conversationsRequest.$http.post).toHaveBeenCalledWith(
+        `/api/v1/projects/${projectUuid}/improvements/improvement-uuid-1/contact_support`,
+      );
+      expect(nexusRequest.$http.post).not.toHaveBeenCalled();
+    });
+
     it('getAnalysis calls the improvements endpoint and adapts the response', async () => {
       conversationsRequest.$http.get.mockResolvedValue({
         data: mockApiResponse,

--- a/src/components/ConversationsImprovements/DrawerDetails/ContactTechnicalSupportDialog.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/ContactTechnicalSupportDialog.vue
@@ -1,0 +1,186 @@
+<template>
+  <UnnnicDialog
+    data-testid="contact-technical-support-dialog"
+    :open="open"
+    lazyMount
+    @update:open="handleOpenChange"
+  >
+    <UnnnicDialogContent size="medium">
+      <UnnnicDialogHeader>
+        <UnnnicDialogTitle data-testid="contact-technical-support-dialog-title">
+          {{ t('audit.improvements.contact_technical_support_dialog.title') }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+
+      <section class="contact-technical-support-dialog__content">
+        <p data-testid="contact-technical-support-dialog-description">
+          {{ description }}
+        </p>
+
+        <section
+          class="contact-technical-support-dialog__info-box"
+          data-testid="contact-technical-support-dialog-info-box"
+        >
+          <p
+            class="contact-technical-support-dialog__info-title"
+            data-testid="contact-technical-support-dialog-info-title"
+          >
+            {{ improvementTitle }}
+          </p>
+
+          <p
+            v-for="item in infoPreviewItems"
+            :key="item.id"
+            class="contact-technical-support-dialog__info-caption"
+            :data-testid="`contact-technical-support-dialog-info-${item.id}`"
+          >
+            {{ item.text }}
+          </p>
+        </section>
+      </section>
+
+      <UnnnicDialogFooter>
+        <UnnnicDialogClose>
+          <UnnnicButton
+            data-testid="contact-technical-support-dialog-cancel"
+            :disabled="isSubmitting"
+            :text="
+              t('audit.improvements.contact_technical_support_dialog.cancel')
+            "
+            type="tertiary"
+            @click="close"
+          />
+        </UnnnicDialogClose>
+        <UnnnicButton
+          data-testid="contact-technical-support-dialog-confirm"
+          :loading="isSubmitting"
+          :text="
+            t(
+              'audit.improvements.contact_technical_support_dialog.contact_support',
+            )
+          "
+          type="primary"
+          @click="onConfirm"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { useImprovementsStore } from '@/store/Improvements';
+import { useProjectStore } from '@/store/Project';
+import { useUserStore } from '@/store/User';
+import { formatLongDate } from '@/utils/formatters';
+
+const SUPPORT_EMAIL = 'support.weni@vtex.com';
+
+const open = defineModel<boolean>('open', {
+  required: true,
+});
+
+const props = defineProps<{
+  improvementUuid: string;
+  improvementTitle: string;
+  conversationsCount: number;
+  improvementTypeLabel: string;
+  identifiedAt: string;
+}>();
+
+const { t } = useI18n();
+const improvementsStore = useImprovementsStore();
+const projectStore = useProjectStore();
+const userStore = useUserStore();
+
+const isSubmitting = ref(false);
+
+const description = computed(() =>
+  t('audit.improvements.contact_technical_support_dialog.description', {
+    support_email: SUPPORT_EMAIL,
+  }),
+);
+
+const infoPreviewItems = computed(() => {
+  const TRANSLATION_KEY = 'audit.improvements.contact_technical_support_dialog';
+
+  const itemsById = {
+    summary: t(`${TRANSLATION_KEY}.summary_type_and_count`, {
+      type: props.improvementTypeLabel,
+      count: props.conversationsCount,
+    }),
+    'identified-on': t(`${TRANSLATION_KEY}.identified_on`, {
+      date: formatLongDate(props.identifiedAt),
+      email: userStore.user.email ?? '',
+    }),
+    'project-uuid': t(`${TRANSLATION_KEY}.project_uuid`, {
+      uuid: projectStore.uuid,
+    }),
+  };
+
+  return Object.entries(itemsById).map(([id, text]) => ({ id, text }));
+});
+
+function close() {
+  open.value = false;
+}
+
+function handleOpenChange(value: boolean) {
+  if (!value && !isSubmitting.value) {
+    close();
+  }
+}
+
+async function onConfirm() {
+  if (isSubmitting.value) {
+    return;
+  }
+
+  isSubmitting.value = true;
+
+  const result = await improvementsStore.contactTechnicalSupport(
+    props.improvementUuid,
+  );
+
+  isSubmitting.value = false;
+
+  if (result.status === 'complete') {
+    close();
+  }
+}
+</script>
+
+<style scoped lang="scss">
+.contact-technical-support-dialog {
+  &__content {
+    padding: $unnnic-space-6;
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-4;
+
+    @include unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+
+  &__info-box {
+    border-radius: $unnnic-radius-2;
+    background: $unnnic-color-bg-base-soft;
+
+    padding: $unnnic-space-3;
+
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-1;
+  }
+
+  &__info-title {
+    font: $unnnic-font-caption-1;
+  }
+
+  &__info-caption {
+    font: $unnnic-font-caption-2;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/DrawerDetails/ImprovementDrawer.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/ImprovementDrawer.vue
@@ -43,7 +43,9 @@
           </p>
         </ImprovementDrawerSection>
 
-        <SuggestedSolutionSection />
+        <SuggestedSolutionSection
+          @open-contact-support="openContactSupportDialog"
+        />
 
         <AffectedConversationsSection
           :open="drawerOpen"
@@ -74,6 +76,16 @@
       :improvementUuid="improvement?.uuid ?? null"
       @success="handleStatusUpdateSuccess"
     />
+
+    <ContactTechnicalSupportDialog
+      v-if="typeTag.category === 'technical_issue' && improvement?.uuid"
+      v-model:open="isContactSupportDialogOpen"
+      :conversationsCount="improvement.conversationsCount ?? 0"
+      :identifiedAt="improvementsStore.analysis.task.createdAt"
+      :improvementTitle="improvement.text"
+      :improvementTypeLabel="typeTag.text"
+      :improvementUuid="improvement.uuid"
+    />
   </UnnnicDrawerNext>
 </template>
 
@@ -85,6 +97,7 @@ import { useImprovementsStore } from '@/store/Improvements';
 import { getImprovementTypeTag } from '@/utils/improvements/getImprovementTypeTag';
 
 import ImprovementStatusDialog from './ImprovementStatusDialog.vue';
+import ContactTechnicalSupportDialog from './ContactTechnicalSupportDialog.vue';
 import SuggestedSolutionSection from './SuggestedSolutionSection.vue';
 import AffectedConversationsSection from './AffectedConversationsSection.vue';
 import ImprovementDrawerSection from './ImprovementDrawerSection.vue';
@@ -109,11 +122,16 @@ const improvementDetail = computed(
 );
 
 const isStatusDialogOpen = ref(false);
+const isContactSupportDialogOpen = ref(false);
 const statusDialogStatus = ref<ImprovementStatus>('ignored');
 
 function openStatusDialog(status: ImprovementStatus) {
   statusDialogStatus.value = status;
   isStatusDialogOpen.value = true;
+}
+
+function openContactSupportDialog() {
+  isContactSupportDialogOpen.value = true;
 }
 
 function handleStatusUpdateSuccess() {
@@ -141,6 +159,7 @@ const typeTag = computed(() => {
   return {
     scheme,
     text: t(`audit.improvements.types.${category}`),
+    category,
   };
 });
 </script>

--- a/src/components/ConversationsImprovements/DrawerDetails/SuggestedSolutionSection.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/SuggestedSolutionSection.vue
@@ -39,6 +39,7 @@
 
       <UnnnicButton
         class="suggested-solution-content__cta"
+        data-testid="suggested-solution-cta"
         :text="ctaText"
         type="secondary"
         @click="handleCtaClick"
@@ -57,6 +58,10 @@ import ImprovementDrawerSection from './ImprovementDrawerSection.vue';
 import { getImprovementTypeTag } from '@/utils/improvements/getImprovementTypeTag';
 import { useProfileStore } from '@/store/Profile.js';
 import { UnnnicDisclaimer } from '@weni/unnnic-system';
+
+const emit = defineEmits<{
+  'open-contact-support': [];
+}>();
 
 const { t } = useI18n();
 
@@ -126,7 +131,7 @@ function handleCtaClick() {
       '*',
     );
   } else if (improvementCategory.value === 'technical_issue') {
-    console.log('contact technical support');
+    emit('open-contact-support');
   }
 }
 </script>

--- a/src/components/ConversationsImprovements/DrawerDetails/__tests__/ContactTechnicalSupportDialog.spec.js
+++ b/src/components/ConversationsImprovements/DrawerDetails/__tests__/ContactTechnicalSupportDialog.spec.js
@@ -1,0 +1,213 @@
+import { mount, flushPromises } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import { useImprovementsStore } from '@/store/Improvements';
+
+import ContactTechnicalSupportDialog from '../ContactTechnicalSupportDialog.vue';
+
+vi.mock('@/store/Project', () => ({
+  useProjectStore: vi.fn(() => ({
+    uuid: 'test-project-uuid',
+  })),
+}));
+
+vi.mock('@/store/User', () => ({
+  useUserStore: vi.fn(() => ({
+    user: {
+      email: 'user@example.com',
+    },
+  })),
+}));
+
+describe('ContactTechnicalSupportDialog.vue', () => {
+  let wrapper;
+  let improvementsStore;
+
+  const technicalIssueDetail = {
+    uuid: 'improvement-uuid-1',
+    text: 'Poor product search results are affecting customer experience.',
+    type: 'poor_product_search_results',
+    description: 'Search results are not relevant.',
+    suggestedSolution: 'Contact technical support to review the search index.',
+    status: 'pending',
+    affectedInstructions: [],
+  };
+
+  const technicalIssueTypeLabel = i18n.global.t(
+    'audit.improvements.types.technical_issue',
+  );
+
+  const defaultProps = {
+    open: true,
+    improvementUuid: 'improvement-uuid-1',
+    improvementTitle: technicalIssueDetail.text,
+    conversationsCount: 12,
+    improvementTypeLabel: technicalIssueTypeLabel,
+    identifiedAt: '2026-06-01T10:00:00Z',
+  };
+
+  const createWrapper = (props = {}) => {
+    wrapper = mount(ContactTechnicalSupportDialog, {
+      props: {
+        ...defaultProps,
+        ...props,
+      },
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+          }),
+        ],
+        stubs: {
+          UnnnicDialogClose: {
+            template: '<div><slot /></div>',
+          },
+        },
+      },
+    });
+
+    improvementsStore = useImprovementsStore();
+  };
+
+  const elements = {
+    title: () =>
+      wrapper.find('[data-testid="contact-technical-support-dialog-title"]'),
+    description: () =>
+      wrapper.find(
+        '[data-testid="contact-technical-support-dialog-description"]',
+      ),
+    infoBox: () =>
+      wrapper.find('[data-testid="contact-technical-support-dialog-info-box"]'),
+    infoTitle: () =>
+      wrapper.find(
+        '[data-testid="contact-technical-support-dialog-info-title"]',
+      ),
+    infoSummary: () =>
+      wrapper.find(
+        '[data-testid="contact-technical-support-dialog-info-summary"]',
+      ),
+    infoIdentifiedOn: () =>
+      wrapper.find(
+        '[data-testid="contact-technical-support-dialog-info-identified-on"]',
+      ),
+    infoProjectUuid: () =>
+      wrapper.find(
+        '[data-testid="contact-technical-support-dialog-info-project-uuid"]',
+      ),
+    cancelButton: () =>
+      wrapper.findComponent(
+        '[data-testid="contact-technical-support-dialog-cancel"]',
+      ),
+    confirmButton: () =>
+      wrapper.findComponent(
+        '[data-testid="contact-technical-support-dialog-confirm"]',
+      ),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders title and description', () => {
+    createWrapper();
+
+    expect(elements.title().text()).toBe(
+      i18n.global.t(
+        'audit.improvements.contact_technical_support_dialog.title',
+      ),
+    );
+    expect(elements.description().text()).toBe(
+      i18n.global.t(
+        'audit.improvements.contact_technical_support_dialog.description',
+        {
+          support_email: 'support.weni@vtex.com',
+        },
+      ),
+    );
+  });
+
+  it('renders the preview box with improvement details', () => {
+    createWrapper();
+
+    expect(elements.infoBox().exists()).toBe(true);
+    expect(elements.infoTitle().text()).toBe(technicalIssueDetail.text);
+    expect(elements.infoSummary().text()).toBe(
+      i18n.global.t(
+        'audit.improvements.contact_technical_support_dialog.summary_type_and_count',
+        {
+          type: technicalIssueTypeLabel,
+          count: 12,
+        },
+      ),
+    );
+    expect(elements.infoIdentifiedOn().text()).toContain('user@example.com');
+    expect(elements.infoProjectUuid().text()).toBe(
+      i18n.global.t(
+        'audit.improvements.contact_technical_support_dialog.project_uuid',
+        {
+          uuid: 'test-project-uuid',
+        },
+      ),
+    );
+  });
+
+  it('closes the dialog when cancel is clicked', async () => {
+    createWrapper();
+
+    await elements.cancelButton().trigger('click');
+
+    expect(wrapper.emitted('update:open')).toEqual([[false]]);
+  });
+
+  it('calls contactTechnicalSupport and closes the dialog on success', async () => {
+    createWrapper();
+    improvementsStore.contactTechnicalSupport = vi
+      .fn()
+      .mockResolvedValue({ status: 'complete' });
+
+    await elements.confirmButton().trigger('click');
+    await flushPromises();
+
+    expect(improvementsStore.contactTechnicalSupport).toHaveBeenCalledWith(
+      'improvement-uuid-1',
+    );
+    expect(wrapper.emitted('update:open')).toEqual([[false]]);
+  });
+
+  it('does not close the dialog when contactTechnicalSupport fails', async () => {
+    createWrapper();
+    improvementsStore.contactTechnicalSupport = vi
+      .fn()
+      .mockResolvedValue({ status: 'error' });
+
+    await elements.confirmButton().trigger('click');
+    await flushPromises();
+
+    expect(wrapper.emitted('update:open')).toBeUndefined();
+  });
+
+  it('disables cancel while submitting', async () => {
+    createWrapper();
+    let resolveContactSupport;
+    improvementsStore.contactTechnicalSupport = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveContactSupport = resolve;
+        }),
+    );
+
+    await elements.confirmButton().trigger('click');
+    await flushPromises();
+
+    expect(elements.cancelButton().props('disabled')).toBe(true);
+
+    resolveContactSupport({ status: 'complete' });
+    await flushPromises();
+  });
+});

--- a/src/components/ConversationsImprovements/DrawerDetails/__tests__/ImprovementDrawer.spec.js
+++ b/src/components/ConversationsImprovements/DrawerDetails/__tests__/ImprovementDrawer.spec.js
@@ -58,6 +58,11 @@ describe('ImprovementDrawer.vue', () => {
             props: ['status', 'improvementUuid', 'open'],
             emits: ['success'],
           },
+          ContactTechnicalSupportDialog: {
+            template:
+              '<div data-testid="contact-technical-support-dialog-stub" :data-open="String(open)" />',
+            props: ['improvementUuid', 'open'],
+          },
           AffectedConversationsSection: {
             template:
               '<section data-testid="improvement-drawer-affected-conversations-section"><h2 data-testid="improvement-drawer-affected-conversations-title">{{ $t(\'audit.improvements.drawer.affected_conversations_title\') }}</h2><button data-testid="emit-close-drawer" @click="$emit(\'close-drawer\')" /></section>',
@@ -117,6 +122,10 @@ describe('ImprovementDrawer.vue', () => {
       wrapper.find(
         '[data-testid="improvement-drawer-suggested-solution-title"]',
       ),
+    suggestedSolutionCta: () =>
+      wrapper.findComponent('[data-testid="suggested-solution-cta"]'),
+    contactSupportDialog: () =>
+      wrapper.find('[data-testid="contact-technical-support-dialog-stub"]'),
     affectedConversationsSection: () =>
       wrapper.find(
         '[data-testid="improvement-drawer-affected-conversations-section"]',
@@ -307,6 +316,31 @@ describe('ImprovementDrawer.vue', () => {
       createWrapper();
 
       expect(elements.diagnosisDescription().text()).toBe('');
+    });
+
+    it('opens the contact technical support dialog when the CTA is clicked for technical issues', async () => {
+      const technicalIssueImprovement = {
+        ...baseImprovement,
+        type: 'poor_product_search_results',
+      };
+      const technicalIssueDetail = {
+        ...baseImprovementDetail,
+        type: 'poor_product_search_results',
+        suggestedSolution: 'Review the search index configuration.',
+      };
+
+      createWrapper(
+        { improvement: technicalIssueImprovement },
+        { improvementDetail: technicalIssueDetail },
+      );
+
+      await elements.suggestedSolutionCta().trigger('click');
+      await nextTick();
+
+      const contactSupportDialog = elements.contactSupportDialog();
+
+      expect(contactSupportDialog.exists()).toBe(true);
+      expect(contactSupportDialog.attributes('data-open')).toBe('true');
     });
   });
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -524,6 +524,20 @@
         "title_label": "Title",
         "title_placeholder": "For example: Unrealistic delivery deadlines"
       },
+      "contact_technical_support_dialog": {
+        "cancel": "Cancel",
+        "contact_support": "Contact support",
+        "description": "We'll send an email to {support_email} with this information:",
+        "error": "Support couldn't be contacted. Try again later",
+        "identified_on": "Identified on {date} by {email}",
+        "project_uuid": "Project UUID: {uuid}",
+        "success": {
+          "description": "Ticket opened for {improvement_title}",
+          "title": "Support notified"
+        },
+        "summary_type_and_count": "{type} · {count, plural, one {# affected conversation} other {# affected conversations}}",
+        "title": "Contact support"
+      },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# affected conversation} other {# affected conversations}}",
         "affected_conversations_title": "Affected conversations",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -523,6 +523,20 @@
         "title_label": "Título",
         "title_placeholder": "Por ejemplo: Plazos de entrega poco realistas"
       },
+      "contact_technical_support_dialog": {
+        "cancel": "Cancelar",
+        "contact_support": "Contactar con soporte",
+        "description": "Enviaremos un correo electrónico a {support_email} con esta información:",
+        "error": "No se pudo contactar con soporte. Intenta nuevamente más tarde",
+        "identified_on": "Identificado el {date} por {email}",
+        "project_uuid": "UUID del proyecto: {uuid}",
+        "success": {
+          "description": "Ticket abierto para {improvement_title}",
+          "title": "Soporte notificado"
+        },
+        "summary_type_and_count": "{type} · {count, plural, one {# conversación afectada} other {# conversaciones afectadas}}",
+        "title": "Contactar con soporte"
+      },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# conversación afectada} other {# conversaciones afectadas}}",
         "affected_conversations_title": "Conversaciones afectadas",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -523,6 +523,20 @@
         "title_label": "Título",
         "title_placeholder": "Por exemplo: Prazos de entrega irreais"
       },
+      "contact_technical_support_dialog": {
+        "cancel": "Cancelar",
+        "contact_support": "Falar com o suporte",
+        "description": "Enviaremos um email para {support_email} com estas informações:",
+        "error": "Não foi possível contatar o suporte. Tente novamente mais tarde",
+        "identified_on": "Identificado em {date} por {email}",
+        "project_uuid": "UUID do projeto: {uuid}",
+        "success": {
+          "description": "Ticket aberto para {improvement_title}",
+          "title": "Suporte notificado"
+        },
+        "summary_type_and_count": "{type} · {count, plural, one {# conversa afetada} other {# conversas afetadas}}",
+        "title": "Falar com o suporte"
+      },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# conversa afetada} other {# conversas afetadas}}",
         "affected_conversations_title": "Conversas afetadas",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -522,6 +522,20 @@
         "title_label": "Titlu",
         "title_placeholder": "De exemplu: Termene de livrare nerealiste"
       },
+      "contact_technical_support_dialog": {
+        "cancel": "Anulează",
+        "contact_support": "Contactează asistența",
+        "description": "Vom trimite un email la {support_email} cu aceste informații:",
+        "error": "Asistența nu a putut fi contactată. Încearcă din nou mai târziu",
+        "identified_on": "Identificat la {date} de {email}",
+        "project_uuid": "UUID-ul proiectului: {uuid}",
+        "success": {
+          "description": "Ticket deschis pentru {improvement_title}",
+          "title": "Asistență notificată"
+        },
+        "summary_type_and_count": "{type} · {count, plural, one {# conversație afectată} few {# conversații afectate} other {# de conversații afectate}}",
+        "title": "Contactează asistența"
+      },
       "drawer": {
         "affected_conversations_count": "{count, plural, one {# instrucțiune actualizată de la analiză} few {# instrucțiuni actualizate de la analiză} other {# de instrucțiuni actualizate de la analiză}}",
         "affected_conversations_title": "Conversații afectate",

--- a/src/store/Improvements.ts
+++ b/src/store/Improvements.ts
@@ -256,6 +256,39 @@ export const useImprovementsStore = defineStore('Improvements', () => {
     }
   }
 
+  async function contactTechnicalSupport(improvementUuid: string) {
+    try {
+      await supervisorApi.improvements.contactSupport({
+        projectUuid: projectUuid.value,
+        improvementUuid,
+      });
+
+      alertStore.add({
+        type: 'success',
+        text: i18n.global.t(
+          'audit.improvements.contact_technical_support_dialog.success.title',
+        ),
+        description: i18n.global.t(
+          'audit.improvements.contact_technical_support_dialog.success.description',
+          {
+            improvement_title: improvementDetail.data?.text ?? '',
+          },
+        ),
+      });
+
+      return { status: 'complete' as const };
+    } catch (error) {
+      console.error(error);
+      alertStore.add({
+        type: 'error',
+        text: i18n.global.t(
+          'audit.improvements.contact_technical_support_dialog.error',
+        ),
+      });
+      return { status: 'error' as const };
+    }
+  }
+
   async function updateImprovementStatus(
     improvementUuid: string,
     status: ImprovementStatus,
@@ -343,6 +376,7 @@ export const useImprovementsStore = defineStore('Improvements', () => {
     fetchAffectedConversations,
     resetAffectedConversations,
     runAnalysis,
+    contactTechnicalSupport,
     updateImprovementStatus,
   };
 });

--- a/src/store/__tests__/Improvements.unit.spec.js
+++ b/src/store/__tests__/Improvements.unit.spec.js
@@ -17,6 +17,7 @@ vi.mock('@/api/nexusaiAPI', () => ({
           getAnalysis: vi.fn(),
           getById: vi.fn(),
           updateStatus: vi.fn(),
+          contactSupport: vi.fn(),
           getAffectedConversations: vi.fn(),
         },
       },
@@ -637,6 +638,53 @@ describe('Improvements Store', () => {
         ),
         description: i18n.global.t(
           'audit.improvements.status_update.error.ignored.description',
+        ),
+      });
+    });
+  });
+
+  describe('contactTechnicalSupport', () => {
+    it('calls contactSupport and shows a success alert', async () => {
+      const improvement = buildImprovement();
+      store.improvementDetail.data = buildImprovementDetail({
+        text: 'Poor product search results',
+      });
+      improvementsApi.contactSupport.mockResolvedValue();
+
+      const result = await store.contactTechnicalSupport(improvement.uuid);
+
+      expect(improvementsApi.contactSupport).toHaveBeenCalledWith({
+        projectUuid: 'test-project-uuid',
+        improvementUuid: improvement.uuid,
+      });
+      expect(result).toEqual({ status: 'complete' });
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'success',
+        text: i18n.global.t(
+          'audit.improvements.contact_technical_support_dialog.success.title',
+        ),
+        description: i18n.global.t(
+          'audit.improvements.contact_technical_support_dialog.success.description',
+          {
+            improvement_title: 'Poor product search results',
+          },
+        ),
+      });
+    });
+
+    it('returns error status and shows an error alert when the request fails', async () => {
+      const improvement = buildImprovement();
+      const error = new Error('contact support failed');
+      improvementsApi.contactSupport.mockRejectedValue(error);
+
+      const result = await store.contactTechnicalSupport(improvement.uuid);
+
+      expect(result).toEqual({ status: 'error' });
+      expect(consoleErrorSpy).toHaveBeenCalledWith(error);
+      expect(alertStore.add).toHaveBeenCalledWith({
+        type: 'error',
+        text: i18n.global.t(
+          'audit.improvements.contact_technical_support_dialog.error',
         ),
       });
     });


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other
```

### Motivation and Context

When an improvement is categorized as a `technical_issue`, users need a way to escalate it to technical support directly from the improvement drawer.

### Summary of Changes

- Added a `contactSupport` method to the `Supervisor.improvements` API, which posts to the `/contact_support` endpoint for a given improvement.
- Added a `contactTechnicalSupport` action to the Improvements store that calls the API, shows a success or error alert, and returns a typed status result.
- Created the `ContactTechnicalSupportDialog` component, which displays a confirmation dialog with a preview of the improvement details (type, affected conversations count, identified date, user email, and project UUID) before submitting the support request.
- Wired the dialog into `ImprovementDrawer`, rendering it only when the improvement category is `technical_issue` and opening it via an `open-contact-support` event emitted from `SuggestedSolutionSection`.
- Replaced the `console.log` placeholder in `SuggestedSolutionSection` with the `open-contact-support` emit.
- Added i18n strings for the dialog in English, Spanish, Portuguese, and Romanian.
- Added unit tests for the new API method, store action, dialog component, and drawer integration.

### Demonstrtion

![image.png](https://app.graphite.com/user-attachments/assets/c32dcb58-67b4-4955-9fb8-238e214ec697.png)

