### PR TITLE
feat: Add NoImprovementIdentified empty state component and zero-count header handling

### DIFF
--- a/src/components/ConversationsImprovements/NoImprovementIdentified.vue
+++ b/src/components/ConversationsImprovements/NoImprovementIdentified.vue
@@ -1,0 +1,65 @@
+<template>
+  <section
+    class="no-improvement-identified"
+    data-testid="no-improvement-identified"
+  >
+    <hgroup class="no-improvement-identified__content">
+      <h2
+        class="no-improvement-identified__title"
+        data-testid="no-improvement-identified-title"
+      >
+        <span
+          class="no-improvement-identified__emoji"
+          aria-hidden="true"
+        >
+          🎉
+        </span>
+        <p>{{ $t('audit.improvements.no_improvement_identified.title') }}</p>
+      </h2>
+      <p
+        class="no-improvement-identified__description"
+        data-testid="no-improvement-identified-description"
+      >
+        {{ $t('audit.improvements.no_improvement_identified.description') }}
+      </p>
+    </hgroup>
+  </section>
+</template>
+
+<script setup lang="ts"></script>
+
+<style scoped lang="scss">
+.no-improvement-identified {
+  flex: 1;
+
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: $unnnic-space-1;
+
+    text-align: center;
+  }
+
+  &__title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: $unnnic-space-05;
+
+    font: $unnnic-font-action;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__description {
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/__tests__/ImprovementsHeader.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementsHeader.spec.js
@@ -6,6 +6,7 @@ import { subDays } from 'date-fns';
 import i18n from '@/utils/plugins/i18n';
 import { useImprovementsStore } from '@/store/Improvements';
 import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
+import { getYesterdayFormattedDate } from '@/utils/formatters';
 
 import ImprovementsHeader from '../ImprovementsHeader.vue';
 
@@ -161,6 +162,26 @@ describe('ImprovementsHeader.vue', () => {
   describe('Header content', () => {
     it('renders the header title', () => {
       expect(findTitle().exists()).toBe(true);
+    });
+
+    it('renders the header title without count when there are no improvements', () => {
+      wrapper.unmount();
+      createWrapper({
+        improvements: {
+          data: [],
+          status: 'complete',
+        },
+      });
+
+      expect(findTitle().text()).toBe(
+        i18n.global.t('audit.improvements.header.title', {
+          date: getYesterdayFormattedDate(),
+          count: 0,
+        }),
+      );
+      expect(findTitle().text()).toBe(
+        `Analysis of conversations from ${getYesterdayFormattedDate()}`,
+      );
     });
 
     it('renders the header description when createdAt is present', () => {

--- a/src/components/ConversationsImprovements/__tests__/NoImprovementIdentified.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/NoImprovementIdentified.spec.js
@@ -1,0 +1,49 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import i18n from '@/utils/plugins/i18n';
+
+import NoImprovementIdentified from '../NoImprovementIdentified.vue';
+
+describe('NoImprovementIdentified.vue', () => {
+  let wrapper;
+
+  const findTitle = () =>
+    wrapper.find('[data-testid="no-improvement-identified-title"]');
+  const findTitleEmoji = () =>
+    wrapper.find('.no-improvement-identified__emoji');
+  const findDescription = () =>
+    wrapper.find('[data-testid="no-improvement-identified-description"]');
+
+  beforeEach(() => {
+    wrapper = shallowMount(NoImprovementIdentified);
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Component rendering', () => {
+    it('renders the empty state section', () => {
+      expect(
+        wrapper.find('[data-testid="no-improvement-identified"]').exists(),
+      ).toBe(true);
+    });
+
+    it('renders the title with the emoji and the correct translation', () => {
+      expect(findTitleEmoji().text()).toBe('🎉');
+      expect(findTitle().text()).toContain(
+        i18n.global.t('audit.improvements.no_improvement_identified.title'),
+      );
+    });
+
+    it('renders the description with the correct translation', () => {
+      expect(findDescription().text()).toBe(
+        i18n.global.t(
+          'audit.improvements.no_improvement_identified.description',
+        ),
+      );
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -566,7 +566,7 @@
         "run_analysis": "Run analysis",
         "run_analysis_already_run_today_tooltip": "Analysis already ran today\nReturn tomorrow to run a new analysis",
         "run_analysis_insufficient_volume_tooltip": "Insufficient conversation volume to run analysis\nMinimum of {min} conversations required",
-        "title": "{count, plural, one {Analysis of conversations from {date} · {count} improvement identified} other {Analysis of conversations from {date} · {count} improvements identified}}"
+        "title": "{count, plural, =0 {Analysis of conversations from {date}} one {Analysis of conversations from {date} · {count} improvement identified} other {Analysis of conversations from {date} · {count} improvements identified}}"
       },
       "insufficient_volume": {
         "description": "Minimum of {min} conversations required to run analysis",
@@ -576,6 +576,10 @@
         "description": "Run your first analysis to identify opportunities for improvement in yesterday's conversations",
         "run_analysis": "Run analysis",
         "title": "No analysis has been run yet"
+      },
+      "no_improvement_identified": {
+        "description": "No improvements were identified in this analysis",
+        "title": "Looking good!"
       },
       "run_analysis_dialog": {
         "cancel": "Cancel",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -565,7 +565,7 @@
         "run_analysis": "Ejecutar análisis",
         "run_analysis_already_run_today_tooltip": "Análisis ya ejecutado hoy\nNueva ejecución disponible mañana",
         "run_analysis_insufficient_volume_tooltip": "Volumen insuficiente de conversaciones para ejecutar el análisis\nMínimo de {min} conversaciones necesarias",
-        "title": "{count, plural, one {Análisis de conversaciones del {date} · {count} mejora identificada} other {Análisis de conversaciones del {date} · {count} mejoras identificadas}}"
+        "title": "{count, plural, =0 {Análisis de conversaciones del {date}} one {Análisis de conversaciones del {date} · {count} mejora identificada} other {Análisis de conversaciones del {date} · {count} mejoras identificadas}}"
       },
       "insufficient_volume": {
         "description": "Mínimo de {min} conversaciones necesarias para ejecutar el análisis",
@@ -575,6 +575,10 @@
         "description": "Ejecuta el primer análisis para identificar oportunidades de mejora en las conversaciones de ayer",
         "run_analysis": "Ejecutar análisis",
         "title": "Aún no se ha ejecutado ningún análisis"
+      },
+      "no_improvement_identified": {
+        "description": "No se identificaron mejoras en este análisis",
+        "title": "¡Todo bien!"
       },
       "run_analysis_dialog": {
         "cancel": "Cancelar",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -565,7 +565,7 @@
         "run_analysis": "Executar análise",
         "run_analysis_already_run_today_tooltip": "Análise já executada hoje\nNova execução disponível amanhã",
         "run_analysis_insufficient_volume_tooltip": "Volume insuficiente de conversas para executar a análise\nMínimo de {min} conversas necessárias",
-        "title": "{count, plural, one {Análise das conversas de {date} · {count} melhoria identificada} other {Análise das conversas de {date} · {count} melhorias identificadas}}"
+        "title": "{count, plural, =0 {Análise das conversas de {date}} one {Análise das conversas de {date} · {count} melhoria identificada} other {Análise das conversas de {date} · {count} melhorias identificadas}}"
       },
       "insufficient_volume": {
         "description": "Mínimo de {min} conversas necessárias para executar a análise",
@@ -575,6 +575,10 @@
         "description": "Execute a primeira análise para identificar oportunidades de melhoria nas conversas de ontem",
         "run_analysis": "Executar análise",
         "title": "Nenhuma análise foi executada ainda"
+      },
+      "no_improvement_identified": {
+        "description": "Nenhuma melhoria foi identificada nesta análise",
+        "title": "Tudo certo!"
       },
       "run_analysis_dialog": {
         "cancel": "Cancelar",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -564,7 +564,7 @@
         "run_analysis": "Rulează analiza",
         "run_analysis_already_run_today_tooltip": "Analiza a fost deja executată astăzi\nO nouă execuție va fi disponibilă mâine",
         "run_analysis_insufficient_volume_tooltip": "Volum insuficient de conversații pentru executarea analizei\nMinimum {min} conversații necesare",
-        "title": "{count, plural, one {Analiza conversațiilor din {date} · {count} îmbunătățire identificată} other {Analiza conversațiilor din {date} · {count} îmbunătățiri identificate}}"
+        "title": "{count, plural, =0 {Analiza conversațiilor din {date}} one {Analiza conversațiilor din {date} · {count} îmbunătățire identificată} other {Analiza conversațiilor din {date} · {count} îmbunătățiri identificate}}"
       },
       "insufficient_volume": {
         "description": "Minimum {min} conversații necesare pentru executarea analizei",
@@ -574,6 +574,10 @@
         "description": "Rulează prima analiză pentru a identifica oportunități de îmbunătățire în conversațiile de ieri",
         "run_analysis": "Rulează analiza",
         "title": "Nicio analiză nu a fost executată încă"
+      },
+      "no_improvement_identified": {
+        "description": "Nu au fost identificate îmbunătățiri în această analiză",
+        "title": "Totul arată bine!"
       },
       "run_analysis_dialog": {
         "cancel": "Anulează",

--- a/src/views/Supervisor/Improvements/__tests__/index.spec.js
+++ b/src/views/Supervisor/Improvements/__tests__/index.spec.js
@@ -9,6 +9,7 @@ import AnalysisInProgressDisclaimer from '@/components/ConversationsImprovements
 import ImprovementsHeader from '@/components/ConversationsImprovements/ImprovementsHeader.vue';
 import ImprovementsList from '@/components/ConversationsImprovements/ImprovementsList.vue';
 import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
+import NoImprovementIdentified from '@/components/ConversationsImprovements/NoImprovementIdentified.vue';
 import InsufficientConversationsVolume from '@/components/ConversationsImprovements/InsufficientConversationsVolume.vue';
 import RunningAnalysis from '@/components/ConversationsImprovements/RunningAnalysis.vue';
 
@@ -22,6 +23,8 @@ describe('Improvements view', () => {
     wrapper.find('[data-testid="conversations-improvements"]');
   const findNoAnalysisPerformed = () =>
     wrapper.findComponent(NoAnalysisPerformed);
+  const findNoImprovementIdentified = () =>
+    wrapper.findComponent(NoImprovementIdentified);
   const findInsufficientConversationsVolume = () =>
     wrapper.findComponent(InsufficientConversationsVolume);
   const findRunningAnalysis = () => wrapper.findComponent(RunningAnalysis);
@@ -187,6 +190,7 @@ describe('Improvements view', () => {
       });
 
       expect(findRunningAnalysis().exists()).toBe(false);
+      expect(findNoImprovementIdentified().exists()).toBe(true);
     });
 
     it('does not render RunningAnalysis when improvements data is available', () => {
@@ -229,6 +233,62 @@ describe('Improvements view', () => {
 
       expect(findRunningAnalysis().exists()).toBe(true);
       expect(findNoAnalysisPerformed().exists()).toBe(false);
+    });
+  });
+
+  describe('NoImprovementIdentified state', () => {
+    it('renders header and NoImprovementIdentified when analysis finished with no improvements', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: {
+            isRunning: false,
+            progress: 5,
+            total: 5,
+            createdAt: '2026-06-18T08:00:00Z',
+          },
+        },
+        improvements: {
+          data: [],
+          status: 'complete',
+        },
+      });
+
+      expect(findImprovementsHeader().exists()).toBe(true);
+      expect(findNoImprovementIdentified().exists()).toBe(true);
+      expect(findNoAnalysisPerformed().exists()).toBe(false);
+      expect(findRunningAnalysis().exists()).toBe(false);
+      expect(findImprovementsList().exists()).toBe(false);
+    });
+
+    it('does not render NoImprovementIdentified when improvements exist', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: {
+            isRunning: false,
+            progress: 5,
+            total: 5,
+            createdAt: '2026-06-18T08:00:00Z',
+          },
+        },
+        improvements: {
+          data: [
+            {
+              uuid: 'improvement-1',
+              text: 'Improve response time',
+              type: 'wrong_behavior_due_to_instructions',
+              conversationsCount: 5,
+            },
+          ],
+          status: 'complete',
+        },
+      });
+
+      expect(findNoImprovementIdentified().exists()).toBe(false);
+      expect(findImprovementsList().exists()).toBe(true);
     });
   });
 

--- a/src/views/Supervisor/Improvements/index.vue
+++ b/src/views/Supervisor/Improvements/index.vue
@@ -14,12 +14,13 @@
       v-else-if="analysis.task.isRunning && !improvements.data.length"
     />
 
-    <template v-else-if="improvements.data.length">
+    <template v-else>
       <AnalysisInProgressDisclaimer v-if="analysis.task.isRunning" />
 
       <ImprovementsHeader v-else />
 
-      <ImprovementsList />
+      <NoImprovementIdentified v-if="!improvements.data.length" />
+      <ImprovementsList v-else />
     </template>
   </section>
 </template>
@@ -33,6 +34,7 @@ import { useImprovementsStore } from '@/store/Improvements';
 import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
 import InsufficientConversationsVolume from '@/components/ConversationsImprovements/InsufficientConversationsVolume.vue';
 import RunningAnalysis from '@/components/ConversationsImprovements/RunningAnalysis.vue';
+import NoImprovementIdentified from '@/components/ConversationsImprovements/NoImprovementIdentified.vue';
 import ImprovementsHeader from '@/components/ConversationsImprovements/ImprovementsHeader.vue';
 import ImprovementsList from '@/components/ConversationsImprovements/ImprovementsList.vue';
 import AnalysisInProgressDisclaimer from '@/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue';


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

When an analysis completes but yields zero improvements, the UI had no dedicated state to communicate this outcome to the user. Without a clear empty state, the interface could appear broken or confusing.

### Summary of Changes

- Added a new `NoImprovementIdentified` component that displays a celebratory empty state (🎉) with a title and description when an analysis completes with no improvements found.
- Updated the Improvements view to render `NoImprovementIdentified` instead of `ImprovementsList` when the analysis is complete but the improvements list is empty, and to always show the `ImprovementsHeader` in this scenario.
- Updated the header title plural rule to include a `=0` case that omits the improvement count from the title when there are no improvements.
- Added translations for the new `no_improvement_identified` state (title and description) in English, Spanish, Portuguese, and Romanian locales.
- Added unit tests for the `NoImprovementIdentified` component and extended existing tests to cover the zero-improvement state in both the header and the Improvements view.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/1e1ce630-d6c7-4071-9e4a-57ee8de09624.png)

