### PR TITLE
feat: Add SafetyGuardrailsBlockMessage component with draft, save, and skeleton loading support

### DIFF
--- a/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsBlockMessage.vue
+++ b/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsBlockMessage.vue
@@ -1,0 +1,32 @@
+<template>
+  <UnnnicTextArea
+    class="safety-guardrails-block-message"
+    data-testid="safety-guardrails-block-message"
+    :modelValue="modelValue"
+    :label="$t('agents.instructions.safety_guardrails.block_message.label')"
+    :message="$t('agents.instructions.safety_guardrails.block_message.helper')"
+    :maxLength="maxLength"
+    @update:model-value="$emit('update:modelValue', $event)"
+  />
+</template>
+
+<script setup>
+defineProps({
+  modelValue: {
+    type: String,
+    required: true,
+  },
+  maxLength: {
+    type: Number,
+    default: 250,
+  },
+});
+
+defineEmits(['update:modelValue']);
+</script>
+
+<style lang="scss" scoped>
+.safety-guardrails-block-message {
+  width: 100%;
+}
+</style>

--- a/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue
+++ b/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue
@@ -50,6 +50,34 @@
           :loading="guardrailsStore.isLoading"
           @update:topic-enabled="onTopicEnabledChange"
         />
+
+        <div
+          v-if="guardrailsStore.isLoading"
+          class="safety-guardrails-drawer__description-skeleton"
+          data-testid="safety-guardrails-drawer-description-skeleton"
+        >
+          <UnnnicSkeletonLoading
+            tag="div"
+            width="135px"
+            height="16px"
+          />
+          <UnnnicSkeletonLoading
+            tag="div"
+            width="100%"
+            height="90px"
+          />
+          <UnnnicSkeletonLoading
+            tag="div"
+            width="362px"
+            height="16px"
+          />
+        </div>
+
+        <SafetyGuardrailsBlockMessage
+          v-else
+          v-model="draftBlockMessage"
+          :maxLength="BLOCK_MESSAGE_MAX_LENGTH"
+        />
       </section>
 
       <UnnnicDrawerFooter>
@@ -80,7 +108,10 @@ import { computed, ref, watch } from 'vue';
 
 import { useGuardrailsConfigStore } from '@/store/GuardrailsConfig';
 
+import SafetyGuardrailsBlockMessage from './SafetyGuardrailsBlockMessage.vue';
 import SafetyGuardrailsTopicList from './SafetyGuardrailsTopicList.vue';
+
+const BLOCK_MESSAGE_MAX_LENGTH = 250;
 
 const modelValue = defineModel({
   type: Boolean,
@@ -90,9 +121,13 @@ const modelValue = defineModel({
 const guardrailsStore = useGuardrailsConfigStore();
 
 const draftTopics = ref([]);
+const draftBlockMessage = ref('');
 const snapshotTopics = ref([]);
+const snapshotBlockMessage = ref('');
 
 const isDirty = computed(() => {
+  if (draftBlockMessage.value !== snapshotBlockMessage.value) return true;
+
   return draftTopics.value.some((topic, index) => {
     return topic.enabled !== snapshotTopics.value[index]?.enabled;
   });
@@ -121,13 +156,17 @@ function cloneTopics(topics) {
 
 async function loadDraft() {
   draftTopics.value = [];
+  draftBlockMessage.value = '';
   snapshotTopics.value = [];
+  snapshotBlockMessage.value = '';
 
   try {
     await guardrailsStore.fetchConfig();
 
     draftTopics.value = cloneTopics(guardrailsStore.topics);
+    draftBlockMessage.value = guardrailsStore.blockingMessage;
     snapshotTopics.value = cloneTopics(guardrailsStore.topics);
+    snapshotBlockMessage.value = guardrailsStore.blockingMessage;
   } catch {
     close();
   }
@@ -147,10 +186,24 @@ async function save() {
     draftTopics.value,
     snapshotTopics.value,
   );
+  const blockingMessageChanged =
+    draftBlockMessage.value !== snapshotBlockMessage.value;
 
-  if (Object.keys(categoryStates).length === 0) return;
+  if (Object.keys(categoryStates).length === 0 && !blockingMessageChanged) {
+    return;
+  }
 
-  await guardrailsStore.updateConfig({ categoryStates });
+  const payload = {};
+
+  if (Object.keys(categoryStates).length > 0) {
+    payload.categoryStates = categoryStates;
+  }
+
+  if (blockingMessageChanged) {
+    payload.blockingMessage = draftBlockMessage.value;
+  }
+
+  await guardrailsStore.updateConfig(payload);
   close();
 }
 
@@ -184,7 +237,8 @@ function onOpenChange(open) {
     color: $unnnic-color-fg-base;
   }
 
-  &__description-states {
+  &__description-states,
+  &__description-skeleton {
     display: flex;
     flex-direction: column;
     gap: $unnnic-space-1;

--- a/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsBlockMessage.spec.js
+++ b/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsBlockMessage.spec.js
@@ -1,0 +1,49 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import SafetyGuardrailsBlockMessage from '../SafetyGuardrailsBlockMessage.vue';
+
+describe('SafetyGuardrailsBlockMessage.vue', () => {
+  let wrapper;
+
+  const createWrapper = (props = {}) =>
+    shallowMount(SafetyGuardrailsBlockMessage, {
+      props: {
+        modelValue: 'Não posso falar sobre esse tópico.',
+        ...props,
+      },
+    });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders the textarea with label, helper, and max length', () => {
+    wrapper = createWrapper();
+
+    const textarea = wrapper.findComponent(
+      '[data-testid="safety-guardrails-block-message"]',
+    );
+
+    expect(textarea.props('modelValue')).toBe(
+      'Não posso falar sobre esse tópico.',
+    );
+    expect(textarea.props('label')).toBe('Block message');
+    expect(textarea.props('message')).toBe(
+      'Displayed to customers when Manager refuses a blocked topic',
+    );
+    expect(textarea.props('maxLength')).toBe(250);
+  });
+
+  it('emits update:modelValue when the textarea changes', async () => {
+    wrapper = createWrapper();
+
+    const textarea = wrapper.findComponent(
+      '[data-testid="safety-guardrails-block-message"]',
+    );
+
+    await textarea.vm.$emit('update:modelValue', 'Updated message');
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([['Updated message']]);
+  });
+});

--- a/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsDrawer.spec.js
+++ b/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsDrawer.spec.js
@@ -5,6 +5,7 @@ import { nextTick } from 'vue';
 
 import SafetyGuardrailsDrawer from '../SafetyGuardrailsDrawer.vue';
 import SafetyGuardrailsTopicList from '../SafetyGuardrailsTopicList.vue';
+import SafetyGuardrailsBlockMessage from '../SafetyGuardrailsBlockMessage.vue';
 
 import nexusaiAPI from '@/api/nexusaiAPI';
 import i18n from '@/utils/plugins/i18n';
@@ -60,6 +61,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
         stubs: {
           UnnnicDrawerNext: false,
           SafetyGuardrailsTopicList: true,
+          SafetyGuardrailsBlockMessage: true,
         },
       },
     });
@@ -73,6 +75,12 @@ describe('SafetyGuardrailsDrawer.vue', () => {
   const findDescription = () =>
     wrapper.find('[data-testid="safety-guardrails-drawer-description"]');
   const findTopicList = () => wrapper.findComponent(SafetyGuardrailsTopicList);
+  const findBlockMessage = () =>
+    wrapper.findComponent(SafetyGuardrailsBlockMessage);
+  const findDescriptionSkeleton = () =>
+    wrapper.find(
+      '[data-testid="safety-guardrails-drawer-description-skeleton"]',
+    );
   const findSave = () =>
     wrapper.findComponent('[data-testid="safety-guardrails-drawer-save"]');
   const findCancel = () =>
@@ -86,7 +94,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     wrapper?.unmount();
   });
 
-  it('renders drawer title, description, and topics from the store', async () => {
+  it('renders drawer title, description, topics, and block message from the store', async () => {
     await createWrapper();
 
     expect(findTitle().text()).toBe(
@@ -113,6 +121,10 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     expect(nexusaiAPI.router.guardrails_config.read).toHaveBeenCalled();
     expect(findTopicList().props('topics')).toEqual(storeConfig.topics);
     expect(findTopicList().props('loading')).toBe(false);
+    expect(findBlockMessage().props('modelValue')).toBe(
+      apiConfig.blocking_message,
+    );
+    expect(findBlockMessage().props('maxLength')).toBe(250);
   });
 
   it('passes loading true to the topic list while fetching', async () => {
@@ -135,6 +147,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
         stubs: {
           UnnnicDrawerNext: false,
           SafetyGuardrailsTopicList: true,
+          SafetyGuardrailsBlockMessage: true,
         },
       },
     });
@@ -142,11 +155,15 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     await nextTick();
 
     expect(findTopicList().props('loading')).toBe(true);
+    expect(findDescriptionSkeleton().exists()).toBe(true);
+    expect(findBlockMessage().exists()).toBe(false);
 
     resolveFetch(storeConfig);
     await flushPromises();
 
     expect(findTopicList().props('loading')).toBe(false);
+    expect(findDescriptionSkeleton().exists()).toBe(false);
+    expect(findBlockMessage().exists()).toBe(true);
   });
 
   it('keeps Save disabled until a draft change is made', async () => {
@@ -158,6 +175,17 @@ describe('SafetyGuardrailsDrawer.vue', () => {
       id: 'politics',
       enabled: false,
     });
+    await nextTick();
+
+    expect(findSave().props('disabled')).toBe(false);
+  });
+
+  it('enables Save when the block message draft changes', async () => {
+    await createWrapper();
+
+    expect(findSave().props('disabled')).toBe(true);
+
+    findBlockMessage().vm.$emit('update:modelValue', 'Updated block message');
     await nextTick();
 
     expect(findSave().props('disabled')).toBe(false);
@@ -180,6 +208,31 @@ describe('SafetyGuardrailsDrawer.vue', () => {
       projectUuid: 'project-uuid',
       data: {
         categoryStates: { politics: false },
+      },
+    });
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+  });
+
+  it('saves changed block message and closes the drawer', async () => {
+    await createWrapper();
+    nexusaiAPI.router.guardrails_config.update.mockResolvedValue({
+      data: {
+        ...apiConfig,
+        blocking_message: 'Updated block message',
+        blocking_message_is_custom: true,
+      },
+    });
+
+    findBlockMessage().vm.$emit('update:modelValue', 'Updated block message');
+    await nextTick();
+
+    await findSave().trigger('click');
+    await flushPromises();
+
+    expect(nexusaiAPI.router.guardrails_config.update).toHaveBeenCalledWith({
+      projectUuid: 'project-uuid',
+      payload: {
+        blocking_message: 'Updated block message',
       },
     });
     expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
@@ -213,6 +266,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
         stubs: {
           UnnnicDrawerNext: false,
           SafetyGuardrailsTopicList: true,
+          SafetyGuardrailsBlockMessage: true,
         },
       },
     });

--- a/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsDrawer.spec.js
+++ b/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsDrawer.spec.js
@@ -122,7 +122,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     expect(findTopicList().props('topics')).toEqual(storeConfig.topics);
     expect(findTopicList().props('loading')).toBe(false);
     expect(findBlockMessage().props('modelValue')).toBe(
-      apiConfig.blocking_message,
+      storeConfig.blockingMessage,
     );
     expect(findBlockMessage().props('maxLength')).toBe(250);
   });
@@ -216,11 +216,8 @@ describe('SafetyGuardrailsDrawer.vue', () => {
   it('saves changed block message and closes the drawer', async () => {
     await createWrapper();
     nexusaiAPI.router.guardrails_config.update.mockResolvedValue({
-      data: {
-        ...apiConfig,
-        blocking_message: 'Updated block message',
-        blocking_message_is_custom: true,
-      },
+      ...storeConfig,
+      blockingMessage: 'Updated block message',
     });
 
     findBlockMessage().vm.$emit('update:modelValue', 'Updated block message');
@@ -231,8 +228,8 @@ describe('SafetyGuardrailsDrawer.vue', () => {
 
     expect(nexusaiAPI.router.guardrails_config.update).toHaveBeenCalledWith({
       projectUuid: 'project-uuid',
-      payload: {
-        blocking_message: 'Updated block message',
+      data: {
+        blockingMessage: 'Updated block message',
       },
     });
     expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -432,6 +432,10 @@
       },
       "safety_guardrails": {
         "allowed": "Extra block off",
+        "block_message": {
+          "helper": "Displayed to customers when Manager refuses a blocked topic",
+          "label": "Block message"
+        },
         "blocked": "Extra block on",
         "configure": "Configure",
         "description": "Extra layer of blocks on sensitive topics, in addition to Manager's built-in safety",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -432,6 +432,10 @@
       },
       "safety_guardrails": {
         "allowed": "Bloqueo extra desactivado",
+        "block_message": {
+          "helper": "Mostrado a los clientes cuando Manager rechaza un tema bloqueado",
+          "label": "Mensaje de bloqueo"
+        },
         "blocked": "Bloqueo extra activado",
         "configure": "Configurar",
         "description": "Capa extra de bloqueos para temas sensibles, además de la seguridad integrada de Manager",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -432,6 +432,10 @@
       },
       "safety_guardrails": {
         "allowed": "Bloqueio extra desativado",
+        "block_message": {
+          "helper": "Exibida aos clientes quando o Manager recusa um tópico bloqueado",
+          "label": "Mensagem de bloqueio"
+        },
         "blocked": "Bloqueio extra ativado",
         "configure": "Configurar",
         "description": "Camada extra de bloqueios para tópicos sensíveis, além da segurança integrada do Manager",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -431,6 +431,10 @@
       },
       "safety_guardrails": {
         "allowed": "Blocarea extra dezactivată",
+        "block_message": {
+          "helper": "Afișat clienților când Manager refuză un subiect blocat",
+          "label": "Mesaj de blocare"
+        },
         "blocked": "Blocarea extra activată",
         "configure": "Configurează",
         "description": "Strat suplimentar de blocări pentru subiecte sensibile, pe lângă securitatea integrată a Manager",


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
Agents need the ability to customize the message shown to customers when a blocked topic is refused by the Manager. Previously, only topic enable/disable states could be configured in the Safety Guardrails drawer, with no way to set a custom blocking message.

### Summary of Changes
- Added a new `SafetyGuardrailsBlockMessage` component that renders a textarea for editing the blocking message, with a 250-character limit and localized label and helper text.
- Integrated `SafetyGuardrailsBlockMessage` into `SafetyGuardrailsDrawer`, including draft/snapshot tracking so the Save button activates when the message is changed and only the modified fields are sent in the update payload.
- Added a skeleton loading state for the block message area while the guardrails config is being fetched.
- Added localized strings for the block message label and helper text in English, Spanish, Brazilian Portuguese, and Romanian.
- Added unit tests for `SafetyGuardrailsBlockMessage` and extended `SafetyGuardrailsDrawer` tests to cover block message rendering, loading state, dirty detection, and save behavior.