### PR TITLE
feat: Add ImprovementsSkeleton, percentage-based progress, sorted improvements, and scroll-aware layout

### DIFF
--- a/src/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue
+++ b/src/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue
@@ -5,8 +5,7 @@
     type="informational"
     :description="
       $t('audit.improvements.analysis_in_progress_disclaimer', {
-        progress: analysis.task?.progress ?? 0,
-        total: analysis.task?.total ?? 0,
+        percentage,
       })
     "
   >
@@ -19,9 +18,19 @@
   </UnnnicDisclaimer>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue';
 import { useImprovementsStore } from '@/store/Improvements';
 import { storeToRefs } from 'pinia';
 
 const improvementsStore = useImprovementsStore();
 const { analysis } = storeToRefs(improvementsStore);
+
+const percentage = computed(() => {
+  const progress = analysis.value.task?.progress ?? 0;
+  const total = analysis.value.task?.total ?? 0;
+
+  if (total <= 0) return 0;
+
+  return Math.round((progress / total) * 100);
+});
 </script>

--- a/src/components/ConversationsImprovements/ImprovementsHeader.vue
+++ b/src/components/ConversationsImprovements/ImprovementsHeader.vue
@@ -50,15 +50,11 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
-import { differenceInDays, isToday } from 'date-fns';
+import { differenceInDays, isToday, subDays } from 'date-fns';
 import { storeToRefs } from 'pinia';
 
 import { useImprovementsStore } from '@/store/Improvements';
-import {
-  formatMonthDayDate,
-  formatTime,
-  getYesterdayFormattedDate,
-} from '@/utils/formatters';
+import { formatMonthDayDate, formatTime } from '@/utils/formatters';
 import RunAnalysisButton from '@/components/ConversationsImprovements/RunAnalysisButton.vue';
 import CustomAnalysisModal from '@/components/ConversationsImprovements/CustomAnalysisModal/CustomAnalysisModal.vue';
 
@@ -83,9 +79,19 @@ const isStaleAnalysis = computed(
   () => analysisDaysAgo.value >= STALE_ANALYSIS_DAYS_THRESHOLD,
 );
 
+const conversationsDate = computed(() => {
+  const createdAt = analysis.value.task?.createdAt;
+
+  if (!createdAt) {
+    return '';
+  }
+
+  return formatMonthDayDate(subDays(new Date(createdAt), 1).toISOString());
+});
+
 const headerTitle = computed(() =>
   t('audit.improvements.header.title', {
-    date: getYesterdayFormattedDate(),
+    date: conversationsDate.value,
     count: improvements.value.data.length,
   }),
 );

--- a/src/components/ConversationsImprovements/ImprovementsList.vue
+++ b/src/components/ConversationsImprovements/ImprovementsList.vue
@@ -56,7 +56,11 @@ const { improvements } = storeToRefs(improvementsStore);
 const selectedImprovement = ref<Improvement | null>(null);
 const isDrawerOpen = ref(false);
 
-const improvementResults = computed(() => improvements.value.data);
+const improvementResults = computed(() =>
+  [...(improvements.value.data ?? [])].sort(
+    (a, b) => b.conversationsCount - a.conversationsCount,
+  ),
+);
 
 const columns = ['improvement', 'type', 'affected_conversations'] as const;
 
@@ -81,10 +85,12 @@ watch(isDrawerOpen, (open) => {
 
   height: 100%;
 
-  overflow: hidden;
-
   display: flex;
   flex-direction: column;
+
+  > * {
+    overflow: initial;
+  }
 
   :deep(.improvements-list__col--improvement) {
     width: calc(100% / 12 * 8);

--- a/src/components/ConversationsImprovements/ImprovementsSkeleton.vue
+++ b/src/components/ConversationsImprovements/ImprovementsSkeleton.vue
@@ -1,0 +1,133 @@
+<template>
+  <section
+    class="improvements-skeleton"
+    data-testid="improvements-skeleton"
+  >
+    <header
+      class="improvements-skeleton__header"
+      data-testid="improvements-skeleton-header"
+    >
+      <div class="improvements-skeleton__header-content">
+        <UnnnicSkeletonLoading
+          tag="div"
+          width="439px"
+          height="20px"
+          data-testid="improvements-skeleton-title"
+        />
+        <UnnnicSkeletonLoading
+          tag="div"
+          width="128px"
+          height="20px"
+          data-testid="improvements-skeleton-description"
+        />
+      </div>
+
+      <UnnnicSkeletonLoading
+        tag="div"
+        width="116px"
+        height="45px"
+        data-testid="improvements-skeleton-button"
+      />
+      <UnnnicSkeletonLoading
+        tag="div"
+        width="116px"
+        height="45px"
+        data-testid="improvements-skeleton-button"
+      />
+    </header>
+
+    <div
+      class="improvements-skeleton__list"
+      data-testid="improvements-skeleton-list"
+    >
+      <div
+        class="improvements-skeleton__list-header"
+        data-testid="improvements-skeleton-list-header"
+      >
+        <UnnnicSkeletonLoading
+          class="improvements-skeleton__col improvements-skeleton__col--improvement"
+          tag="div"
+          width="100%"
+          height="20px"
+          data-testid="improvements-skeleton-column-improvement"
+        />
+        <UnnnicSkeletonLoading
+          class="improvements-skeleton__col improvements-skeleton__col--type"
+          tag="div"
+          width="100%"
+          height="20px"
+          data-testid="improvements-skeleton-column-type"
+        />
+        <UnnnicSkeletonLoading
+          class="improvements-skeleton__col improvements-skeleton__col--affected_conversations"
+          tag="div"
+          width="100%"
+          height="20px"
+          data-testid="improvements-skeleton-column-affected_conversations"
+        />
+      </div>
+
+      <UnnnicSkeletonLoading
+        v-for="index in 7"
+        :key="index"
+        tag="div"
+        width="100%"
+        height="60px"
+        :data-testid="`improvements-skeleton-row-${index}`"
+      />
+    </div>
+  </section>
+</template>
+
+<style scoped lang="scss">
+.improvements-skeleton {
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-6;
+
+  width: 100%;
+
+  * > div {
+    display: flex;
+  }
+
+  &__header {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    align-items: center;
+    column-gap: $unnnic-space-4;
+
+    width: 100%;
+  }
+
+  &__header-content {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-1;
+  }
+
+  &__list {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
+
+    width: 100%;
+  }
+
+  &__list-header {
+    display: flex;
+    gap: $unnnic-space-4;
+
+    width: 100%;
+  }
+
+  &__col--improvement {
+    width: calc(100% / 12 * 8);
+  }
+
+  &__col--type,
+  &__col--affected_conversations {
+    width: calc(100% / 12 * 2);
+  }
+}
+</style>

--- a/src/components/ConversationsImprovements/__tests__/AnalysisInProgressDisclaimer.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/AnalysisInProgressDisclaimer.spec.js
@@ -76,8 +76,7 @@ describe('AnalysisInProgressDisclaimer.vue', () => {
       expect(disclaimer.props('type')).toBe('informational');
       expect(disclaimer.props('description')).toBe(
         i18n.global.t('audit.improvements.analysis_in_progress_disclaimer', {
-          progress: 10,
-          total: 437,
+          percentage: 2,
         }),
       );
     });
@@ -114,7 +113,7 @@ describe('AnalysisInProgressDisclaimer.vue', () => {
       expect(findDisclaimer().exists()).toBe(false);
     });
 
-    it('uses zero for progress and total when task values are missing', () => {
+    it('uses zero for percentage when task values are missing', () => {
       wrapper.unmount();
       createWrapper({
         analysis: {
@@ -125,8 +124,7 @@ describe('AnalysisInProgressDisclaimer.vue', () => {
 
       expect(findDisclaimer().props('description')).toBe(
         i18n.global.t('audit.improvements.analysis_in_progress_disclaimer', {
-          progress: 0,
-          total: 0,
+          percentage: 0,
         }),
       );
     });
@@ -140,8 +138,7 @@ describe('AnalysisInProgressDisclaimer.vue', () => {
 
       expect(findDisclaimer().props('description')).toBe(
         i18n.global.t('audit.improvements.analysis_in_progress_disclaimer', {
-          progress: 25,
-          total: 437,
+          percentage: 6,
         }),
       );
     });

--- a/src/components/ConversationsImprovements/__tests__/ImprovementsHeader.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementsHeader.spec.js
@@ -6,7 +6,10 @@ import { subDays } from 'date-fns';
 import i18n from '@/utils/plugins/i18n';
 import { useImprovementsStore } from '@/store/Improvements';
 import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
-import { getYesterdayFormattedDate } from '@/utils/formatters';
+import {
+  formatMonthDayDate,
+  getYesterdayFormattedDate,
+} from '@/utils/formatters';
 
 import ImprovementsHeader from '../ImprovementsHeader.vue';
 
@@ -181,6 +184,32 @@ describe('ImprovementsHeader.vue', () => {
       );
       expect(findTitle().text()).toBe(
         `Analysis of conversations from ${getYesterdayFormattedDate()}`,
+      );
+    });
+
+    it('renders the header title with the conversations date one day before createdAt', () => {
+      const createdAt = subDays(new Date(), 5).toISOString();
+      const conversationsDate = formatMonthDayDate(
+        subDays(new Date(createdAt), 1).toISOString(),
+      );
+
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'complete',
+          task: {
+            ...DEFAULT_IMPROVEMENTS_TASK,
+            createdAt,
+            isRunning: false,
+          },
+        },
+      });
+
+      expect(findTitle().text()).toBe(
+        i18n.global.t('audit.improvements.header.title', {
+          date: conversationsDate,
+          count: 1,
+        }),
       );
     });
 

--- a/src/components/ConversationsImprovements/__tests__/ImprovementsList.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementsList.spec.js
@@ -17,15 +17,19 @@ describe('ImprovementsList.vue', () => {
       uuid: 'improvement-uuid-1',
       text: 'The agent tone does not match the configured brand voice in refund conversations.',
       type: 'personality_deviation',
-      conversationsCount: 18,
+      conversationsCount: 12,
     },
     {
       uuid: 'improvement-uuid-2',
       text: 'The agent asks too many questions before providing an answer about order status.',
       type: 'many_questions_before_answering',
-      conversationsCount: 12,
+      conversationsCount: 18,
     },
   ];
+
+  const sortedMockImprovements = [...mockImprovements].sort(
+    (a, b) => b.conversationsCount - a.conversationsCount,
+  );
 
   const createWrapper = (stateOverrides = {}) => {
     const pinia = createTestingPinia({
@@ -106,8 +110,17 @@ describe('ImprovementsList.vue', () => {
       const rows = elements.rows();
 
       expect(rows).toHaveLength(mockImprovements.length);
-      expect(rows[0].props('improvement')).toEqual(mockImprovements[0]);
-      expect(rows[1].props('improvement')).toEqual(mockImprovements[1]);
+      expect(rows[0].props('improvement')).toEqual(sortedMockImprovements[0]);
+      expect(rows[1].props('improvement')).toEqual(sortedMockImprovements[1]);
+    });
+
+    it('sorts improvements by conversationsCount in descending order', () => {
+      const rows = elements.rows();
+
+      expect(rows[0].props('improvement').conversationsCount).toBe(18);
+      expect(rows[1].props('improvement').conversationsCount).toBe(12);
+      expect(rows[0].props('improvement').uuid).toBe('improvement-uuid-2');
+      expect(rows[1].props('improvement').uuid).toBe('improvement-uuid-1');
     });
 
     it('does not apply the selected modifier class initially', () => {
@@ -129,7 +142,7 @@ describe('ImprovementsList.vue', () => {
 
       expect(elements.drawer().props('open')).toBe(true);
       expect(elements.drawer().props('improvement')).toEqual(
-        mockImprovements[0],
+        sortedMockImprovements[0],
       );
     });
 

--- a/src/components/ConversationsImprovements/__tests__/ImprovementsSkeleton.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/ImprovementsSkeleton.spec.js
@@ -1,0 +1,95 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import ImprovementsSkeleton from '../ImprovementsSkeleton.vue';
+
+describe('ImprovementsSkeleton.vue', () => {
+  let wrapper;
+
+  const elements = {
+    root: () => wrapper.find('[data-testid="improvements-skeleton"]'),
+    header: () => wrapper.find('[data-testid="improvements-skeleton-header"]'),
+    title: () =>
+      wrapper.findComponent('[data-testid="improvements-skeleton-title"]'),
+    description: () =>
+      wrapper.findComponent(
+        '[data-testid="improvements-skeleton-description"]',
+      ),
+    buttons: () =>
+      wrapper.findAllComponents('[data-testid="improvements-skeleton-button"]'),
+    list: () => wrapper.find('[data-testid="improvements-skeleton-list"]'),
+    listHeader: () =>
+      wrapper.find('[data-testid="improvements-skeleton-list-header"]'),
+    columnImprovement: () =>
+      wrapper.findComponent(
+        '[data-testid="improvements-skeleton-column-improvement"]',
+      ),
+    columnType: () =>
+      wrapper.findComponent(
+        '[data-testid="improvements-skeleton-column-type"]',
+      ),
+    columnAffectedConversations: () =>
+      wrapper.findComponent(
+        '[data-testid="improvements-skeleton-column-affected_conversations"]',
+      ),
+    rows: () =>
+      wrapper.findAllComponents('[data-testid^="improvements-skeleton-row-"]'),
+  };
+
+  const createWrapper = () => {
+    wrapper = shallowMount(ImprovementsSkeleton);
+  };
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders the skeleton structure', () => {
+    createWrapper();
+
+    expect(elements.root().exists()).toBe(true);
+    expect(elements.header().exists()).toBe(true);
+    expect(elements.list().exists()).toBe(true);
+    expect(elements.listHeader().exists()).toBe(true);
+  });
+
+  it('renders header title and description skeletons', () => {
+    createWrapper();
+
+    expect(elements.title().exists()).toBe(true);
+    expect(elements.title().props('width')).toBe('439px');
+    expect(elements.title().props('height')).toBe('20px');
+
+    expect(elements.description().exists()).toBe(true);
+    expect(elements.description().props('width')).toBe('128px');
+    expect(elements.description().props('height')).toBe('20px');
+  });
+
+  it('renders two button skeletons', () => {
+    createWrapper();
+
+    expect(elements.buttons()).toHaveLength(2);
+    elements.buttons().forEach((button) => {
+      expect(button.props('width')).toBe('116px');
+      expect(button.props('height')).toBe('45px');
+    });
+  });
+
+  it('renders table column skeletons', () => {
+    createWrapper();
+
+    expect(elements.columnImprovement().exists()).toBe(true);
+    expect(elements.columnType().exists()).toBe(true);
+    expect(elements.columnAffectedConversations().exists()).toBe(true);
+  });
+
+  it('renders seven row skeletons', () => {
+    createWrapper();
+
+    expect(elements.rows()).toHaveLength(7);
+    elements.rows().forEach((row) => {
+      expect(row.props('width')).toBe('100%');
+      expect(row.props('height')).toBe('60px');
+    });
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -479,7 +479,7 @@
     },
 
     "improvements": {
-      "analysis_in_progress_disclaimer": "Analysis in progress: {progress} of {total} conversations processed. New items may appear shortly.",
+      "analysis_in_progress_disclaimer": "Analysis in progress: {percentage}% of conversations processed. New items may appear shortly.",
       "analysis_complete": {
         "no_improvements_description": "No improvements identified in the conversations from {date}",
         "ready_description": "Improvements from {date} are ready in your backlog.",
@@ -573,7 +573,7 @@
         "title": "Insufficient conversation volume"
       },
       "no_analysis": {
-        "description": "Run your first analysis to identify opportunities for improvement in yesterday's conversations",
+        "description": "Run your first analysis to identify opportunities for improvement in a sample of yesterday's conversations",
         "run_analysis": "Run analysis",
         "title": "No analysis has been run yet"
       },
@@ -589,7 +589,7 @@
       },
       "running_analysis": {
         "description": "This may take a few hours. You can close this screen.",
-        "title": "Analyzing conversations from yesterday"
+        "title": "Analyzing a sample of conversations from yesterday"
       },
       "stale_analysis_disclaimer": {
         "description": "Run a new analysis to identify opportunities for improvement",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -478,7 +478,7 @@
       }
     },
     "improvements": {
-      "analysis_in_progress_disclaimer": "Análisis en curso: {progress} de {total} conversaciones procesadas. Pueden aparecer nuevos ítems en breve.",
+      "analysis_in_progress_disclaimer": "Análisis en curso: {percentage}% de las conversaciones procesadas. Pueden aparecer nuevos ítems en breve.",
       "analysis_complete": {
         "no_improvements_description": "No se identificaron mejoras en las conversaciones del {date}",
         "ready_description": "Las mejoras del {date} están listas en el backlog.",
@@ -572,7 +572,7 @@
         "title": "Volumen insuficiente de conversaciones"
       },
       "no_analysis": {
-        "description": "Ejecuta el primer análisis para identificar oportunidades de mejora en las conversaciones de ayer",
+        "description": "Ejecuta el primer análisis para identificar oportunidades de mejora en una muestra de las conversaciones de ayer",
         "run_analysis": "Ejecutar análisis",
         "title": "Aún no se ha ejecutado ningún análisis"
       },
@@ -588,7 +588,7 @@
       },
       "running_analysis": {
         "description": "Esto puede tardar unas horas. Puedes cerrar esta pantalla.",
-        "title": "Analizando conversaciones de ayer"
+        "title": "Analizando una muestra de conversaciones de ayer"
       },
       "stale_analysis_disclaimer": {
         "description": "Ejecuta un nuevo análisis para identificar oportunidades de mejora",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -478,7 +478,7 @@
       }
     },
     "improvements": {
-      "analysis_in_progress_disclaimer": "Análise em andamento: {progress} de {total} conversas processadas. Novos itens podem aparecer em breve.",
+      "analysis_in_progress_disclaimer": "Análise em andamento: {percentage}% das conversas processadas. Novos itens podem aparecer em breve.",
       "analysis_complete": {
         "no_improvements_description": "Nenhuma melhoria identificada nas conversas de {date}",
         "ready_description": "As melhorias de {date} estão prontas no backlog.",
@@ -572,7 +572,7 @@
         "title": "Volume insuficiente de conversas"
       },
       "no_analysis": {
-        "description": "Execute a primeira análise para identificar oportunidades de melhoria nas conversas de ontem",
+        "description": "Execute a primeira análise para identificar oportunidades de melhoria em uma amostra das conversas de ontem",
         "run_analysis": "Executar análise",
         "title": "Nenhuma análise foi executada ainda"
       },
@@ -588,7 +588,7 @@
       },
       "running_analysis": {
         "description": "Isso pode levar algumas horas. Você pode fechar esta tela.",
-        "title": "Analisando conversas de ontem"
+        "title": "Analisando uma amostra de conversas de ontem"
       },
       "stale_analysis_disclaimer": {
         "description": "Execute uma nova análise para identificar oportunidades de melhoria",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -477,7 +477,7 @@
       }
     },
     "improvements": {
-      "analysis_in_progress_disclaimer": "Analiză în curs: {progress} din {total} conversații procesate. Pot apărea elemente noi în curând.",
+      "analysis_in_progress_disclaimer": "Analiză în curs: {percentage}% din conversații procesate. Pot apărea elemente noi în curând.",
       "analysis_complete": {
         "no_improvements_description": "Nu s-au identificat îmbunătățiri în conversațiile din {date}",
         "ready_description": "Îmbunătățirile din {date} sunt gata în backlog.",
@@ -571,7 +571,7 @@
         "title": "Volum insuficient de conversații"
       },
       "no_analysis": {
-        "description": "Rulează prima analiză pentru a identifica oportunități de îmbunătățire în conversațiile de ieri",
+        "description": "Rulează prima analiză pentru a identifica oportunități de îmbunătățire într-un eșantion din conversațiile de ieri",
         "run_analysis": "Rulează analiza",
         "title": "Nicio analiză nu a fost executată încă"
       },
@@ -587,7 +587,7 @@
       },
       "running_analysis": {
         "description": "Acest proces poate dura câteva ore. Poți închide acest ecran.",
-        "title": "Se analizează conversații de ieri"
+        "title": "Se analizează un eșantion de conversații de ieri"
       },
       "stale_analysis_disclaimer": {
         "description": "Rulează o nouă analiză pentru a identifica oportunități de îmbunătățire",

--- a/src/store/Supervisor.js
+++ b/src/store/Supervisor.js
@@ -68,6 +68,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
   });
 
   const topics = ref([]);
+  const topicsStatus = ref(null);
 
   const queryConversationUuid = ref(query?.uuid || '');
 
@@ -278,14 +279,26 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
   }
 
   async function getTopics() {
-    const response = await supervisorApi.conversations.getTopics({
-      projectUuid: projectUuid.value,
-    });
+    if (topicsStatus.value === 'complete' || topicsStatus.value === 'loading') {
+      return;
+    }
 
-    topics.value = response.map((topic) => ({
-      label: topic.name,
-      value: topic.uuid,
-    }));
+    topicsStatus.value = 'loading';
+
+    try {
+      const response = await supervisorApi.conversations.getTopics({
+        projectUuid: projectUuid.value,
+      });
+
+      topics.value = response.map((topic) => ({
+        label: topic.name,
+        value: topic.uuid,
+      }));
+      topicsStatus.value = 'complete';
+    } catch (error) {
+      topicsStatus.value = 'error';
+      console.error('Error loading topics:', error);
+    }
   }
 
   async function exportSupervisorData({ token }) {
@@ -313,6 +326,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
     defaultFilters,
     temporaryFilters,
     topics,
+    topicsStatus,
     resetFilters,
     updateFilters,
     getInitialSelectFilter,

--- a/src/store/__tests__/Supervisor.unit.spec.js
+++ b/src/store/__tests__/Supervisor.unit.spec.js
@@ -11,6 +11,7 @@ vi.mock('@/api/nexusaiAPI', () => ({
         conversations: {
           list: vi.fn(),
           getById: vi.fn(),
+          getTopics: vi.fn(),
           export: vi.fn(),
         },
       },
@@ -77,6 +78,11 @@ describe('Supervisor Store', () => {
 
     it('has the correct initial state for selectedConversation', () => {
       expect(store.selectedConversation).toBeNull();
+    });
+
+    it('has the correct initial state for topics', () => {
+      expect(store.topics).toEqual([]);
+      expect(store.topicsStatus).toBeNull();
     });
 
     it('has the correct initial state for filters', () => {
@@ -539,6 +545,57 @@ describe('Supervisor Store', () => {
           topics: [],
         },
       });
+    });
+  });
+
+  describe('getTopics', () => {
+    it('fetches topics and marks status as complete', async () => {
+      nexusaiAPI.agent_builder.supervisor.conversations.getTopics.mockResolvedValue(
+        [
+          { name: 'Billing', uuid: 'topic-1' },
+          { name: 'Support', uuid: 'topic-2' },
+        ],
+      );
+
+      await store.getTopics();
+
+      expect(
+        nexusaiAPI.agent_builder.supervisor.conversations.getTopics,
+      ).toHaveBeenCalledWith({
+        projectUuid: 'test-project-uuid',
+      });
+      expect(store.topics).toEqual([
+        { label: 'Billing', value: 'topic-1' },
+        { label: 'Support', value: 'topic-2' },
+      ]);
+      expect(store.topicsStatus).toBe('complete');
+    });
+
+    it('does not fetch topics again when already loaded', async () => {
+      nexusaiAPI.agent_builder.supervisor.conversations.getTopics.mockResolvedValue(
+        [{ name: 'Billing', uuid: 'topic-1' }],
+      );
+
+      await store.getTopics();
+      await store.getTopics();
+
+      expect(
+        nexusaiAPI.agent_builder.supervisor.conversations.getTopics,
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not fetch topics again while a request is in progress', async () => {
+      nexusaiAPI.agent_builder.supervisor.conversations.getTopics.mockReturnValue(
+        new Promise(() => {}),
+      );
+
+      store.getTopics();
+      await store.getTopics();
+
+      expect(
+        nexusaiAPI.agent_builder.supervisor.conversations.getTopics,
+      ).toHaveBeenCalledTimes(1);
+      expect(store.topicsStatus).toBe('loading');
     });
   });
 });

--- a/src/views/Supervisor/Improvements/__tests__/index.spec.js
+++ b/src/views/Supervisor/Improvements/__tests__/index.spec.js
@@ -8,6 +8,7 @@ import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
 import AnalysisInProgressDisclaimer from '@/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue';
 import ImprovementsHeader from '@/components/ConversationsImprovements/ImprovementsHeader.vue';
 import ImprovementsList from '@/components/ConversationsImprovements/ImprovementsList.vue';
+import ImprovementsSkeleton from '@/components/ConversationsImprovements/ImprovementsSkeleton.vue';
 import NoAnalysisPerformed from '@/components/ConversationsImprovements/NoAnalysisPerformed.vue';
 import NoImprovementIdentified from '@/components/ConversationsImprovements/NoImprovementIdentified.vue';
 import InsufficientConversationsVolume from '@/components/ConversationsImprovements/InsufficientConversationsVolume.vue';
@@ -21,6 +22,8 @@ describe('Improvements view', () => {
 
   const findSection = () =>
     wrapper.find('[data-testid="conversations-improvements"]');
+  const findImprovementsSkeleton = () =>
+    wrapper.findComponent(ImprovementsSkeleton);
   const findNoAnalysisPerformed = () =>
     wrapper.findComponent(NoAnalysisPerformed);
   const findNoImprovementIdentified = () =>
@@ -77,6 +80,54 @@ describe('Improvements view', () => {
   describe('on mount', () => {
     it('loads improvements when the view mounts', () => {
       expect(improvementsStore.fetchImprovements).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('ImprovementsSkeleton state', () => {
+    it('renders ImprovementsSkeleton while the initial fetch is loading', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'loading',
+          task: { ...DEFAULT_IMPROVEMENTS_TASK },
+        },
+        improvements: {
+          data: [],
+          status: 'loading',
+        },
+      });
+
+      expect(findImprovementsSkeleton().exists()).toBe(true);
+      expect(findNoAnalysisPerformed().exists()).toBe(false);
+      expect(findInsufficientConversationsVolume().exists()).toBe(false);
+      expect(findRunningAnalysis().exists()).toBe(false);
+    });
+
+    it('does not render ImprovementsSkeleton after analysis has a createdAt', () => {
+      wrapper.unmount();
+      createWrapper({
+        analysis: {
+          status: 'loading',
+          task: {
+            isRunning: true,
+            progress: 0,
+            total: 437,
+            createdAt: '2026-06-18T08:00:00Z',
+          },
+        },
+        improvements: {
+          data: [],
+          status: 'loading',
+        },
+      });
+
+      expect(findImprovementsSkeleton().exists()).toBe(false);
+      expect(findRunningAnalysis().exists()).toBe(true);
+    });
+
+    it('does not render ImprovementsSkeleton when status is not loading', () => {
+      expect(findImprovementsSkeleton().exists()).toBe(false);
+      expect(findNoAnalysisPerformed().exists()).toBe(true);
     });
   });
 

--- a/src/views/Supervisor/Improvements/index.vue
+++ b/src/views/Supervisor/Improvements/index.vue
@@ -3,8 +3,9 @@
     class="conversations-improvements"
     data-testid="conversations-improvements"
   >
+    <ImprovementsSkeleton v-if="isLoadingImprovements" />
     <InsufficientConversationsVolume
-      v-if="
+      v-else-if="
         !analysis.task.createdAt &&
         runAnalysisBlockReason === 'insufficient_volume'
       "
@@ -26,7 +27,7 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue';
+import { computed, onMounted } from 'vue';
 import { storeToRefs } from 'pinia';
 
 import { useImprovementsStore } from '@/store/Improvements';
@@ -38,10 +39,15 @@ import NoImprovementIdentified from '@/components/ConversationsImprovements/NoIm
 import ImprovementsHeader from '@/components/ConversationsImprovements/ImprovementsHeader.vue';
 import ImprovementsList from '@/components/ConversationsImprovements/ImprovementsList.vue';
 import AnalysisInProgressDisclaimer from '@/components/ConversationsImprovements/AnalysisInProgressDisclaimer.vue';
+import ImprovementsSkeleton from '@/components/ConversationsImprovements/ImprovementsSkeleton.vue';
 
 const improvementsStore = useImprovementsStore();
 const { analysis, improvements, runAnalysisBlockReason } =
   storeToRefs(improvementsStore);
+
+const isLoadingImprovements = computed(
+  () => analysis.value.status === 'loading' && !analysis.value.task.createdAt,
+);
 
 onMounted(() => {
   improvementsStore.fetchImprovements();

--- a/src/views/Supervisor/SupervisorConversations/ConversationsTable/__tests__/index.spec.js
+++ b/src/views/Supervisor/SupervisorConversations/ConversationsTable/__tests__/index.spec.js
@@ -75,19 +75,19 @@ describe('ConversationsTable.vue', () => {
     stubActions: false,
   });
 
-  const setConversations = (results) => {
+  const setConversations = (results, status = 'complete') => {
     supervisorStore.conversations.data.results = [...results];
     supervisorStore.conversations.data.count = results.length;
     supervisorStore.conversations.data.newNext = null;
     supervisorStore.conversations.data.legacyNext = null;
-    supervisorStore.conversations.status = 'complete';
+    supervisorStore.conversations.status = status;
   };
 
-  const createWrapper = async () => {
+  const createWrapper = async ({ conversationsStatus = 'complete' } = {}) => {
     supervisorStore = useSupervisorStore();
     supervisorStore.filters.start = '2023-01-01';
     supervisorStore.filters.end = '2023-01-31';
-    setConversations(mockResultsWithSource);
+    setConversations(mockResultsWithSource, conversationsStatus);
 
     wrapper = mount(ConversationsTable, {
       global: {
@@ -131,7 +131,16 @@ describe('ConversationsTable.vue', () => {
     expect(elements.columnHeader('hour').text()).toBe('Hour');
   });
 
-  it('loads conversations on mount', () => {
+  it('does not reload conversations on mount when already loaded', () => {
+    expect(supervisorStore.loadConversations).not.toHaveBeenCalled();
+  });
+
+  it('loads conversations on mount when they have not been loaded yet', async () => {
+    wrapper?.unmount();
+    vi.clearAllMocks();
+
+    await createWrapper({ conversationsStatus: null });
+
     expect(supervisorStore.loadConversations).toHaveBeenCalled();
   });
 

--- a/src/views/Supervisor/SupervisorConversations/ConversationsTable/index.vue
+++ b/src/views/Supervisor/SupervisorConversations/ConversationsTable/index.vue
@@ -116,9 +116,17 @@ watch(
     () => supervisorStore.filters.topics,
   ],
   (newValue, oldValue) => {
+    const isInitialRun =
+      !oldValue || oldValue.every((value) => value === undefined);
     const hasFiltersChanged = !isEqual(newValue, oldValue);
+    const hasConversationsLoaded =
+      supervisorStore.conversations.status === 'complete';
 
-    if (!hasFiltersChanged) return;
+    if (isInitialRun) {
+      if (hasConversationsLoaded) return;
+    } else if (!hasFiltersChanged) {
+      return;
+    }
 
     pagination.value.page = 1;
     supervisorStore.loadConversations();

--- a/src/views/Supervisor/SupervisorFilters/__tests__/SupervisorFilters.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/SupervisorFilters.spec.js
@@ -147,8 +147,8 @@ describe('SupervisorFilters.vue', () => {
   });
 
   describe('Get topics', () => {
-    it('gets topics', async () => {
-      expect(store.getTopics).toHaveBeenCalled();
+    it('gets topics on mount', async () => {
+      expect(store.getTopics).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/views/Supervisor/__tests__/index.spec.js
+++ b/src/views/Supervisor/__tests__/index.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { shallowMount, flushPromises } from '@vue/test-utils';
 import { reactive } from 'vue';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
@@ -129,6 +129,16 @@ describe('Supervisor view', () => {
     beforeEach(async () => {
       mockSpy = vi.fn();
 
+      supervisorStore.conversations = {
+        status: 'complete',
+        data: {
+          next: 'next-page-url',
+          results: [{ uuid: '1' }, { uuid: '2' }],
+        },
+      };
+
+      await flushPromises();
+
       wrapper.vm.scrollContainer = {
         scrollHeight: 500,
         clientHeight: 800,
@@ -140,14 +150,6 @@ describe('Supervisor view', () => {
       };
 
       wrapper.vm.isCheckingScroll = false;
-
-      supervisorStore.conversations = {
-        status: 'complete',
-        data: {
-          next: 'next-page-url',
-          results: [{ uuid: '1' }, { uuid: '2' }],
-        },
-      };
     });
 
     it('should call loadMoreConversations when there is no scrollbar', async () => {
@@ -219,6 +221,31 @@ describe('Supervisor view', () => {
 
       expect(wrapper.vm.isCheckingScroll).toBe(false);
     });
+
+    it('toggles scroll spacing class based on scrollbar presence', async () => {
+      const content = wrapper.find('.supervisor__content');
+
+      wrapper.vm.scrollContainer = {
+        scrollHeight: 500,
+        clientHeight: 800,
+        scrollTop: 0,
+      };
+
+      wrapper.vm.updateHasScroll();
+      await wrapper.vm.$nextTick();
+
+      expect(content.classes()).not.toContain(
+        'supervisor__content--with-scroll',
+      );
+      expect(wrapper.vm.hasScroll).toBe(false);
+
+      wrapper.vm.scrollContainer.scrollHeight = 1000;
+      wrapper.vm.updateHasScroll();
+      await wrapper.vm.$nextTick();
+
+      expect(content.classes()).toContain('supervisor__content--with-scroll');
+      expect(wrapper.vm.hasScroll).toBe(true);
+    });
   });
 
   describe('Scroll-based pagination', () => {
@@ -226,6 +253,16 @@ describe('Supervisor view', () => {
 
     beforeEach(async () => {
       mockSpy = vi.fn();
+
+      supervisorStore.conversations = {
+        status: 'complete',
+        data: {
+          next: 'next-page-url',
+          results: [{ uuid: '1' }, { uuid: '2' }],
+        },
+      };
+
+      await flushPromises();
 
       wrapper.vm.scrollContainer = {
         scrollHeight: 1000,
@@ -238,14 +275,6 @@ describe('Supervisor view', () => {
       };
 
       wrapper.vm.isCheckingScroll = false;
-
-      supervisorStore.conversations = {
-        status: 'complete',
-        data: {
-          next: 'next-page-url',
-          results: [{ uuid: '1' }, { uuid: '2' }],
-        },
-      };
     });
 
     it('should call loadMoreConversations when scrolled to bottom', async () => {

--- a/src/views/Supervisor/index.vue
+++ b/src/views/Supervisor/index.vue
@@ -10,7 +10,10 @@
   >
     <section
       ref="scrollContainer"
-      class="supervisor__content"
+      :class="[
+        'supervisor__content',
+        { 'supervisor__content--with-scroll': hasScroll },
+      ]"
       @scroll="loadConversations"
     >
       <SupervisorHeader
@@ -35,7 +38,15 @@
 </template>
 
 <script setup>
-import { computed, onBeforeMount, watch, ref, nextTick } from 'vue';
+import {
+  computed,
+  onBeforeMount,
+  onBeforeUnmount,
+  onMounted,
+  watch,
+  ref,
+  nextTick,
+} from 'vue';
 import { useRouter, useRoute, RouterView } from 'vue-router';
 
 import SupervisorHeader from './SupervisorHeader.vue';
@@ -53,6 +64,7 @@ const route = useRoute();
 const supervisorConversations = ref(null);
 const scrollContainer = ref(null);
 const isCheckingScroll = ref(false);
+const hasScroll = ref(false);
 
 const selectedConversation = computed(() => {
   return supervisorStore.selectedConversation;
@@ -89,9 +101,13 @@ function isScrollReachedBottom() {
   return isInScrollBottom;
 }
 
-function hasScrollbar() {
+function updateHasScroll() {
   const container = scrollContainer.value;
-  return container.scrollHeight > container.clientHeight;
+  const next = !!container && container.scrollHeight > container.clientHeight;
+
+  if (hasScroll.value !== next) {
+    hasScroll.value = next;
+  }
 }
 
 async function checkAndLoadMoreIfNeeded() {
@@ -102,12 +118,14 @@ async function checkAndLoadMoreIfNeeded() {
   try {
     await nextTick();
 
+    updateHasScroll();
+
     if (!scrollContainer.value) return;
 
     if (!hasMoreConversationsToLoad()) return;
 
-    if (!hasScrollbar()) {
-      supervisorConversations.value?.loadMoreConversations();
+    if (!hasScroll.value) {
+      supervisorConversations.value?.loadMoreConversations?.();
     }
   } finally {
     isCheckingScroll.value = false;
@@ -120,7 +138,7 @@ function loadConversations() {
   const shouldLoadMore = isScrollReachedBottom();
 
   if (shouldLoadMore) {
-    supervisorConversations.value?.loadMoreConversations();
+    supervisorConversations.value?.loadMoreConversations?.();
   }
 }
 
@@ -150,6 +168,11 @@ watch(
   { immediate: true },
 );
 
+watch([isConversationsRoute, selectedConversation], async () => {
+  await nextTick();
+  updateHasScroll();
+});
+
 onBeforeMount(async () => {
   updateQuery();
 
@@ -158,6 +181,15 @@ onBeforeMount(async () => {
   if (queryConversationUuid && !selectedConversation) {
     supervisorStore.selectConversation(queryConversationUuid);
   }
+});
+
+onMounted(() => {
+  updateHasScroll();
+  window.addEventListener('resize', updateHasScroll);
+});
+
+onBeforeUnmount(() => {
+  window.removeEventListener('resize', updateHasScroll);
 });
 </script>
 
@@ -179,13 +211,16 @@ onBeforeMount(async () => {
     display: flex;
     flex-direction: column;
 
-    $scroll-margin: calc($unnnic-spacing-nano / 2 + $unnnic-spacing-nano);
-
     overflow-y: auto;
 
     margin: $unnnic-spacing-sm 0;
-    padding-right: $scroll-margin;
-    margin-right: $scroll-margin;
+
+    &--with-scroll {
+      $scroll-margin: calc($unnnic-spacing-nano / 2 + $unnnic-spacing-nano);
+
+      padding-right: $scroll-margin;
+      margin-right: $scroll-margin;
+    }
   }
 
   :deep(.supervisor__header) {


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [x] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

Several UX and correctness improvements were needed in the Conversations Improvements feature: the analysis progress indicator was showing raw counts instead of a meaningful percentage, the header title was always showing "yesterday" instead of the actual date the analysis was run on, improvements were not sorted by impact, and there was no loading skeleton while the initial data fetch was in progress. Additionally, the topics fetch in the Supervisor store had no guard against duplicate requests, and the scroll spacing in the Supervisor view was being applied unconditionally even when no scrollbar was present.

### Summary of Changes

- **Analysis progress disclaimer** now computes and displays a percentage (e.g. `42%`) instead of raw `progress / total` counts, with a safe guard against division by zero. Locale strings updated across EN, ES, PT-BR, RO.
- **Improvements header title** now derives the conversations date from `analysis.task.createdAt` minus one day, replacing the hardcoded `getYesterdayFormattedDate()` helper call.
- **Improvements list** now sorts results by `conversationsCount` in descending order so the highest-impact items appear first.
- **`ImprovementsSkeleton`** **component** added to display a full-page skeleton loader (header, column headers, and 7 row placeholders) while the initial analysis fetch is in progress and no `createdAt` is available yet.
- **`isLoadingImprovements`** computed property added to the Improvements view to gate the skeleton display, replacing the first rendered state with the skeleton instead of showing nothing.
- **`getTopics`** **in the Supervisor store** now tracks a `topicsStatus` ref (`null` → `loading` → `complete` / `error`) and skips duplicate or concurrent fetches.
- **Supervisor scroll spacing** is now applied conditionally via a `supervisor__content--with-scroll` modifier class, driven by a reactive `hasScroll` ref that is updated on mount, resize, and route/conversation changes, preventing unnecessary padding when no scrollbar exists.
- **`ConversationsTable`** watcher now skips reloading conversations on the initial render if they have already been loaded, avoiding redundant API calls on navigation.
- Supervisor view tests updated to set conversation state before `flushPromises` to reflect the corrected initialization order, and a new test covers the scroll spacing class toggle.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/4cef40ca-5dd7-464a-95e8-881ee31582c2.png)

![image.png](https://app.graphite.com/user-attachments/assets/bb50a34c-fee7-48b3-94b3-b2afc1cf432a.png)

![image.png](https://app.graphite.com/user-attachments/assets/e7f8d972-2014-4900-86ad-e2835c6f0d2c.png)

