### PR TITLE
feat: Add stale analysis disclaimer to ImprovementsHeader component

### DIFF
--- a/src/components/ConversationsImprovements/ImprovementsHeader.vue
+++ b/src/components/ConversationsImprovements/ImprovementsHeader.vue
@@ -3,6 +3,21 @@
     class="conversations-improvements-header"
     data-testid="conversations-improvements-header"
   >
+    <UnnnicDisclaimer
+      v-if="isStaleAnalysis"
+      class="conversations-improvements-header__stale-disclaimer"
+      data-testid="stale-analysis-disclaimer"
+      type="informational"
+      :title="
+        $t('audit.improvements.stale_analysis_disclaimer.title', {
+          days: analysisDaysAgo,
+        })
+      "
+      :description="
+        $t('audit.improvements.stale_analysis_disclaimer.description')
+      "
+    />
+
     <hgroup class="conversations-improvements-header__content">
       <h2
         class="conversations-improvements-header__title"
@@ -35,7 +50,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { isToday } from 'date-fns';
+import { differenceInDays, isToday } from 'date-fns';
 import { storeToRefs } from 'pinia';
 
 import { useImprovementsStore } from '@/store/Improvements';
@@ -47,10 +62,26 @@ import {
 import RunAnalysisButton from '@/components/ConversationsImprovements/RunAnalysisButton.vue';
 import CustomAnalysisModal from '@/components/ConversationsImprovements/CustomAnalysisModal/CustomAnalysisModal.vue';
 
+const STALE_ANALYSIS_DAYS_THRESHOLD = 5;
+
 const { t } = useI18n();
 const isCustomAnalysisModalOpen = ref(false);
 const improvementsStore = useImprovementsStore();
 const { analysis, improvements } = storeToRefs(improvementsStore);
+
+const analysisDaysAgo = computed(() => {
+  const createdAt = analysis.value.task?.createdAt;
+
+  if (!createdAt) {
+    return 0;
+  }
+
+  return differenceInDays(new Date(), new Date(createdAt));
+});
+
+const isStaleAnalysis = computed(
+  () => analysisDaysAgo.value >= STALE_ANALYSIS_DAYS_THRESHOLD,
+);
 
 const headerTitle = computed(() =>
   t('audit.improvements.header.title', {
@@ -87,9 +118,14 @@ const openCustomAnalysisModal = () => {
 .conversations-improvements-header {
   display: grid;
   grid-template-columns: 1fr auto auto;
-  gap: $unnnic-space-4;
+  column-gap: $unnnic-space-4;
+  row-gap: $unnnic-space-6;
 
   width: 100%;
+
+  &__stale-disclaimer {
+    grid-column: 1 / -1;
+  }
 
   &__content {
     display: flex;

--- a/src/components/ConversationsImprovements/__tests__/ImprovementsHeader.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementsHeader.spec.js
@@ -1,0 +1,170 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { subDays } from 'date-fns';
+
+import i18n from '@/utils/plugins/i18n';
+import { useImprovementsStore } from '@/store/Improvements';
+import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
+
+import ImprovementsHeader from '../ImprovementsHeader.vue';
+
+describe('ImprovementsHeader.vue', () => {
+  let wrapper;
+  let improvementsStore;
+
+  const findStaleDisclaimer = () =>
+    wrapper.findComponent('[data-testid="stale-analysis-disclaimer"]');
+  const findTitle = () =>
+    wrapper.find('[data-testid="conversations-improvements-header-title"]');
+  const findDescription = () =>
+    wrapper.find(
+      '[data-testid="conversations-improvements-header-description"]',
+    );
+
+  const createWrapper = (stateOverrides = {}) => {
+    const pinia = createTestingPinia({
+      createSpy: vi.fn,
+      initialState: {
+        Improvements: {
+          analysis: {
+            status: 'complete',
+            task: {
+              ...DEFAULT_IMPROVEMENTS_TASK,
+              createdAt: new Date().toISOString(),
+              isRunning: false,
+            },
+            ...(stateOverrides.analysis || {}),
+          },
+          improvements: {
+            data: [{ id: '1' }],
+            status: 'complete',
+            ...(stateOverrides.improvements || {}),
+          },
+        },
+      },
+    });
+
+    wrapper = shallowMount(ImprovementsHeader, {
+      global: {
+        plugins: [pinia],
+        stubs: {
+          UnnnicDisclaimer: {
+            name: 'UnnnicDisclaimer',
+            template: '<div data-testid="stale-analysis-disclaimer" />',
+            props: ['type', 'title', 'description'],
+          },
+          UnnnicButton: true,
+          RunAnalysisButton: true,
+          CustomAnalysisModal: true,
+        },
+      },
+    });
+
+    improvementsStore = useImprovementsStore(pinia);
+
+    return wrapper;
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Stale analysis disclaimer', () => {
+    it('does not render the disclaimer when the analysis is less than 5 days old', () => {
+      expect(findStaleDisclaimer().exists()).toBe(false);
+    });
+
+    it('does not render the disclaimer when the analysis is 4 days old', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: {
+            ...DEFAULT_IMPROVEMENTS_TASK,
+            createdAt: subDays(new Date(), 4).toISOString(),
+            isRunning: false,
+          },
+        },
+      });
+
+      expect(findStaleDisclaimer().exists()).toBe(false);
+    });
+
+    it('renders the disclaimer when the analysis is 5 days old', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: {
+            ...DEFAULT_IMPROVEMENTS_TASK,
+            createdAt: subDays(new Date(), 5).toISOString(),
+            isRunning: false,
+          },
+        },
+      });
+
+      const disclaimer = findStaleDisclaimer();
+
+      expect(disclaimer.exists()).toBe(true);
+      expect(disclaimer.props('type')).toBe('informational');
+      expect(disclaimer.props('title')).toBe(
+        i18n.global.t('audit.improvements.stale_analysis_disclaimer.title', {
+          days: 5,
+        }),
+      );
+      expect(disclaimer.props('description')).toBe(
+        i18n.global.t(
+          'audit.improvements.stale_analysis_disclaimer.description',
+        ),
+      );
+    });
+
+    it('renders the disclaimer with the correct day count when older than 5 days', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: {
+            ...DEFAULT_IMPROVEMENTS_TASK,
+            createdAt: subDays(new Date(), 10).toISOString(),
+            isRunning: false,
+          },
+        },
+      });
+
+      expect(findStaleDisclaimer().props('title')).toBe(
+        i18n.global.t('audit.improvements.stale_analysis_disclaimer.title', {
+          days: 10,
+        }),
+      );
+    });
+
+    it('does not render the disclaimer when createdAt is missing', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: null,
+          task: { ...DEFAULT_IMPROVEMENTS_TASK },
+        },
+      });
+
+      expect(findStaleDisclaimer().exists()).toBe(false);
+    });
+  });
+
+  describe('Header content', () => {
+    it('renders the header title', () => {
+      expect(findTitle().exists()).toBe(true);
+    });
+
+    it('renders the header description when createdAt is present', () => {
+      expect(findDescription().exists()).toBe(true);
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -587,6 +587,10 @@
         "description": "This may take a few hours. You can close this screen.",
         "title": "Analyzing {count} conversations from yesterday"
       },
+      "stale_analysis_disclaimer": {
+        "description": "Run a new analysis to identify opportunities for improvement",
+        "title": "{days, plural, one {The last analysis was run # day ago} other {The last analysis was run # days ago}}"
+      },
       "status_dialog": {
         "cancel": "Cancel",
         "ignored": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -586,6 +586,10 @@
         "description": "Esto puede tardar unas horas. Puedes cerrar esta pantalla.",
         "title": "Analizando {count} conversaciones de ayer"
       },
+      "stale_analysis_disclaimer": {
+        "description": "Ejecuta un nuevo análisis para identificar oportunidades de mejora",
+        "title": "{days, plural, one {El último análisis se ejecutó hace # día} other {El último análisis se ejecutó hace # días}}"
+      },
       "status_dialog": {
         "cancel": "Cancelar",
         "ignored": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -586,6 +586,10 @@
         "description": "Isso pode levar algumas horas. Você pode fechar esta tela.",
         "title": "Analisando {count} conversas de ontem"
       },
+      "stale_analysis_disclaimer": {
+        "description": "Execute uma nova análise para identificar oportunidades de melhoria",
+        "title": "{days, plural, one {A última análise foi executada há # dia} other {A última análise foi executada há # dias}}"
+      },
       "status_dialog": {
         "cancel": "Cancelar",
         "ignored": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -585,6 +585,10 @@
         "description": "Acest proces poate dura câteva ore. Poți închide acest ecran.",
         "title": "Se analizează {count} conversații de ieri"
       },
+      "stale_analysis_disclaimer": {
+        "description": "Rulează o nouă analiză pentru a identifica oportunități de îmbunătățire",
+        "title": "{days, plural, one {Ultima analiză a fost executată acum # zi} few {Ultima analiză a fost executată acum # zile} other {Ultima analiză a fost executată acum # de zile}}"
+      },
       "status_dialog": {
         "cancel": "Anulează",
         "ignored": {

--- a/src/views/Supervisor/index.vue
+++ b/src/views/Supervisor/index.vue
@@ -189,7 +189,7 @@ onBeforeMount(async () => {
   }
 
   :deep(.supervisor__header) {
-    padding: 0 $unnnic-spacing-sm $unnnic-spacing-md;
+    padding: 0 $unnnic-space-4 $unnnic-space-4;
   }
 
   &__conversations {


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

When an analysis hasn't been re-run in several days, users may be acting on outdated insights without realizing it. A visual indicator is needed to prompt them to run a fresh analysis when the existing one is stale.

### Summary of Changes

- Added a stale analysis disclaimer to the `ImprovementsHeader` component that appears when the last analysis was run 5 or more days ago.
- The disclaimer displays how many days ago the analysis was run (with proper singular/plural handling) and prompts the user to run a new analysis.
- Introduced a `STALE_ANALYSIS_DAYS_THRESHOLD` constant (set to 5) and two computed properties — `analysisDaysAgo` and `isStaleAnalysis` — to drive the disclaimer's visibility.
- Added localized strings for the stale analysis disclaimer in English, Spanish, Portuguese (BR), and Romanian.
- Added unit tests covering all disclaimer visibility scenarios: analysis less than 5 days old, exactly 5 days old, more than 5 days old, and missing `createdAt`.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/4122575c-62b8-48d0-874c-6da7816de210.png)

