### PR TITLE
feat: Add SafetyGuardrailsDrawer with configure button integration

### DIFF
--- a/src/components/Instructions/InstructionsCategorization/SafetyGuardrails.vue
+++ b/src/components/Instructions/InstructionsCategorization/SafetyGuardrails.vue
@@ -22,9 +22,20 @@
       type="secondary"
       :text="$t('agents.instructions.safety_guardrails.configure')"
       data-testid="safety-guardrails-configure"
+      @click="isDrawerOpen = true"
     />
+
+    <SafetyGuardrailsDrawer v-model="isDrawerOpen" />
   </section>
 </template>
+
+<script setup>
+import { ref } from 'vue';
+
+import SafetyGuardrailsDrawer from '@/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue';
+
+const isDrawerOpen = ref(false);
+</script>
 
 <style lang="scss" scoped>
 .safety-guardrails {

--- a/src/components/Instructions/InstructionsCategorization/__tests__/SafetyGuardrails.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/SafetyGuardrails.spec.js
@@ -1,8 +1,10 @@
 import { shallowMount } from '@vue/test-utils';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import SafetyGuardrails from '../SafetyGuardrails.vue';
 import i18n from '@/utils/plugins/i18n.js';
+
+import SafetyGuardrails from '../SafetyGuardrails.vue';
+import SafetyGuardrailsDrawer from '@/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue';
 
 describe('SafetyGuardrails.vue', () => {
   let wrapper;
@@ -16,6 +18,7 @@ describe('SafetyGuardrails.vue', () => {
     wrapper.find('[data-testid="safety-guardrails-description"]');
   const findConfigure = () =>
     wrapper.findComponent('[data-testid="safety-guardrails-configure"]');
+  const findDrawer = () => wrapper.findComponent(SafetyGuardrailsDrawer);
 
   afterEach(() => {
     wrapper?.unmount();
@@ -34,5 +37,15 @@ describe('SafetyGuardrails.vue', () => {
     expect(findConfigure().props('text')).toBe(
       i18n.global.t('agents.instructions.safety_guardrails.configure'),
     );
+  });
+
+  it('opens the drawer when Configure is clicked', async () => {
+    wrapper = createWrapper();
+
+    expect(findDrawer().props('modelValue')).toBe(false);
+
+    await findConfigure().trigger('click');
+
+    expect(findDrawer().props('modelValue')).toBe(true);
   });
 });

--- a/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue
+++ b/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue
@@ -1,0 +1,81 @@
+<template>
+  <UnnnicDrawerNext
+    :open="modelValue"
+    lazyMount
+    data-testid="safety-guardrails-drawer"
+    @update:open="onOpenChange"
+  >
+    <UnnnicDrawerContent size="large">
+      <UnnnicDrawerHeader>
+        <UnnnicDrawerTitle data-testid="safety-guardrails-drawer-title">
+          {{ $t('agents.instructions.safety_guardrails.drawer.title') }}
+        </UnnnicDrawerTitle>
+      </UnnnicDrawerHeader>
+
+      <section
+        class="safety-guardrails-drawer"
+        data-testid="safety-guardrails-drawer-content"
+      >
+        <p
+          class="safety-guardrails-drawer__description"
+          data-testid="safety-guardrails-drawer-description"
+        >
+          {{ $t('agents.instructions.safety_guardrails.drawer.description') }}
+        </p>
+      </section>
+
+      <UnnnicDrawerFooter>
+        <UnnnicDrawerClose>
+          <UnnnicButton
+            data-testid="safety-guardrails-drawer-cancel"
+            :text="$t('cancel')"
+            type="tertiary"
+            @click="close"
+          />
+        </UnnnicDrawerClose>
+        <UnnnicButton
+          data-testid="safety-guardrails-drawer-save"
+          :text="$t('agents.instructions.safety_guardrails.save')"
+          type="primary"
+          @click="close"
+        />
+      </UnnnicDrawerFooter>
+    </UnnnicDrawerContent>
+  </UnnnicDrawerNext>
+</template>
+
+<script setup>
+const modelValue = defineModel({
+  type: Boolean,
+  required: true,
+});
+
+function close() {
+  modelValue.value = false;
+}
+
+function onOpenChange(open) {
+  if (!open) close();
+}
+</script>
+
+<style lang="scss" scoped>
+.safety-guardrails-drawer {
+  height: 100%;
+
+  padding: $unnnic-space-6;
+
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-6;
+
+  overflow-y: auto;
+
+  &__description {
+    margin: 0;
+
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
+  }
+}
+</style>

--- a/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue
+++ b/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue
@@ -16,12 +16,34 @@
         class="safety-guardrails-drawer"
         data-testid="safety-guardrails-drawer-content"
       >
-        <p
+        <section
           class="safety-guardrails-drawer__description"
           data-testid="safety-guardrails-drawer-description"
         >
-          {{ $t('agents.instructions.safety_guardrails.drawer.description') }}
-        </p>
+          <p>
+            {{
+              $t(
+                'agents.instructions.safety_guardrails.drawer.description.intro',
+              )
+            }}
+          </p>
+          <div class="safety-guardrails-drawer__description-states">
+            <p>
+              {{
+                $t(
+                  'agents.instructions.safety_guardrails.drawer.description.on',
+                )
+              }}
+            </p>
+            <p>
+              {{
+                $t(
+                  'agents.instructions.safety_guardrails.drawer.description.off',
+                )
+              }}
+            </p>
+          </div>
+        </section>
       </section>
 
       <UnnnicDrawerFooter>
@@ -72,10 +94,18 @@ function onOpenChange(open) {
   overflow-y: auto;
 
   &__description {
-    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-2;
 
-    font: $unnnic-font-body;
+    @include unnnic-font-body;
     color: $unnnic-color-fg-base;
+  }
+
+  &__description-states {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-1;
   }
 }
 </style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -433,6 +433,11 @@
       "safety_guardrails": {
         "configure": "Configure",
         "description": "Extra layer of blocks on sensitive topics, in addition to Manager's built-in safety",
+        "drawer": {
+          "description": "When a topic is on, Manager refuses to discuss it. Turn off to allow",
+          "title": "Safety guardrails"
+        },
+        "save": "Save",
         "title": "Extra safety guardrails"
       }
     },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -434,8 +434,12 @@
         "configure": "Configure",
         "description": "Extra layer of blocks on sensitive topics, in addition to Manager's built-in safety",
         "drawer": {
-          "description": "When a topic is on, Manager refuses to discuss it. Turn off to allow",
-          "title": "Safety guardrails"
+          "description": {
+            "intro": "These are extra blocks on top of Manager's built-in safety.",
+            "off": "Off: the extra block is removed, Manager's built-in safety limits still apply.",
+            "on": "On: Manager refuses the topic and shows your block message."
+          },
+          "title": "Extra safety guardrails"
         },
         "save": "Save",
         "title": "Extra safety guardrails"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -434,8 +434,12 @@
         "configure": "Configurar",
         "description": "Capa extra de bloqueos para temas sensibles, además de la seguridad integrada de Manager",
         "drawer": {
-          "description": "Cuando un tema está activado, Manager se niega a discutirlo. Desactiva para permitir",
-          "title": "Barreras de seguridad"
+          "description": {
+            "intro": "Estos son bloqueos adicionales además de la seguridad integrada de Manager.",
+            "off": "Desactivado: se elimina el bloqueo adicional, los límites de seguridad integrada de Manager siguen aplicando.",
+            "on": "Activado: Manager se niega a discutir el tema y muestra tu mensaje de bloqueo."
+          },
+          "title": "Capas adicionales de seguridad"
         },
         "save": "Guardar",
         "title": "Capas adicionales de seguridad"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -433,6 +433,11 @@
       "safety_guardrails": {
         "configure": "Configurar",
         "description": "Capa extra de bloqueos para temas sensibles, además de la seguridad integrada de Manager",
+        "drawer": {
+          "description": "Cuando un tema está activado, Manager se niega a discutirlo. Desactiva para permitir",
+          "title": "Barreras de seguridad"
+        },
+        "save": "Guardar",
         "title": "Capas adicionales de seguridad"
       }
     },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -433,6 +433,11 @@
       "safety_guardrails": {
         "configure": "Configurar",
         "description": "Camada extra de bloqueios para tópicos sensíveis, além da segurança integrada do Manager",
+        "drawer": {
+          "description": "Quando um tópico está ativado, o Manager se recusa a discuti-lo. Desative para permitir",
+          "title": "Barreiras de segurança"
+        },
+        "save": "Salvar",
         "title": "Camadas extras de segurança"
       }
     },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -434,8 +434,12 @@
         "configure": "Configurar",
         "description": "Camada extra de bloqueios para tópicos sensíveis, além da segurança integrada do Manager",
         "drawer": {
-          "description": "Quando um tópico está ativado, o Manager se recusa a discuti-lo. Desative para permitir",
-          "title": "Barreiras de segurança"
+          "description": {
+            "intro": "Estes são bloqueios extras além da segurança integrada do Manager.",
+            "off": "Desativado: o bloqueio extra é removido, os limites de segurança integrada do Manager ainda se aplicam.",
+            "on": "Ativado: o Manager se recusa a discutir o tópico e mostra sua mensagem de bloqueio."
+          },
+          "title": "Camadas extras de segurança"
         },
         "save": "Salvar",
         "title": "Camadas extras de segurança"

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -433,8 +433,12 @@
         "configure": "Configurează",
         "description": "Strat suplimentar de blocări pentru subiecte sensibile, pe lângă securitatea integrată a Manager",
         "drawer": {
-          "description": "Când un subiect este activat, Manager refuză să îl discute. Dezactivează pentru a permite",
-          "title": "Guardrails de siguranță"
+          "description": {
+            "intro": "Acestea sunt blocări suplimentare pe lângă securitatea integrată a Manager.",
+            "off": "Dezactivat: blocarea suplimentară este eliminată, limitele de securitate integrate ale Manager se aplică în continuare.",
+            "on": "Activat: Manager refuză să discute subiectul și afișează mesajul tău de blocare."
+          },
+          "title": "Măsuri suplimentare de siguranță"
         },
         "save": "Salva",
         "title": "Măsuri suplimentare de siguranță"

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -432,6 +432,11 @@
       "safety_guardrails": {
         "configure": "Configurează",
         "description": "Strat suplimentar de blocări pentru subiecte sensibile, pe lângă securitatea integrată a Manager",
+        "drawer": {
+          "description": "Când un subiect este activat, Manager refuză să îl discute. Dezactivează pentru a permite",
+          "title": "Guardrails de siguranță"
+        },
+        "save": "Salva",
         "title": "Măsuri suplimentare de siguranță"
       }
     },


### PR DESCRIPTION
## Description

### Type of Change

```
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other
```

### Motivation and Context

The Safety Guardrails "Configure" button had no action associated with it. This change wires up the button to open a drawer where users can manage sensitive topic guardrails for the Manager agent.

### Summary of Changes

- Created a new `SafetyGuardrailsDrawer` component that renders a drawer with a title, description, cancel, and save actions.
- Connected the "Configure" button in `SafetyGuardrails.vue` to toggle the drawer open via a reactive `isDrawerOpen` ref.
- Added a test to verify that clicking "Configure" opens the drawer.
- Added localization strings for the drawer title, description, and save button in English, Spanish, Portuguese (BR), and Romanian.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/9e571b85-2713-4565-8e30-1b3244dbd485.png)

