### PR TITLE
feat: Show next available analysis time in already-run-today tooltip

### DIFF
--- a/src/components/ConversationsImprovements/RunAnalysisButton.vue
+++ b/src/components/ConversationsImprovements/RunAnalysisButton.vue
@@ -21,11 +21,13 @@
 import { computed, ref } from 'vue';
 import { useI18n } from 'vue-i18n';
 import { storeToRefs } from 'pinia';
+import { addHours } from 'date-fns';
 
 import {
   MIN_CONVERSATIONS_FOR_ANALYSIS,
   useImprovementsStore,
 } from '@/store/Improvements';
+import { formatTime } from '@/utils/formatters';
 
 import RunAnalysisDialog from './RunAnalysisDialog.vue';
 
@@ -42,7 +44,8 @@ const props = withDefaults(
 
 const { t } = useI18n();
 const improvementsStore = useImprovementsStore();
-const { runAnalysisBlockReason, improvements } = storeToRefs(improvementsStore);
+const { analysis, runAnalysisBlockReason, improvements } =
+  storeToRefs(improvementsStore);
 
 const isRunAnalysisDialogOpen = ref(false);
 
@@ -50,8 +53,14 @@ const buttonText = computed(() => t(props.translationKey));
 
 const tooltipText = computed(() => {
   if (runAnalysisBlockReason.value === 'already_run_today') {
+    const createdAt = analysis.value.task.createdAt;
+    const nextAvailableAt = createdAt
+      ? formatTime(addHours(new Date(createdAt), 24).toISOString())
+      : '';
+
     return t(
       'audit.improvements.header.run_analysis_already_run_today_tooltip',
+      { time: nextAvailableAt },
     );
   }
 

--- a/src/components/ConversationsImprovements/__tests__/RunAnalysisButton.spec.js
+++ b/src/components/ConversationsImprovements/__tests__/RunAnalysisButton.spec.js
@@ -2,12 +2,15 @@ import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 
+import { addHours } from 'date-fns';
+
 import i18n from '@/utils/plugins/i18n';
 import {
   MIN_CONVERSATIONS_FOR_ANALYSIS,
   useImprovementsStore,
 } from '@/store/Improvements';
 import { DEFAULT_IMPROVEMENTS_TASK } from '@/store/types/Improvements.types';
+import { formatTime } from '@/utils/formatters';
 
 import RunAnalysisButton from '../RunAnalysisButton.vue';
 import RunAnalysisDialog from '../RunAnalysisDialog.vue';
@@ -119,6 +122,8 @@ describe('RunAnalysisButton.vue', () => {
 
     it('disables the button and enables tooltip when analysis already ran today', () => {
       wrapper.unmount();
+      const createdAt = new Date().toISOString();
+
       createWrapper({
         analysis: {
           status: 'complete',
@@ -127,7 +132,7 @@ describe('RunAnalysisButton.vue', () => {
             isRunning: false,
             progress: 5,
             total: 5,
-            createdAt: new Date().toISOString(),
+            createdAt,
           },
         },
       });
@@ -137,6 +142,9 @@ describe('RunAnalysisButton.vue', () => {
       expect(findTooltip().props('text')).toBe(
         i18n.global.t(
           'audit.improvements.header.run_analysis_already_run_today_tooltip',
+          {
+            time: formatTime(addHours(new Date(createdAt), 24).toISOString()),
+          },
         ),
       );
     });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -650,7 +650,7 @@
         "description": "Ran on {date} at {time}",
         "description_today": "Ran today at {time}",
         "run_analysis": "Run analysis",
-        "run_analysis_already_run_today_tooltip": "Analysis already ran today\nReturn tomorrow to run a new analysis",
+        "run_analysis_already_run_today_tooltip": "Analysis already ran in the last 24h.\nNext analysis available at {time}",
         "run_analysis_insufficient_volume_tooltip": "Insufficient conversation volume to run analysis\nMinimum of {min} conversations required",
         "title": "{count, plural, =0 {Analysis of conversations from {date}} one {Analysis of conversations from {date} · {count} improvement identified} other {Analysis of conversations from {date} · {count} improvements identified}}"
       },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -649,7 +649,7 @@
         "description": "Ejecutado el {date} a las {time}",
         "description_today": "Ejecutado hoy a las {time}",
         "run_analysis": "Ejecutar análisis",
-        "run_analysis_already_run_today_tooltip": "Análisis ya ejecutado hoy\nNueva ejecución disponible mañana",
+        "run_analysis_already_run_today_tooltip": "Análisis ya ejecutado en las últimas 24h.\nPróximo análisis disponible a las {time}",
         "run_analysis_insufficient_volume_tooltip": "Volumen insuficiente de conversaciones para ejecutar el análisis\nMínimo de {min} conversaciones necesarias",
         "title": "{count, plural, =0 {Análisis de conversaciones del {date}} one {Análisis de conversaciones del {date} · {count} mejora identificada} other {Análisis de conversaciones del {date} · {count} mejoras identificadas}}"
       },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -649,7 +649,7 @@
         "description": "Executado em {date} às {time}",
         "description_today": "Executado hoje às {time}",
         "run_analysis": "Executar análise",
-        "run_analysis_already_run_today_tooltip": "Análise já executada hoje\nNova execução disponível amanhã",
+        "run_analysis_already_run_today_tooltip": "Análise já executada nas últimas 24h.\nPróxima análise disponível às {time}",
         "run_analysis_insufficient_volume_tooltip": "Volume insuficiente de conversas para executar a análise\nMínimo de {min} conversas necessárias",
         "title": "{count, plural, =0 {Análise das conversas de {date}} one {Análise das conversas de {date} · {count} melhoria identificada} other {Análise das conversas de {date} · {count} melhorias identificadas}}"
       },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -648,7 +648,7 @@
         "description": "Rulat pe {date} la {time}",
         "description_today": "Rulat astăzi la {time}",
         "run_analysis": "Rulează analiza",
-        "run_analysis_already_run_today_tooltip": "Analiza a fost deja executată astăzi\nO nouă execuție va fi disponibilă mâine",
+        "run_analysis_already_run_today_tooltip": "Analiza a fost deja executată în ultimele 24h.\nUrmătoarea analiză este disponibilă la {time}",
         "run_analysis_insufficient_volume_tooltip": "Volum insuficient de conversații pentru executarea analizei\nMinimum {min} conversații necesare",
         "title": "{count, plural, =0 {Analiza conversațiilor din {date}} one {Analiza conversațiilor din {date} · {count} îmbunătățire identificată} other {Analiza conversațiilor din {date} · {count} îmbunătățiri identificate}}"
       },


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [ ] Tests
    - [ ] Other

### Motivation and Context

When a user attempts to run an analysis that has already been executed, the tooltip message previously indicated only that the analysis had run today and to return tomorrow. This lacked precision, as the cooldown is based on a 24-hour window rather than a calendar day boundary.

### Summary of Changes

The "already run today" tooltip now displays the exact time when the next analysis will become available, calculated as 24 hours after the last analysis was created. The tooltip message has been updated across all supported locales (English, Spanish, Portuguese, and Romanian) to reflect this 24-hour window logic and include the `{time}` placeholder. The `RunAnalysisButton` component now computes this next available time using `addHours` from `date-fns` and formats it with the existing `formatTime` utility before passing it to the translation string.



### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/d0f88017-6df9-47f3-844e-5743f0119271.png)

