### PR TITLE
feat: Enhance SupervisorUsername component with amazing conversation feature

### DIFF
--- a/setupVitest.js
+++ b/setupVitest.js
@@ -120,6 +120,42 @@ const unnnicTooltipStub = {
   template: genericStub,
 };
 
+const unnnicPopoverStub = {
+  name: 'UnnnicPopover',
+  inheritAttrs: false,
+  props: Unnnic?.unnnicPopover?.props,
+  emits: Unnnic?.unnnicPopover?.emits,
+  template: genericStub,
+};
+
+const unnnicPopoverTriggerStub = {
+  name: 'UnnnicPopoverTrigger',
+  inheritAttrs: false,
+  props: Unnnic?.unnnicPopoverTrigger?.props,
+  emits: Unnnic?.unnnicPopoverTrigger?.emits,
+  template: genericStub,
+};
+
+const unnnicPopoverContentStub = {
+  name: 'UnnnicPopoverContent',
+  inheritAttrs: false,
+  props: Unnnic?.unnnicPopoverContent?.props,
+  emits: Unnnic?.unnnicPopoverContent?.emits,
+  template: genericStub,
+};
+
+const OverrideUnnnicPopoverPlugin = {
+  install(app) {
+    // Override Unnnic Popover after UnnnicSystemPlugin registers the real
+    // components. Mutating the app context avoids Vue's re-registration warning.
+    Object.assign(app._context.components, {
+      UnnnicPopover: unnnicPopoverStub,
+      UnnnicPopoverTrigger: unnnicPopoverTriggerStub,
+      UnnnicPopoverContent: unnnicPopoverContentStub,
+    });
+  },
+};
+
 const ContentItemActionsStub = {
   name: 'ContentItemActionsStub',
   props: {
@@ -143,7 +179,7 @@ const ContentItemActionsStub = {
   `,
 };
 
-config.global.plugins = [i18n, UnnnicSystemPlugin];
+config.global.plugins = [i18n, UnnnicSystemPlugin, OverrideUnnnicPopoverPlugin];
 config.global.components = {
   UnnnicDivider,
   UnnnicIntelligenceText,

--- a/src/api/adapters/supervisor/conversation.ts
+++ b/src/api/adapters/supervisor/conversation.ts
@@ -13,6 +13,7 @@ interface ApiDataLegacy {
     end_date: string;
     resolution: string;
     name: string;
+    is_amazing?: boolean;
   }[];
 }
 
@@ -31,6 +32,7 @@ interface ApiDataV2 {
     nps: string | null;
     created_at: string;
     classification: string | null;
+    is_amazing?: boolean;
   }[];
 }
 
@@ -101,6 +103,7 @@ export const ConversationAdapter = {
                   }
                 : null,
             topics: result.topic,
+            isAmazing: Boolean(result.is_amazing),
           }),
         ),
       };

--- a/src/components/Instructions/ModalValidateInstruction/__tests__/__snapshots__/Instruction.spec.js.snap
+++ b/src/components/Instructions/ModalValidateInstruction/__tests__/__snapshots__/Instruction.spec.js.snap
@@ -7,14 +7,26 @@ exports[`Instruction.vue > Component rendering > should match snapshot 1`] = `
       <!----><textarea data-v-f10cd9b6="" class="unnnic-text-area__textarea unnnic-text-area__textarea--size-md unnnic-text-area__textarea--type-normal" placeholder="You're funny, but don't make jokes" value="Initial text"></textarea>
       <!---->
     </section>
-    <section data-v-ee639d0b="" class="instruction-ai-suggestion"><button data-v-df136255="" class="unnnic-popover-trigger instruction-ai-suggestion__trigger instruction-ai-suggestion__trigger--disabled" id="reka-popover-trigger-v-0" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="" data-state="closed">
-        <div data-v-03fa3548="" data-v-61269528="" class="unnnic-tooltip-trigger unnnic-tooltip" data-testid="tooltip-trigger" data-state="closed" data-grace-area-trigger=""><svg data-v-b593673c="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="unnnic-icon unnnic-icon-scheme--gray-300 unnnic-icon-size--sm" data-testid="iconify-icon"></svg> See AI suggestion</div>
-        <div data-v-61269528="" disabled="false" defer="false" forcemount="false">
-          <!---->
+    <section data-v-ee639d0b="" class="instruction-ai-suggestion">
+      <div>
+        <div class="instruction-ai-suggestion__trigger instruction-ai-suggestion__trigger--disabled">
+          <div data-v-03fa3548="" data-v-61269528="" class="unnnic-tooltip-trigger unnnic-tooltip" data-testid="tooltip-trigger" data-state="closed" data-grace-area-trigger=""><svg data-v-b593673c="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="unnnic-icon unnnic-icon-scheme--gray-300 unnnic-icon-size--sm" data-testid="iconify-icon"></svg> See AI suggestion</div>
+          <div data-v-61269528="" disabled="false" defer="false" forcemount="false">
+            <!---->
+          </div>
         </div>
-      </button>
-      <div disabled="false" defer="false" forcemount="false">
-        <!---->
+        <div>
+          <h3 class="instruction-ai-suggestion__title">AI suggestion</h3>
+          <section data-v-a13fc64d="" data-v-f10cd9b6="" class="unnnic-form-element instruction-ai-suggestion__textarea">
+            <!----><textarea data-v-f10cd9b6="" class="unnnic-text-area__textarea unnnic-text-area__textarea--size-md unnnic-text-area__textarea--type-normal" placeholder="You're funny, but don't make jokes" value=""></textarea>
+            <!---->
+          </section>
+          <footer class="unnnic-popover__footer"><button data-v-d7396b6a="" class="unnnic-button unnnic-button--size-large unnnic-button--primary">
+              <!----><svg data-v-b593673c="" data-v-d7396b6a="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" style="visibility: visible;" width="1em" height="1em" viewBox="0 0 16 16" class="unnnic-icon unnnic-icon-scheme--fg-on-primary unnnic-icon-size--ant unnnic--clickable unnnic-button__icon-left" data-testid="icon-left"></svg>
+              <!----><span data-v-d7396b6a="" class="unnnic-button__label" style="visibility: visible;" data-testid="button-label">Apply AI suggestion </span>
+              <!---->
+            </button></footer>
+        </div>
       </div>
     </section>
   </section><button data-v-d7396b6a="" data-v-ee639d0b="" data-testid="revalidate-button" class="unnnic-button unnnic-button--size-large unnnic-button--primary">

--- a/src/components/Instructions/ModalValidateInstruction/__tests__/__snapshots__/ModalValidateInstruction.spec.js.snap
+++ b/src/components/Instructions/ModalValidateInstruction/__tests__/__snapshots__/ModalValidateInstruction.spec.js.snap
@@ -8,14 +8,26 @@ exports[`ModalValidateInstruction.vue > Component rendering > should match snaps
         <!----><textarea data-v-f10cd9b6="" class="unnnic-text-area__textarea unnnic-text-area__textarea--size-md unnnic-text-area__textarea--type-normal" placeholder="You're funny, but don't make jokes" value="Test instruction text"></textarea>
         <!---->
       </section>
-      <section data-v-ee639d0b="" class="instruction-ai-suggestion"><button data-v-df136255="" class="unnnic-popover-trigger instruction-ai-suggestion__trigger instruction-ai-suggestion__trigger--disabled" id="reka-popover-trigger-v-0" type="button" aria-haspopup="dialog" aria-expanded="false" aria-controls="" data-state="closed">
-          <div data-v-03fa3548="" data-v-61269528="" class="unnnic-tooltip-trigger unnnic-tooltip" data-testid="tooltip-trigger" data-state="closed" data-grace-area-trigger=""><svg data-v-b593673c="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="unnnic-icon unnnic-icon-scheme--gray-300 unnnic-icon-size--sm" data-testid="iconify-icon"></svg> See AI suggestion</div>
-          <div data-v-61269528="" disabled="false" defer="false" forcemount="false">
-            <!---->
+      <section data-v-ee639d0b="" class="instruction-ai-suggestion">
+        <div>
+          <div class="instruction-ai-suggestion__trigger instruction-ai-suggestion__trigger--disabled">
+            <div data-v-03fa3548="" data-v-61269528="" class="unnnic-tooltip-trigger unnnic-tooltip" data-testid="tooltip-trigger" data-state="closed" data-grace-area-trigger=""><svg data-v-b593673c="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="unnnic-icon unnnic-icon-scheme--gray-300 unnnic-icon-size--sm" data-testid="iconify-icon"></svg> See AI suggestion</div>
+            <div data-v-61269528="" disabled="false" defer="false" forcemount="false">
+              <!---->
+            </div>
           </div>
-        </button>
-        <div disabled="false" defer="false" forcemount="false">
-          <!---->
+          <div>
+            <h3 class="instruction-ai-suggestion__title">AI suggestion</h3>
+            <section data-v-a13fc64d="" data-v-f10cd9b6="" class="unnnic-form-element instruction-ai-suggestion__textarea">
+              <!----><textarea data-v-f10cd9b6="" class="unnnic-text-area__textarea unnnic-text-area__textarea--size-md unnnic-text-area__textarea--type-normal" placeholder="You're funny, but don't make jokes" value=""></textarea>
+              <!---->
+            </section>
+            <footer class="unnnic-popover__footer"><button data-v-d7396b6a="" class="unnnic-button unnnic-button--size-large unnnic-button--primary">
+                <!----><svg data-v-b593673c="" data-v-d7396b6a="" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" style="visibility: visible;" width="1em" height="1em" viewBox="0 0 16 16" class="unnnic-icon unnnic-icon-scheme--fg-on-primary unnnic-icon-size--ant unnnic--clickable unnnic-button__icon-left" data-testid="icon-left"></svg>
+                <!----><span data-v-d7396b6a="" class="unnnic-button__label" style="visibility: visible;" data-testid="button-label">Apply AI suggestion </span>
+                <!---->
+              </button></footer>
+          </div>
         </div>
       </section>
     </section><button data-v-d7396b6a="" data-v-ee639d0b="" data-testid="revalidate-button" disabled="" class="unnnic-button unnnic-button--size-large unnnic-button--primary">

--- a/src/components/Supervisor/SupervisorUsername.vue
+++ b/src/components/Supervisor/SupervisorUsername.vue
@@ -1,15 +1,61 @@
 <template>
-  <h3
-    data-testid="supervisor-username"
-    class="supervisor-username"
-    :class="`supervisor-username--${font}`"
-  >
-    {{ displayName }}
-  </h3>
+  <section class="supervisor-username">
+    <h3
+      data-testid="supervisor-username"
+      class="supervisor-username__text"
+      :class="`supervisor-username__text--${font}`"
+    >
+      {{ displayName }}
+    </h3>
+    <UnnnicPopover
+      v-if="isAmazing && featureFlagsStore.flags.conversationsImprovements"
+      v-model:open="isPopoverOpen"
+      class="is-amazing-popover"
+      data-testid="amazing-conversation-popover"
+    >
+      <UnnnicPopoverTrigger
+        class="supervisor-username__is-amazing"
+        data-testid="amazing-conversation-trigger"
+        @mouseenter="isPopoverOpen = true"
+        @mouseleave="isPopoverOpen = false"
+      >
+        <UnnnicIcon
+          class="is-amazing__icon"
+          icon="star"
+          filled
+          scheme="fg-accent"
+          size="sm"
+          data-testid="amazing-conversation-icon"
+        />
+      </UnnnicPopoverTrigger>
+      <UnnnicPopoverContent
+        class="is-amazing-popover__content"
+        side="top"
+        size="large"
+        :align="font === 'emphasis' ? 'start' : 'end'"
+        data-testid="amazing-conversation-content"
+        @close-auto-focus.prevent
+      >
+        <p
+          class="is-amazing-popover__title"
+          data-testid="amazing-conversation-title"
+        >
+          {{ $t('audit.conversations.amazing_conversation.title') }}
+        </p>
+        <p
+          class="is-amazing-popover__description"
+          data-testid="amazing-conversation-description"
+        >
+          {{ $t('audit.conversations.amazing_conversation.description') }}
+        </p>
+      </UnnnicPopoverContent>
+    </UnnnicPopover>
+  </section>
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 
 import i18n from '@/utils/plugins/i18n';
 
@@ -18,13 +64,19 @@ const props = withDefaults(
     username?: string;
     fallbackKey?: string;
     font?: 'emphasis' | 'display-2';
+    isAmazing?: boolean;
   }>(),
   {
     username: '',
     fallbackKey: 'audit.conversations.unnamed_contact',
     font: 'emphasis',
+    isAmazing: false,
   },
 );
+
+const isPopoverOpen = ref(false);
+
+const featureFlagsStore = useFeatureFlagsStore();
 
 const displayName = computed(() => {
   return props.username || `[${i18n.global.t(props.fallbackKey)}]`;
@@ -33,18 +85,45 @@ const displayName = computed(() => {
 
 <style scoped lang="scss">
 .supervisor-username {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  display: flex;
+  align-items: center;
+  gap: $unnnic-space-2;
 
-  color: $unnnic-color-fg-emphasized;
+  &__text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
 
-  &--emphasis {
-    @include unnnic-font-emphasis;
+    color: $unnnic-color-fg-emphasized;
+    &--emphasis {
+      @include unnnic-font-emphasis;
+    }
+
+    &--display-2 {
+      @include unnnic-font-display-2;
+    }
   }
 
-  &--display-2 {
-    @include unnnic-font-display-2;
+  &__is-amazing {
+    background-color: $unnnic-color-bg-accent-plain;
+    border-radius: $unnnic-radius-full;
+
+    padding: $unnnic-space-05;
+
+    display: flex;
+  }
+}
+
+.is-amazing-popover {
+  color: $unnnic-color-fg-emphasized;
+
+  &__title {
+    @include unnnic-font-display-3;
+    margin-bottom: $unnnic-space-2;
+  }
+
+  &__description {
+    @include unnnic-font-body;
   }
 }
 </style>

--- a/src/components/Supervisor/__tests__/SupervisorUsername.spec.js
+++ b/src/components/Supervisor/__tests__/SupervisorUsername.spec.js
@@ -1,0 +1,110 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import SupervisorUsername from '@/components/Supervisor/SupervisorUsername.vue';
+
+describe('SupervisorUsername.vue', () => {
+  let wrapper;
+
+  const createWrapper = (
+    props = {},
+    { conversationsImprovements = true } = {},
+  ) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      stubActions: false,
+      initialState: {
+        FeatureFlags: {
+          activeFeatures: conversationsImprovements ? ['improvements'] : [],
+        },
+      },
+    });
+
+    wrapper = mount(SupervisorUsername, {
+      props: {
+        username: 'Jane Doe',
+        ...props,
+      },
+      global: {
+        plugins: [pinia],
+      },
+    });
+  };
+
+  const elements = {
+    username: () => wrapper.find('[data-testid="supervisor-username"]'),
+    popover: () => wrapper.find('[data-testid="amazing-conversation-popover"]'),
+    trigger: () => wrapper.find('[data-testid="amazing-conversation-trigger"]'),
+    icon: () => wrapper.find('[data-testid="amazing-conversation-icon"]'),
+    title: () => wrapper.find('[data-testid="amazing-conversation-title"]'),
+    description: () =>
+      wrapper.find('[data-testid="amazing-conversation-description"]'),
+    popoverComponent: () => wrapper.findComponent({ name: 'UnnnicPopover' }),
+  };
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders the username', () => {
+    createWrapper();
+
+    expect(elements.username().text()).toBe('Jane Doe');
+  });
+
+  it('renders the fallback when username is empty', () => {
+    createWrapper({ username: '' });
+
+    expect(elements.username().text()).toBe(
+      `[${i18n.global.t('audit.conversations.unnamed_contact')}]`,
+    );
+  });
+
+  it('applies the font class', () => {
+    createWrapper({ font: 'display-2' });
+
+    expect(elements.username().classes()).toContain(
+      'supervisor-username__text--display-2',
+    );
+  });
+
+  it('does not render the amazing conversation popover by default', () => {
+    createWrapper();
+
+    expect(elements.popover().exists()).toBe(false);
+  });
+
+  it('does not render the amazing conversation popover when the feature flag is disabled', () => {
+    createWrapper({ isAmazing: true }, { conversationsImprovements: false });
+
+    expect(elements.popover().exists()).toBe(false);
+  });
+
+  it('renders the amazing conversation popover when isAmazing is true and the feature flag is enabled', () => {
+    createWrapper({ isAmazing: true });
+
+    expect(elements.popover().exists()).toBe(true);
+    expect(elements.trigger().exists()).toBe(true);
+    expect(elements.icon().exists()).toBe(true);
+    expect(elements.title().text()).toBe(
+      i18n.global.t('audit.conversations.amazing_conversation.title'),
+    );
+    expect(elements.description().text()).toBe(
+      i18n.global.t('audit.conversations.amazing_conversation.description'),
+    );
+  });
+
+  it('opens the popover on trigger mouseenter and closes on mouseleave', async () => {
+    createWrapper({ isAmazing: true });
+
+    expect(elements.popoverComponent().props('open')).toBe(false);
+
+    await elements.trigger().trigger('mouseenter');
+    expect(elements.popoverComponent().props('open')).toBe(true);
+
+    await elements.trigger().trigger('mouseleave');
+    expect(elements.popoverComponent().props('open')).toBe(false);
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -390,6 +390,10 @@
         "transferred_to_human_support": "Transferred to human support",
         "transferred_to_human_support_description": "Includes conversations (AI-assisted and not assisted) transferred to a human representative."
       },
+      "amazing_conversation": {
+        "description": "This conversation shows the agent's ability to address multiple customer questions effectively. The clear resolution and attentive follow-up resulted in a satisfied customer.",
+        "title": "Amazing conversation"
+      },
       "conversations_count": "{count} conversations found",
       "unnamed_contact": "Unnamed contact",
       "attended_by_agent": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -390,6 +390,10 @@
         "transferred_to_human_support": "Transferidas a soporte humano",
         "transferred_to_human_support_description": "Incluye conversaciones (Atendido por IA y No atendido) transferidas a un representante humano."
       },
+      "amazing_conversation": {
+        "description": "Esta conversación muestra la capacidad del agente para responder múltiples preguntas del cliente de manera efectiva. La resolución clara y el seguimiento atento dieron como resultado un cliente satisfecho.",
+        "title": "Conversación increíble"
+      },
       "conversations_count": "{count} conversaciones encontradas",
       "unnamed_contact": "Contacto sin nombre",
       "attended_by_agent": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -390,6 +390,10 @@
         "transferred_to_human_support": "Transferido para o atendimento humano",
         "transferred_to_human_support_description": "Inclui conversas (Atendido por IA e Não atendido) encaminhadas a um atendente humano."
       },
+      "amazing_conversation": {
+        "description": "Esta conversa mostra a capacidade do agente de responder múltiplas perguntas do cliente com eficiência. A resolução clara e o acompanhamento atencioso resultaram em um cliente satisfeito.",
+        "title": "Conversa incrível"
+      },
       "conversations_count": "{count} conversas encontradas",
       "unnamed_contact": "Contato sem nome",
       "attended_by_agent": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -389,6 +389,10 @@
         "transferred_to_human_support": "Transferat la asistență umană",
         "transferred_to_human_support_description": "Include conversații (asistat de IA și neasistat) transferate către un reprezentant uman."
       },
+      "amazing_conversation": {
+        "description": "Această conversație demonstrează capacitatea agentului de a răspunde eficient la multiple întrebări ale clientului. Rezolvarea clară și urmărirea atentă au avut ca rezultat un client mulțumit.",
+        "title": "Conversație extraordinară"
+      },
       "conversations_count": "{count} conversații găsite",
       "unnamed_contact": "Contact fără nume",
       "attended_by_agent": {

--- a/src/store/types/Conversations.types.ts
+++ b/src/store/types/Conversations.types.ts
@@ -4,6 +4,7 @@ interface Csat {
 }
 
 export interface Conversation {
+  isAmazing: boolean;
   uuid: string;
   id: string;
   start: string;

--- a/src/views/Supervisor/SupervisorConversations/Conversation/Header.vue
+++ b/src/views/Supervisor/SupervisorConversations/Conversation/Header.vue
@@ -4,6 +4,7 @@
       <SupervisorUsername
         :username="conversation?.username"
         font="display-2"
+        :isAmazing="conversation?.isAmazing"
       />
 
       <UnnnicButton

--- a/src/views/Supervisor/SupervisorConversations/ConversationsTable/ConversationInfos.vue
+++ b/src/views/Supervisor/SupervisorConversations/ConversationsTable/ConversationInfos.vue
@@ -3,6 +3,7 @@
     <SupervisorUsername
       :username="username"
       data-testid="conversation-username"
+      :isAmazing="isAmazing"
     />
 
     <p
@@ -23,9 +24,11 @@ const props = withDefaults(
   defineProps<{
     username?: string;
     urn: string;
+    isAmazing?: boolean;
   }>(),
   {
     username: '',
+    isAmazing: false,
   },
 );
 

--- a/src/views/Supervisor/SupervisorConversations/ConversationsTable/ConversationRow.vue
+++ b/src/views/Supervisor/SupervisorConversations/ConversationsTable/ConversationRow.vue
@@ -12,6 +12,7 @@
       <ConversationInfos
         :username="conversation.username"
         :urn="conversation.urn"
+        :isAmazing="conversation.isAmazing"
       />
     </UnnnicTableCell>
 

--- a/src/views/Supervisor/SupervisorConversations/ConversationsTable/__tests__/ConversationInfos.spec.js
+++ b/src/views/Supervisor/SupervisorConversations/ConversationsTable/__tests__/ConversationInfos.spec.js
@@ -1,5 +1,6 @@
-import { expect } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
+import { createTestingPinia } from '@pinia/testing';
 
 import ConversationInfos from '@/views/Supervisor/SupervisorConversations/ConversationsTable/ConversationInfos.vue';
 
@@ -8,30 +9,66 @@ describe('ConversationInfos.vue', () => {
   const mockUsername = 'John Doe';
   const mockUrn = 'conversation-123';
 
+  const createWrapper = (props = {}) => {
+    wrapper = mount(ConversationInfos, {
+      props: {
+        username: mockUsername,
+        urn: mockUrn,
+        ...props,
+      },
+      global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            stubActions: false,
+            initialState: {
+              FeatureFlags: {
+                activeFeatures: ['improvements'],
+              },
+            },
+          }),
+        ],
+      },
+    });
+  };
+
   const conversationsUsername = () =>
     wrapper.findComponent('[data-testid="conversation-username"]');
   const conversationsUrn = () =>
     wrapper.find('[data-testid="conversation-urn"]');
 
-  beforeEach(() => {
-    wrapper = mount(ConversationInfos, {
-      props: {
-        username: mockUsername,
-        urn: mockUrn,
-      },
-    });
+  afterEach(() => {
+    wrapper?.unmount();
   });
 
   it('renders the component correctly', () => {
+    createWrapper();
+
     expect(conversationsUrn().exists()).toBe(true);
     expect(conversationsUsername().exists()).toBe(true);
   });
 
   it('displays the urn correctly', () => {
+    createWrapper();
+
     expect(conversationsUrn().text()).toBe(mockUrn);
   });
 
   it('displays the username correctly', () => {
+    createWrapper();
+
     expect(conversationsUsername().text()).toBe(mockUsername);
+  });
+
+  it('passes isAmazing to SupervisorUsername', () => {
+    createWrapper({ isAmazing: true });
+
+    expect(conversationsUsername().props('isAmazing')).toBe(true);
+  });
+
+  it('defaults isAmazing to false', () => {
+    createWrapper();
+
+    expect(conversationsUsername().props('isAmazing')).toBe(false);
   });
 });

--- a/src/views/Supervisor/SupervisorConversations/ConversationsTable/__tests__/ConversationRow.spec.js
+++ b/src/views/Supervisor/SupervisorConversations/ConversationsTable/__tests__/ConversationRow.spec.js
@@ -1,5 +1,6 @@
 import { mount } from '@vue/test-utils';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
 
 import ConversationRow from '@/views/Supervisor/SupervisorConversations/ConversationsTable/ConversationRow.vue';
 import ConversationInfos from '@/views/Supervisor/SupervisorConversations/ConversationsTable/ConversationInfos.vue';
@@ -17,6 +18,7 @@ describe('ConversationRow.vue', () => {
     status: 'in_progress',
     start: '2026-02-05T10:30:00Z',
     csat: null,
+    isAmazing: false,
   };
 
   const createWrapper = (props = {}) => {
@@ -26,6 +28,17 @@ describe('ConversationRow.vue', () => {
         ...props,
       },
       global: {
+        plugins: [
+          createTestingPinia({
+            createSpy: vi.fn,
+            stubActions: false,
+            initialState: {
+              FeatureFlags: {
+                activeFeatures: ['improvements'],
+              },
+            },
+          }),
+        ],
         stubs: {
           UnnnicTableRow: {
             template: '<tr v-bind="$attrs"><slot /></tr>',
@@ -81,6 +94,20 @@ describe('ConversationRow.vue', () => {
 
     expect(conversationInfos.props('username')).toBe(baseConversation.username);
     expect(conversationInfos.props('urn')).toBe(baseConversation.urn);
+    expect(conversationInfos.props('isAmazing')).toBe(
+      baseConversation.isAmazing,
+    );
+  });
+
+  it('passes isAmazing as true when conversation is amazing', () => {
+    createWrapper({
+      conversation: {
+        ...baseConversation,
+        isAmazing: true,
+      },
+    });
+
+    expect(elements.conversationInfos().props('isAmazing')).toBe(true);
   });
 
   it('renders the status tag', () => {


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other
```

### Motivation and Context

Conversations identified as "amazing" need a visual indicator to highlight the agent's exceptional performance. This surfaces the `is_amazing` flag from the conversation data and presents it to the user through a popover tooltip on the supervisor username component.

### Summary of Changes

- Added an `isAmazing` prop to `SupervisorUsername`, `ConversationInfos`, and `ConversationRow` components, propagating the `is_amazing` field from the `Conversation` type through the component tree.
- Extended `SupervisorUsername` to render a star icon badge and a `UnnnicPopover` with a title and description when `isAmazing` is `true` and the `conversationsImprovements` feature flag is enabled. The popover opens and closes on trigger hover.
- Added `is_amazing` to the `Conversation` TypeScript interface.
- Added `amazing_conversation` locale keys (title and description) in English, Spanish, Portuguese, and Romanian.
- Registered `UnnnicPopover`, `UnnnicPopoverTrigger`, and `UnnnicPopoverContent` stubs in the Vitest setup via an `OverrideUnnnicPopoverPlugin` to prevent Vue re-registration warnings and ensure correct stub behavior in tests.
- Added a full test suite for `SupervisorUsername`, covering username rendering, fallback display, font class application, popover visibility gating by `isAmazing` and feature flag, and hover-driven open/close behavior.
- Updated `ConversationInfos` and `ConversationRow` tests to include Pinia setup, `isAmazing` prop assertions, and the `is_amazing` field in the base conversation fixture.
- Updated snapshots for `Instruction.vue` and `ModalValidateInstruction.vue` to reflect the new stubbed popover structure.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/d270835e-dddc-4ef6-8f07-fc15e11d4329.png)

