### PR TITLE
feat: Add SafetyGuardrails component behind customGuardrails feature flag

### DIFF
--- a/src/components/Instructions/InstructionsCategorization/CategoriesView.vue
+++ b/src/components/Instructions/InstructionsCategorization/CategoriesView.vue
@@ -13,20 +13,26 @@
       @delete-category="$emit('delete-category', $event)"
       @edit="$emit('edit', $event)"
     />
+
+    <SafetyGuardrails v-if="featureFlags.customGuardrails" />
   </section>
 </template>
 
 <script setup>
 import { computed } from 'vue';
 
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 import { useInstructionsStore } from '@/store/Instructions';
 
 import CategoryAccordion from './CategoryAccordion.vue';
+import SafetyGuardrails from './SafetyGuardrails.vue';
 
 defineEmits(['delete-category', 'edit']);
 
+const featureFlagsStore = useFeatureFlagsStore();
 const instructionsStore = useInstructionsStore();
 
+const featureFlags = computed(() => featureFlagsStore.flags);
 const groups = computed(() => instructionsStore.groupedInstructions);
 </script>
 

--- a/src/components/Instructions/InstructionsCategorization/SafetyGuardrails.vue
+++ b/src/components/Instructions/InstructionsCategorization/SafetyGuardrails.vue
@@ -1,0 +1,63 @@
+<template>
+  <section
+    class="safety-guardrails"
+    data-testid="safety-guardrails"
+  >
+    <div class="safety-guardrails__content">
+      <h2
+        class="safety-guardrails__title"
+        data-testid="safety-guardrails-title"
+      >
+        {{ $t('agents.instructions.safety_guardrails.title') }}
+      </h2>
+      <p
+        class="safety-guardrails__description"
+        data-testid="safety-guardrails-description"
+      >
+        {{ $t('agents.instructions.safety_guardrails.description') }}
+      </p>
+    </div>
+
+    <UnnnicButton
+      type="secondary"
+      :text="$t('agents.instructions.safety_guardrails.configure')"
+      data-testid="safety-guardrails-configure"
+    />
+  </section>
+</template>
+
+<style lang="scss" scoped>
+.safety-guardrails {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: $unnnic-space-2;
+
+  padding: $unnnic-space-4;
+
+  border: 1px solid $unnnic-color-border-base;
+  border-radius: $unnnic-radius-2;
+
+  &__content {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-1;
+
+    min-width: 0;
+  }
+
+  &__title {
+    margin: 0;
+
+    font: $unnnic-font-action;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__description {
+    margin: 0;
+
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+}
+</style>

--- a/src/components/Instructions/InstructionsCategorization/__tests__/CategoriesView.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/CategoriesView.spec.js
@@ -4,6 +4,7 @@ import { createTestingPinia } from '@pinia/testing';
 
 import CategoriesView from '../CategoriesView.vue';
 import CategoryAccordion from '../CategoryAccordion.vue';
+import SafetyGuardrails from '../SafetyGuardrails.vue';
 import { useInstructionsStore } from '@/store/Instructions';
 
 vi.mock('@/store/Project', () => ({
@@ -12,7 +13,10 @@ vi.mock('@/store/Project', () => ({
 
 vi.mock('@/store/FeatureFlags', () => ({
   useFeatureFlagsStore: () => ({
-    flags: { categorizationOfInstructions: true },
+    flags: {
+      categorizationOfInstructions: true,
+      customGuardrails: true,
+    },
   }),
 }));
 
@@ -158,5 +162,11 @@ describe('CategoriesView.vue', () => {
       .vm.$emit('delete-category', group);
 
     expect(wrapper.emitted('delete-category')).toEqual([[group]]);
+  });
+
+  it('renders SafetyGuardrails when the customGuardrails flag is enabled', () => {
+    wrapper = createWrapper();
+
+    expect(wrapper.findComponent(SafetyGuardrails).exists()).toBe(true);
   });
 });

--- a/src/components/Instructions/InstructionsCategorization/__tests__/SafetyGuardrails.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/SafetyGuardrails.spec.js
@@ -1,0 +1,33 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import SafetyGuardrails from '../SafetyGuardrails.vue';
+
+describe('SafetyGuardrails.vue', () => {
+  let wrapper;
+
+  const createWrapper = () => shallowMount(SafetyGuardrails);
+
+  const findSection = () => wrapper.find('[data-testid="safety-guardrails"]');
+  const findTitle = () =>
+    wrapper.find('[data-testid="safety-guardrails-title"]');
+  const findDescription = () =>
+    wrapper.find('[data-testid="safety-guardrails-description"]');
+  const findConfigure = () =>
+    wrapper.findComponent('[data-testid="safety-guardrails-configure"]');
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders the section title, description, and configure button', () => {
+    wrapper = createWrapper();
+
+    expect(findSection().exists()).toBe(true);
+    expect(findTitle().text()).toBe('Safety guardrails');
+    expect(findDescription().text()).toBe(
+      "Sensitive topics Manager won't discuss",
+    );
+    expect(findConfigure().props('text')).toBe('Configure');
+  });
+});

--- a/src/components/Instructions/InstructionsCategorization/__tests__/SafetyGuardrails.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/SafetyGuardrails.spec.js
@@ -2,6 +2,7 @@ import { shallowMount } from '@vue/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import SafetyGuardrails from '../SafetyGuardrails.vue';
+import i18n from '@/utils/plugins/i18n.js';
 
 describe('SafetyGuardrails.vue', () => {
   let wrapper;
@@ -24,10 +25,14 @@ describe('SafetyGuardrails.vue', () => {
     wrapper = createWrapper();
 
     expect(findSection().exists()).toBe(true);
-    expect(findTitle().text()).toBe('Safety guardrails');
-    expect(findDescription().text()).toBe(
-      "Sensitive topics Manager won't discuss",
+    expect(findTitle().text()).toBe(
+      i18n.global.t('agents.instructions.safety_guardrails.title'),
     );
-    expect(findConfigure().props('text')).toBe('Configure');
+    expect(findDescription().text()).toBe(
+      i18n.global.t('agents.instructions.safety_guardrails.description'),
+    );
+    expect(findConfigure().props('text')).toBe(
+      i18n.global.t('agents.instructions.safety_guardrails.configure'),
+    );
   });
 });

--- a/src/components/Instructions/InstructionsCategorization/index.vue
+++ b/src/components/Instructions/InstructionsCategorization/index.vue
@@ -124,6 +124,10 @@ function onRemoveCategoryModalOpenChange(open) {
   flex-direction: column;
   gap: $unnnic-space-4;
 
+  margin-bottom: calc(
+    $unnnic-space-1 * 13
+  ); // 52px to fit the "test your agents" button
+
   // Mirrors UnnnicPageHeader's grid (1fr + minmax(250px, 20%))
   &__toolbar {
     display: grid;

--- a/src/components/Instructions/InstructionsList.vue
+++ b/src/components/Instructions/InstructionsList.vue
@@ -72,10 +72,6 @@ defineProps({
 
 <style lang="scss" scoped>
 .instructions-list {
-  margin-bottom: calc(
-    $unnnic-space-1 * 13
-  ); // 52px to fit the "test your agents" button
-
   display: flex;
   flex-direction: column;
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -429,6 +429,11 @@
             }
           }
         }
+      },
+      "safety_guardrails": {
+        "configure": "Configure",
+        "description": "Sensitive topics Manager won't discuss",
+        "title": "Safety guardrails"
       }
     },
     "profile": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -432,8 +432,8 @@
       },
       "safety_guardrails": {
         "configure": "Configure",
-        "description": "Sensitive topics Manager won't discuss",
-        "title": "Safety guardrails"
+        "description": "Extra layer of blocks on sensitive topics, in addition to Manager's built-in safety",
+        "title": "Extra safety guardrails"
       }
     },
     "profile": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -429,6 +429,11 @@
             }
           }
         }
+      },
+      "safety_guardrails": {
+        "configure": "Configurar",
+        "description": "Temas sensibles que Manager no discutirá",
+        "title": "Barreras de seguridad"
       }
     },
     "profile": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -432,8 +432,8 @@
       },
       "safety_guardrails": {
         "configure": "Configurar",
-        "description": "Temas sensibles que Manager no discutirá",
-        "title": "Barreras de seguridad"
+        "description": "Capa extra de bloqueos para temas sensibles, además de la seguridad integrada de Manager",
+        "title": "Capas adicionales de seguridad"
       }
     },
     "profile": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -429,6 +429,11 @@
             }
           }
         }
+      },
+      "safety_guardrails": {
+        "configure": "Configurar",
+        "description": "Tópicos sensíveis que o Manager não discutirá",
+        "title": "Barreiras de segurança"
       }
     },
     "profile": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -432,8 +432,8 @@
       },
       "safety_guardrails": {
         "configure": "Configurar",
-        "description": "Tópicos sensíveis que o Manager não discutirá",
-        "title": "Barreiras de segurança"
+        "description": "Camada extra de bloqueios para tópicos sensíveis, além da segurança integrada do Manager",
+        "title": "Camadas extras de segurança"
       }
     },
     "profile": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -428,6 +428,11 @@
             }
           }
         }
+      },
+      "safety_guardrails": {
+        "configure": "Configurează",
+        "description": "Subiecte sensibile pe care Manager refuză să le discute",
+        "title": "Guardrails de siguranță"
       }
     },
     "profile": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -431,8 +431,8 @@
       },
       "safety_guardrails": {
         "configure": "Configurează",
-        "description": "Subiecte sensibile pe care Manager refuză să le discute",
-        "title": "Guardrails de siguranță"
+        "description": "Strat suplimentar de blocări pentru subiecte sensibile, pe lângă securitatea integrată a Manager",
+        "title": "Măsuri suplimentare de siguranță"
       }
     },
     "profile": {

--- a/src/store/FeatureFlags.js
+++ b/src/store/FeatureFlags.js
@@ -47,6 +47,7 @@ export const useFeatureFlagsStore = defineStore('FeatureFlags', () => {
     categorizationOfInstructions: isFeatureFlagEnabled(
       'categorization_of_instructions',
     ),
+    customGuardrails: isFeatureFlagEnabled('custom_guardrails'),
   }));
 
   return {


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other
```

### Motivation and Context

A new Safety Guardrails section is needed in the instructions categorization view to allow users to configure sensitive topics that the Manager agent won't discuss.

### Summary of Changes

- Added a new `SafetyGuardrails.vue` component that displays a title, description, and a "Configure" button inside a styled card section.
- Integrated `SafetyGuardrails` into `CategoriesView.vue`, rendering it conditionally based on the `customGuardrails` feature flag.
- Added the `customGuardrails` flag to the `FeatureFlags` store, mapped to the `custom_guardrails` feature flag key.
- Added localization strings for the Safety Guardrails section (`title`, `description`, and `configure`) in English, Spanish, Portuguese (BR), and Romanian.
- Added unit tests for the `SafetyGuardrails` component and updated `CategoriesView` tests to cover the `customGuardrails` feature flag behavior.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/f867b022-0477-4515-8b89-6dfbad7f45f6.png)

