### PR TITLE
feat: Add allow topics confirmation dialog to safety guardrails drawer

### DIFF
--- a/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsAllowTopicsDialog.vue
+++ b/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsAllowTopicsDialog.vue
@@ -1,0 +1,106 @@
+<template>
+  <UnnnicDialog
+    v-model:open="open"
+    data-testid="safety-guardrails-allow-topics-dialog"
+    lazyMount
+  >
+    <UnnnicDialogContent>
+      <UnnnicDialogHeader type="attention">
+        <UnnnicDialogTitle
+          data-testid="safety-guardrails-allow-topics-dialog-title"
+        >
+          {{ title }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+
+      <section
+        class="safety-guardrails-allow-topics-dialog__content"
+        data-testid="safety-guardrails-allow-topics-dialog-description"
+      >
+        <p>{{ description }}</p>
+      </section>
+
+      <UnnnicDialogFooter>
+        <UnnnicDialogClose>
+          <UnnnicButton
+            data-testid="safety-guardrails-allow-topics-dialog-cancel"
+            :text="$t('cancel')"
+            type="tertiary"
+            :disabled="loading"
+          />
+        </UnnnicDialogClose>
+        <UnnnicButton
+          data-testid="safety-guardrails-allow-topics-dialog-allow"
+          :text="
+            $t(
+              'agents.instructions.safety_guardrails.allow_topics.confirm_button',
+            )
+          "
+          type="attention"
+          :loading="loading"
+          @click="emit('confirm')"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { formatListToReadable } from '@/utils/formatters';
+
+const open = defineModel('open', {
+  type: Boolean,
+  required: true,
+});
+
+const props = defineProps({
+  topicNames: {
+    type: Array,
+    required: true,
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['confirm']);
+
+const { t } = useI18n();
+
+const isSingleTopic = computed(() => props.topicNames.length === 1);
+
+function translateAllowTopics(key) {
+  const base = 'agents.instructions.safety_guardrails.allow_topics';
+
+  if (isSingleTopic.value) {
+    return t(`${base}.${key}_single`, { topic: props.topicNames[0] });
+  }
+
+  return t(`${base}.${key}_multiple`, {
+    count: props.topicNames.length,
+    topics: formatListToReadable(props.topicNames),
+  });
+}
+
+const title = computed(() => translateAllowTopics('title'));
+const description = computed(() => translateAllowTopics('description'));
+</script>
+
+<style scoped lang="scss">
+.safety-guardrails-allow-topics-dialog {
+  &__content {
+    padding: $unnnic-space-6;
+
+    p {
+      margin: 0;
+
+      @include unnnic-font-body;
+      color: $unnnic-color-fg-base;
+    }
+  }
+}
+</style>

--- a/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue
+++ b/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue
@@ -101,13 +101,22 @@
       </UnnnicDrawerFooter>
     </UnnnicDrawerContent>
   </UnnnicDrawerNext>
+
+  <SafetyGuardrailsAllowTopicsDialog
+    v-model:open="isAllowTopicsDialogOpen"
+    :topicNames="unblockedTopicNames"
+    :loading="guardrailsStore.isSaving"
+    @confirm="onConfirmAllowTopics"
+  />
 </template>
 
 <script setup>
 import { computed, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
 
 import { useGuardrailsConfigStore } from '@/store/GuardrailsConfig';
 
+import SafetyGuardrailsAllowTopicsDialog from './SafetyGuardrailsAllowTopicsDialog.vue';
 import SafetyGuardrailsBlockMessage from './SafetyGuardrailsBlockMessage.vue';
 import SafetyGuardrailsTopicList from './SafetyGuardrailsTopicList.vue';
 
@@ -118,12 +127,21 @@ const modelValue = defineModel({
   required: true,
 });
 
+const { t } = useI18n();
 const guardrailsStore = useGuardrailsConfigStore();
 
 const draftTopics = ref([]);
 const draftBlockMessage = ref('');
 const snapshotTopics = ref([]);
 const snapshotBlockMessage = ref('');
+const isAllowTopicsDialogOpen = ref(false);
+const unblockedTopicIds = ref([]);
+
+const unblockedTopicNames = computed(() => {
+  return unblockedTopicIds.value.map((id) =>
+    t(`agents.instructions.safety_guardrails.topics.${id}.name`),
+  );
+});
 
 const isDirty = computed(() => {
   if (draftBlockMessage.value !== snapshotBlockMessage.value) return true;
@@ -154,11 +172,24 @@ function cloneTopics(topics) {
   return topics.map((topic) => ({ ...topic }));
 }
 
+function getUnblockedTopicIds() {
+  return draftTopics.value
+    .filter((topic) => {
+      const previous = snapshotTopics.value.find(
+        (item) => item.id === topic.id,
+      );
+      return previous?.enabled === true && topic.enabled === false;
+    })
+    .map((topic) => topic.id);
+}
+
 async function loadDraft() {
   draftTopics.value = [];
   draftBlockMessage.value = '';
   snapshotTopics.value = [];
   snapshotBlockMessage.value = '';
+  isAllowTopicsDialogOpen.value = false;
+  unblockedTopicIds.value = [];
 
   try {
     await guardrailsStore.fetchConfig();
@@ -179,9 +210,7 @@ function onTopicEnabledChange({ id, enabled }) {
   if (topic) topic.enabled = enabled;
 }
 
-async function save() {
-  if (!canSave.value) return;
-
+async function persistChanges() {
   const categoryStates = guardrailsStore.buildCategoryStatesDiff(
     draftTopics.value,
     snapshotTopics.value,
@@ -207,7 +236,27 @@ async function save() {
   close();
 }
 
+async function save() {
+  if (!canSave.value) return;
+
+  const unblockedIds = getUnblockedTopicIds();
+
+  if (unblockedIds.length > 0) {
+    unblockedTopicIds.value = unblockedIds;
+    isAllowTopicsDialogOpen.value = true;
+    return;
+  }
+
+  await persistChanges();
+}
+
+async function onConfirmAllowTopics() {
+  await persistChanges();
+  isAllowTopicsDialogOpen.value = false;
+}
+
 function close() {
+  isAllowTopicsDialogOpen.value = false;
   modelValue.value = false;
 }
 

--- a/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsAllowTopicsDialog.spec.js
+++ b/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsAllowTopicsDialog.spec.js
@@ -1,0 +1,82 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import { nextTick } from 'vue';
+
+import SafetyGuardrailsAllowTopicsDialog from '../SafetyGuardrailsAllowTopicsDialog.vue';
+import i18n from '@/utils/plugins/i18n.js';
+import { formatListToReadable } from '@/utils/formatters';
+
+describe('SafetyGuardrailsAllowTopicsDialog.vue', () => {
+  let wrapper;
+
+  const allowTopicsT = (key, params) =>
+    i18n.global.t(
+      `agents.instructions.safety_guardrails.allow_topics.${key}`,
+      params ?? {},
+    );
+
+  const createWrapper = (props = {}) =>
+    shallowMount(SafetyGuardrailsAllowTopicsDialog, {
+      props: {
+        open: true,
+        topicNames: ['Beliefs'],
+        ...props,
+      },
+    });
+
+  const findTitle = () =>
+    wrapper.find('[data-testid="safety-guardrails-allow-topics-dialog-title"]');
+  const findDescription = () =>
+    wrapper.find(
+      '[data-testid="safety-guardrails-allow-topics-dialog-description"]',
+    );
+  const findAllow = () =>
+    wrapper.findComponent(
+      '[data-testid="safety-guardrails-allow-topics-dialog-allow"]',
+    );
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders single-topic title and description', () => {
+    wrapper = createWrapper();
+
+    expect(findTitle().text()).toBe(
+      allowTopicsT('title_single', { topic: 'Beliefs' }),
+    );
+    expect(findDescription().text()).toBe(
+      allowTopicsT('description_single', { topic: 'Beliefs' }),
+    );
+  });
+
+  it('renders multiple-topics title and description', () => {
+    const topicNames = ['Beliefs', 'Politics', 'Religion'];
+
+    wrapper = createWrapper({ topicNames });
+
+    expect(findTitle().text()).toBe(
+      allowTopicsT('title_multiple', { count: topicNames.length }),
+    );
+    expect(findDescription().text()).toBe(
+      allowTopicsT('description_multiple', {
+        topics: formatListToReadable(topicNames),
+      }),
+    );
+  });
+
+  it('emits confirm when confirm button is clicked', async () => {
+    wrapper = createWrapper();
+
+    await findAllow().trigger('click');
+
+    expect(wrapper.emitted('confirm')).toEqual([[]]);
+  });
+
+  it('passes loading to the confirm button', async () => {
+    wrapper = createWrapper({ loading: true });
+    await nextTick();
+
+    expect(findAllow().props('loading')).toBe(true);
+  });
+});

--- a/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsDrawer.spec.js
+++ b/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsDrawer.spec.js
@@ -240,9 +240,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
 
   it('saves blocked topics without confirmation', async () => {
     await createWrapper();
-    nexusaiAPI.router.guardrails_config.update.mockResolvedValue({
-      data: apiConfig,
-    });
+    nexusaiAPI.router.guardrails_config.update.mockResolvedValue(storeConfig);
 
     findTopicList().vm.$emit('update:topic-enabled', {
       id: 'hate',
@@ -255,8 +253,8 @@ describe('SafetyGuardrailsDrawer.vue', () => {
 
     expect(nexusaiAPI.router.guardrails_config.update).toHaveBeenCalledWith({
       projectUuid: 'project-uuid',
-      payload: {
-        category_states: { hate: true },
+      data: {
+        categoryStates: { hate: true },
       },
     });
     expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);

--- a/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsDrawer.spec.js
+++ b/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsDrawer.spec.js
@@ -6,6 +6,7 @@ import { nextTick } from 'vue';
 import SafetyGuardrailsDrawer from '../SafetyGuardrailsDrawer.vue';
 import SafetyGuardrailsTopicList from '../SafetyGuardrailsTopicList.vue';
 import SafetyGuardrailsBlockMessage from '../SafetyGuardrailsBlockMessage.vue';
+import SafetyGuardrailsAllowTopicsDialog from '../SafetyGuardrailsAllowTopicsDialog.vue';
 
 import nexusaiAPI from '@/api/nexusaiAPI';
 import i18n from '@/utils/plugins/i18n';
@@ -62,6 +63,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
           UnnnicDrawerNext: false,
           SafetyGuardrailsTopicList: true,
           SafetyGuardrailsBlockMessage: true,
+          SafetyGuardrailsAllowTopicsDialog: true,
         },
       },
     });
@@ -77,6 +79,8 @@ describe('SafetyGuardrailsDrawer.vue', () => {
   const findTopicList = () => wrapper.findComponent(SafetyGuardrailsTopicList);
   const findBlockMessage = () =>
     wrapper.findComponent(SafetyGuardrailsBlockMessage);
+  const findAllowTopicsDialog = () =>
+    wrapper.findComponent(SafetyGuardrailsAllowTopicsDialog);
   const findDescriptionSkeleton = () =>
     wrapper.find(
       '[data-testid="safety-guardrails-drawer-description-skeleton"]',
@@ -148,6 +152,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
           UnnnicDrawerNext: false,
           SafetyGuardrailsTopicList: true,
           SafetyGuardrailsBlockMessage: true,
+          SafetyGuardrailsAllowTopicsDialog: true,
         },
       },
     });
@@ -191,7 +196,24 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     expect(findSave().props('disabled')).toBe(false);
   });
 
-  it('saves changed category states and closes the drawer', async () => {
+  it('opens confirm dialog when saving with unblocked topics', async () => {
+    await createWrapper();
+
+    findTopicList().vm.$emit('update:topic-enabled', {
+      id: 'politics',
+      enabled: false,
+    });
+    await nextTick();
+
+    await findSave().trigger('click');
+    await nextTick();
+
+    expect(nexusaiAPI.router.guardrails_config.update).not.toHaveBeenCalled();
+    expect(findAllowTopicsDialog().props('open')).toBe(true);
+    expect(findAllowTopicsDialog().props('topicNames')).toEqual(['Politics']);
+  });
+
+  it('saves after confirming allow topics dialog', async () => {
     await createWrapper();
     nexusaiAPI.router.guardrails_config.update.mockResolvedValue(storeConfig);
 
@@ -202,12 +224,39 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     await nextTick();
 
     await findSave().trigger('click');
+    await nextTick();
+
+    findAllowTopicsDialog().vm.$emit('confirm');
     await flushPromises();
 
     expect(nexusaiAPI.router.guardrails_config.update).toHaveBeenCalledWith({
       projectUuid: 'project-uuid',
       data: {
         categoryStates: { politics: false },
+      },
+    });
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+  });
+
+  it('saves blocked topics without confirmation', async () => {
+    await createWrapper();
+    nexusaiAPI.router.guardrails_config.update.mockResolvedValue({
+      data: apiConfig,
+    });
+
+    findTopicList().vm.$emit('update:topic-enabled', {
+      id: 'hate',
+      enabled: true,
+    });
+    await nextTick();
+
+    await findSave().trigger('click');
+    await flushPromises();
+
+    expect(nexusaiAPI.router.guardrails_config.update).toHaveBeenCalledWith({
+      projectUuid: 'project-uuid',
+      payload: {
+        category_states: { hate: true },
       },
     });
     expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
@@ -264,6 +313,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
           UnnnicDrawerNext: false,
           SafetyGuardrailsTopicList: true,
           SafetyGuardrailsBlockMessage: true,
+          SafetyGuardrailsAllowTopicsDialog: true,
         },
       },
     });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -431,6 +431,13 @@
         }
       },
       "safety_guardrails": {
+        "allow_topics": {
+          "confirm_button": "Remove",
+          "description_multiple": "Manager will be able to answer questions about {topics}. You can reactivate these extra blocks anytime",
+          "description_single": "Manager will be able to answer questions about {topic}. You can reactivate this extra block anytime",
+          "title_multiple": "Remove {count} extra blocks",
+          "title_single": "Remove extra block for {topic}"
+        },
         "allowed": "Extra block off",
         "block_message": {
           "helper": "Displayed to customers when Manager refuses a blocked topic",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -431,6 +431,13 @@
         }
       },
       "safety_guardrails": {
+        "allow_topics": {
+          "confirm_button": "Eliminar",
+          "description_multiple": "Manager podrá responder preguntas sobre {topics}. Puedes reactivar estos bloqueos adicionales en cualquier momento",
+          "description_single": "Manager podrá responder preguntas sobre {topic}. Puedes reactivar este bloqueo adicional en cualquier momento",
+          "title_multiple": "Eliminar {count} bloqueos adicionales",
+          "title_single": "Eliminar bloqueo adicional para {topic}"
+        },
         "allowed": "Bloqueo extra desactivado",
         "block_message": {
           "helper": "Mostrado a los clientes cuando Manager rechaza un tema bloqueado",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -431,6 +431,13 @@
         }
       },
       "safety_guardrails": {
+        "allow_topics": {
+          "confirm_button": "Remover",
+          "description_multiple": "O Manager poderá responder perguntas sobre {topics}. Você pode reativar esses bloqueios extras a qualquer momento",
+          "description_single": "O Manager poderá responder perguntas sobre {topic}. Você pode reativar esse bloqueio extra a qualquer momento",
+          "title_multiple": "Remover {count} bloqueios extras",
+          "title_single": "Remover bloqueio extra para {topic}"
+        },
         "allowed": "Bloqueio extra desativado",
         "block_message": {
           "helper": "Exibida aos clientes quando o Manager recusa um tópico bloqueado",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -430,6 +430,13 @@
         }
       },
       "safety_guardrails": {
+        "allow_topics": {
+          "confirm_button": "Elimină",
+          "description_multiple": "Manager va putea răspunde la întrebări despre {topics}. Poți reactiva aceste blocări suplimentare oricând",
+          "description_single": "Manager va putea răspunde la întrebări despre {topic}. Poți reactiva această blocare suplimentară oricând",
+          "title_multiple": "Elimină {count} blocări suplimentare",
+          "title_single": "Elimină blocarea suplimentară pentru {topic}"
+        },
         "allowed": "Blocarea extra dezactivată",
         "block_message": {
           "helper": "Afișat clienților când Manager refuză un subiect blocat",


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [x] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
When a user disables a previously enabled safety guardrail topic, there was no confirmation step to make the user aware of the implications. This change introduces an explicit confirmation dialog to prevent accidental unblocking of sensitive topics.

### Summary of Changes
- Added a new `SafetyGuardrailsAllowTopicsDialog` component that displays a confirmation dialog when the user attempts to save changes that include unblocking one or more previously enabled guardrail topics. The dialog adapts its title and description based on whether one or multiple topics are being unblocked.
- Updated `SafetyGuardrailsDrawer` to intercept the save flow: if any topics are being switched from enabled to disabled, the allow topics dialog is opened and the actual save (`persistChanges`) is deferred until the user confirms. If no topics are being unblocked, the save proceeds immediately without showing the dialog.
- Added `getUnblockedTopicIds` to detect which topics transitioned from enabled to disabled between the snapshot and the current draft.
- Added localization strings for the new dialog (title and description, both single and multiple topic variants) in English, Spanish, Portuguese, and Romanian.
- Added unit tests for `SafetyGuardrailsAllowTopicsDialog` covering single/multiple topic rendering, the confirm emit, and the loading state. Updated `SafetyGuardrailsDrawer` tests to cover the new confirmation flow, including cases where the dialog is shown for unblocked topics, where saving proceeds after confirmation, and where blocking topics skips the dialog entirely.