### PR TITLE
fix: Update redirect path in SuggestedSolutionSection to include knowledge context

### DIFF
--- a/src/components/ConversationsImprovements/DrawerDetails/SuggestedSolutionSection.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/SuggestedSolutionSection.vue
@@ -118,7 +118,7 @@ function handleCtaClick() {
     window.parent.postMessage(
       {
         event: 'redirect',
-        path: 'aiBuild',
+        path: 'aiBuild:knowledge',
       },
       '*',
     );


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The redirect path for the CTA button in the Suggested Solution Section was pointing to the wrong location, failing to navigate users directly to the knowledge section within the AI Build page.

### Summary of Changes
Updated the redirect path in `SuggestedSolutionSection.vue` from `aiBuild` to `aiBuild:knowledge`, ensuring the CTA button correctly navigates users to the knowledge subsection of the AI Build page.