### PR TITLE
fix: Update contactSupport API, analysis status handling, and remove conversation count from title

### DIFF
--- a/src/api/nexus/Supervisor.js
+++ b/src/api/nexus/Supervisor.js
@@ -93,10 +93,17 @@ export const Supervisor = {
       );
     },
 
-    async contactSupport({ projectUuid, improvementUuid }) {
-      await conversationsRequest.$http.post(
-        `/api/v1/projects/${projectUuid}/improvements/${improvementUuid}/contact_support`,
+    async contactSupport({ projectUuid, improvementUuid, projectName, email }) {
+      const { data } = await conversationsRequest.$http.post(
+        `/api/v1/projects/${projectUuid}/improvements/open-support-ticket/`,
+        {
+          improvement_uuid: improvementUuid,
+          project_name: projectName,
+          email,
+        },
       );
+
+      return data;
     },
 
     async getById({ projectUuid, improvementUuid }) {

--- a/src/api/nexus/__tests__/Supervisor.spec.js
+++ b/src/api/nexus/__tests__/Supervisor.spec.js
@@ -257,17 +257,27 @@ describe('Supervisor.js', () => {
     });
 
     it('contactSupport calls the contact support endpoint', async () => {
-      conversationsRequest.$http.post.mockResolvedValue({ data: {} });
+      conversationsRequest.$http.post.mockResolvedValue({
+        data: { status: 'sent' },
+      });
 
-      await Supervisor.improvements.contactSupport({
+      const result = await Supervisor.improvements.contactSupport({
         projectUuid,
         improvementUuid: 'improvement-uuid-1',
+        projectName: 'Test Project',
+        email: 'user@example.com',
       });
 
       expect(conversationsRequest.$http.post).toHaveBeenCalledWith(
-        `/api/v1/projects/${projectUuid}/improvements/improvement-uuid-1/contact_support`,
+        `/api/v1/projects/${projectUuid}/improvements/open-support-ticket/`,
+        {
+          improvement_uuid: 'improvement-uuid-1',
+          project_name: 'Test Project',
+          email: 'user@example.com',
+        },
       );
       expect(nexusRequest.$http.post).not.toHaveBeenCalled();
+      expect(result).toEqual({ status: 'sent' });
     });
 
     it('getAnalysis calls the improvements endpoint and adapts the response', async () => {

--- a/src/components/ConversationsImprovements/DrawerDetails/SuggestedSolutionSection.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/SuggestedSolutionSection.vue
@@ -126,7 +126,7 @@ function handleCtaClick() {
     window.parent.postMessage(
       {
         event: 'redirect',
-        path: 'aiAgents:instructions',
+        path: 'aiAgents:agents/instructions',
       },
       '*',
     );

--- a/src/components/ConversationsImprovements/RunningAnalysis.vue
+++ b/src/components/ConversationsImprovements/RunningAnalysis.vue
@@ -13,11 +13,7 @@
         class="running-analysis__title"
         data-testid="running-analysis-title"
       >
-        {{
-          $t('audit.improvements.running_analysis.title', {
-            count: improvementsStore.analysis.task?.total ?? 0,
-          })
-        }}
+        {{ $t('audit.improvements.running_analysis.title') }}
       </h2>
       <p
         class="running-analysis__description"
@@ -29,11 +25,7 @@
   </section>
 </template>
 
-<script setup lang="ts">
-import { useImprovementsStore } from '@/store/Improvements';
-
-const improvementsStore = useImprovementsStore();
-</script>
+<script setup lang="ts"></script>
 
 <style scoped lang="scss">
 .running-analysis {

--- a/src/components/ConversationsImprovements/__tests__/RunningAnalysis.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/RunningAnalysis.spec.js
@@ -77,9 +77,7 @@ describe('RunningAnalysis.vue', () => {
 
     it('renders the title with the conversation count from the store', () => {
       expect(findTitle().text()).toBe(
-        i18n.global.t('audit.improvements.running_analysis.title', {
-          count: 437,
-        }),
+        i18n.global.t('audit.improvements.running_analysis.title'),
       );
     });
 
@@ -93,29 +91,13 @@ describe('RunningAnalysis.vue', () => {
       });
 
       expect(findTitle().text()).toBe(
-        i18n.global.t('audit.improvements.running_analysis.title', {
-          count: 0,
-        }),
+        i18n.global.t('audit.improvements.running_analysis.title'),
       );
     });
 
     it('renders the description with the correct translation', () => {
       expect(findDescription().text()).toBe(
         i18n.global.t('audit.improvements.running_analysis.description'),
-      );
-    });
-  });
-
-  describe('Store reactivity', () => {
-    it('updates the title when the conversation count changes', async () => {
-      improvementsStore.analysis.task.total = 12;
-
-      await wrapper.vm.$nextTick();
-
-      expect(findTitle().text()).toBe(
-        i18n.global.t('audit.improvements.running_analysis.title', {
-          count: 12,
-        }),
       );
     });
   });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -585,7 +585,7 @@
       },
       "running_analysis": {
         "description": "This may take a few hours. You can close this screen.",
-        "title": "Analyzing {count} conversations from yesterday"
+        "title": "Analyzing conversations from yesterday"
       },
       "stale_analysis_disclaimer": {
         "description": "Run a new analysis to identify opportunities for improvement",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -584,7 +584,7 @@
       },
       "running_analysis": {
         "description": "Esto puede tardar unas horas. Puedes cerrar esta pantalla.",
-        "title": "Analizando {count} conversaciones de ayer"
+        "title": "Analizando conversaciones de ayer"
       },
       "stale_analysis_disclaimer": {
         "description": "Ejecuta un nuevo análisis para identificar oportunidades de mejora",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -584,7 +584,7 @@
       },
       "running_analysis": {
         "description": "Isso pode levar algumas horas. Você pode fechar esta tela.",
-        "title": "Analisando {count} conversas de ontem"
+        "title": "Analisando conversas de ontem"
       },
       "stale_analysis_disclaimer": {
         "description": "Execute uma nova análise para identificar oportunidades de melhoria",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -583,7 +583,7 @@
       },
       "running_analysis": {
         "description": "Acest proces poate dura câteva ore. Poți închide acest ecran.",
-        "title": "Se analizează {count} conversații de ieri"
+        "title": "Se analizează conversații de ieri"
       },
       "stale_analysis_disclaimer": {
         "description": "Rulează o nouă analiză pentru a identifica oportunități de îmbunătățire",

--- a/src/store/Improvements.ts
+++ b/src/store/Improvements.ts
@@ -1,12 +1,13 @@
 import { computed, reactive } from 'vue';
 import { defineStore } from 'pinia';
-import { isToday } from 'date-fns';
+import { differenceInHours } from 'date-fns';
 
 import nexusaiAPI from '@/api/nexusaiAPI';
 import i18n from '@/utils/plugins/i18n';
 import { getYesterdayFormattedDate } from '@/utils/formatters';
 import { useProjectStore } from './Project';
 import { useAlertStore } from './Alert';
+import { useUserStore } from './User';
 
 import type {
   AffectedConversationsResponse,
@@ -103,8 +104,10 @@ function notifyStatusUpdate(
 
 export const useImprovementsStore = defineStore('Improvements', () => {
   const alertStore = useAlertStore();
+  const userStore = useUserStore();
 
   const projectUuid = computed(() => useProjectStore().uuid);
+  const projectName = computed(() => useProjectStore().project.name);
   const supervisorApi = nexusaiAPI.agent_builder.supervisor;
 
   const analysis = reactive<{
@@ -161,7 +164,7 @@ export const useImprovementsStore = defineStore('Improvements', () => {
 
     const createdAt = analysis.task.createdAt;
 
-    if (createdAt && isToday(new Date(createdAt))) {
+    if (createdAt && differenceInHours(new Date(), new Date(createdAt)) < 24) {
       return 'already_run_today';
     }
 
@@ -219,9 +222,9 @@ export const useImprovementsStore = defineStore('Improvements', () => {
 
     if (response.task.isRunning) {
       await pollAnalysisUntilComplete(response);
-    } else {
-      setStatus('complete');
     }
+
+    setStatus('complete');
   }
 
   async function fetchImprovements() {
@@ -261,6 +264,8 @@ export const useImprovementsStore = defineStore('Improvements', () => {
       await supervisorApi.improvements.contactSupport({
         projectUuid: projectUuid.value,
         improvementUuid,
+        projectName: projectName.value,
+        email: userStore.user.email ?? '',
       });
 
       alertStore.add({

--- a/src/store/Project.ts
+++ b/src/store/Project.ts
@@ -13,6 +13,7 @@ interface ProjectDetails {
 
 interface ProjectInfo {
   status: null | 'loading' | 'success' | 'error';
+  name: string;
   wwcChannelUuid: string;
 }
 
@@ -24,6 +25,7 @@ export const useProjectStore = defineStore('Project', () => {
 
   const project = ref<ProjectInfo>({
     status: null,
+    name: '',
     wwcChannelUuid: '',
   });
 
@@ -35,6 +37,7 @@ export const useProjectStore = defineStore('Project', () => {
         projectUuid: uuid,
       });
 
+      project.value.name = data.name ?? '';
       project.value.wwcChannelUuid = data.default_channel_uuid;
       project.value.status = 'success';
     } catch (error) {

--- a/src/store/__tests__/Improvements.unit.spec.js
+++ b/src/store/__tests__/Improvements.unit.spec.js
@@ -28,6 +28,17 @@ vi.mock('@/api/nexusaiAPI', () => ({
 vi.mock('@/store/Project', () => ({
   useProjectStore: vi.fn(() => ({
     uuid: 'test-project-uuid',
+    project: {
+      name: 'Test Project',
+    },
+  })),
+}));
+
+vi.mock('@/store/User', () => ({
+  useUserStore: vi.fn(() => ({
+    user: {
+      email: 'user@example.com',
+    },
   })),
 }));
 
@@ -206,8 +217,8 @@ describe('Improvements Store', () => {
       expect(improvementsApi.getAnalysis).toHaveBeenCalledTimes(3);
       expect(store.improvements.data).toEqual(improvements);
       expect(store.analysis.task.isRunning).toBe(false);
-      expect(store.analysis.status).toBe('loading');
-      expect(store.improvements.status).toBe('loading');
+      expect(store.analysis.status).toBe('complete');
+      expect(store.improvements.status).toBe('complete');
       expect(alertStore.add).not.toHaveBeenCalled();
     });
 
@@ -248,7 +259,7 @@ describe('Improvements Store', () => {
       expect(store.runAnalysisBlockReason).toBeNull();
     });
 
-    it('returns already_run_today when task was created today', () => {
+    it('returns already_run_today when task was created less than 24 hours ago', () => {
       store.analysis.status = 'complete';
       store.analysis.yesterdayConversationsCount = 50;
       store.analysis.task = {
@@ -259,6 +270,19 @@ describe('Improvements Store', () => {
       };
 
       expect(store.runAnalysisBlockReason).toBe('already_run_today');
+    });
+
+    it('does not return already_run_today when task was created 24 hours ago or more', () => {
+      store.analysis.status = 'complete';
+      store.analysis.yesterdayConversationsCount = 50;
+      store.analysis.task = {
+        isRunning: false,
+        progress: 5,
+        total: 5,
+        createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+      };
+
+      expect(store.runAnalysisBlockReason).toBeNull();
     });
 
     it('prioritizes already_run_today over insufficient_volume', () => {
@@ -412,8 +436,8 @@ describe('Improvements Store', () => {
       expect(improvementsApi.getAnalysis).toHaveBeenCalledWith({
         projectUuid: 'test-project-uuid',
       });
-      expect(store.analysis.status).toBe('loading');
-      expect(store.improvements.status).toBe('loading');
+      expect(store.analysis.status).toBe('complete');
+      expect(store.improvements.status).toBe('complete');
       expect(store.analysis.task).toEqual({
         isRunning: false,
         progress: 3,
@@ -457,8 +481,8 @@ describe('Improvements Store', () => {
       expect(improvementsApi.getAnalysis).toHaveBeenCalledTimes(
         MAX_POLL_REQUESTS + 1,
       );
-      expect(store.analysis.status).toBe('loading');
-      expect(store.improvements.status).toBe('loading');
+      expect(store.analysis.status).toBe('complete');
+      expect(store.improvements.status).toBe('complete');
       expect(store.analysis.task).toEqual({
         isRunning: true,
         progress: 0,
@@ -656,6 +680,8 @@ describe('Improvements Store', () => {
       expect(improvementsApi.contactSupport).toHaveBeenCalledWith({
         projectUuid: 'test-project-uuid',
         improvementUuid: improvement.uuid,
+        projectName: 'Test Project',
+        email: 'user@example.com',
       });
       expect(result).toEqual({ status: 'complete' });
       expect(alertStore.add).toHaveBeenCalledWith({


### PR DESCRIPTION
## Description

### Type of Change

    - [x] Bugfix
    - [ ] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

Several small issues were identified in the Conversations Improvements feature that needed to be corrected: the contact support endpoint was pointing to the wrong URL and missing required payload fields, the running analysis title was unnecessarily displaying a conversation count, the `already_run_today` block reason was using a strict "today" check instead of a 24-hour window, and the analysis status was not being set to `complete` when polling finished without a running task.

### Summary of Changes

- Updated `contactSupport` to use the correct `conversationsRequest` HTTP client and endpoint (`/open-support-ticket/`), and added `improvement_uuid`, `project_name`, and `email` to the request body. The method now returns the response data.
- The `contactSupport` call in the Improvements store now passes `projectName` (sourced from the Project store) and `email` (sourced from the User store) as arguments.
- The Project store now stores and exposes the project `name` field, populated from the API response.
- Replaced the `isToday` check for `already_run_today` with a `differenceInHours < 24` check, so analyses run late at night are still correctly blocked the following morning within the 24-hour window.
- Fixed the analysis flow so that `setStatus('complete')` is always called after polling, regardless of whether the task was running.
- Removed the conversation count interpolation (`{count}`) from the running analysis title across all locales (en, es, pt_br, ro), simplifying the title to "Analyzing conversations from yesterday."
- Fixed the redirect path in `SuggestedSolutionSection` from `aiAgents:instructions` to `aiAgents:agents/instructions`.