### PR TITLE
refactor: Migrate delete file/site modals from UnnnicModal to UnnnicDialog

### DIFF
--- a/src/components/Knowledge/ContentFiles.vue
+++ b/src/components/Knowledge/ContentFiles.vue
@@ -67,51 +67,49 @@
       @remove="onRemove"
     />
 
-    <UnnnicModal
-      v-if="modalDeleteFile"
-      :text="$t('content_bases.files.delete_file.title')"
-      :closeIcon="false"
-      class="delete-file-modal"
-      persistent
-      data-test="modal-remove-file"
+    <UnnnicDialog
+      data-testid="modal-remove-file"
+      :open="!!modalDeleteFile"
+      lazyMount
+      @update:open="onDeleteFileModalOpenUpdate"
     >
-      <template #icon>
-        <UnnnicIcon
-          icon="error"
-          size="md"
-          scheme="red-10"
-        />
-      </template>
+      <UnnnicDialogContent v-if="modalDeleteFile">
+        <UnnnicDialogHeader type="warning">
+          <UnnnicDialogTitle>
+            {{ $t('content_bases.files.delete_file.title') }}
+          </UnnnicDialogTitle>
+        </UnnnicDialogHeader>
 
-      <template #message>
-        <div
-          v-html="
-            $t('content_bases.files.delete_file.description', {
-              name: modalDeleteFile.name,
-            })
-          "
-        ></div>
-      </template>
-      <template #options>
-        <UnnnicButton
-          class="create-repository__container__button"
-          type="tertiary"
-          @click="modalDeleteFile = false"
+        <i18n-t
+          tag="p"
+          class="delete-file-modal__description"
+          keypath="content_bases.files.delete_file.description"
         >
-          {{ $t('content_bases.files.delete_file.cancel') }}
-        </UnnnicButton>
+          <template #name>
+            <b>{{ modalDeleteFile.name }}</b>
+          </template>
+        </i18n-t>
 
-        <UnnnicButton
-          class="create-repository__container__button attention-button"
-          type="warning"
-          :loading="modalDeleteFile.status === 'deleting'"
-          data-test="button-remove"
-          @click="remove"
-        >
-          {{ $t('content_bases.files.delete_file.delete') }}
-        </UnnnicButton>
-      </template>
-    </UnnnicModal>
+        <UnnnicDialogFooter>
+          <UnnnicDialogClose>
+            <UnnnicButton
+              :text="$t('content_bases.files.delete_file.cancel')"
+              type="tertiary"
+              :disabled="modalDeleteFile.status === 'deleting'"
+              @click="closeDeleteFileModal"
+            />
+          </UnnnicDialogClose>
+
+          <UnnnicButton
+            data-testid="button-remove"
+            :text="$t('content_bases.files.delete_file.delete')"
+            type="warning"
+            :loading="modalDeleteFile.status === 'deleting'"
+            @click="remove"
+          />
+        </UnnnicDialogFooter>
+      </UnnnicDialogContent>
+    </UnnnicDialog>
   </div>
 </template>
 
@@ -305,6 +303,15 @@ export default {
       };
     },
 
+    closeDeleteFileModal() {
+      if (this.modalDeleteFile?.status === 'deleting') return;
+      this.modalDeleteFile = null;
+    },
+
+    onDeleteFileModalOpenUpdate(open) {
+      if (!open) this.closeDeleteFileModal();
+    },
+
     onRemove($event) {
       if (['fail-upload'].includes($event.status)) {
         this.files.removeItem({ uuid: $event.uuid });
@@ -326,7 +333,7 @@ export default {
         })
         .then(() => {
           this.alertStore.add({
-            type: 'default',
+            type: 'informational',
             text: this.$t('content_bases.files.file_removed_from_base', {
               name: this.modalDeleteFile.name,
             }),
@@ -343,22 +350,15 @@ export default {
 
 <style lang="scss" scoped>
 .delete-file-modal {
-  :deep(.unnnic-modal-container-background-body-description-container) {
-    padding-bottom: $unnnic-spacing-xs;
-  }
+  &__description {
+    margin: $unnnic-space-6;
 
-  :deep(.unnnic-modal-container-background-body__icon-slot) {
-    display: flex;
-    justify-content: center;
-    margin-bottom: $unnnic-spacing-sm;
-  }
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
 
-  :deep(.unnnic-modal-container-background-body-title) {
-    padding-bottom: $unnnic-spacing-sm;
-  }
-
-  :deep(.unnnic-modal-container-background-body) {
-    padding-top: $unnnic-spacing-giant;
+    :deep(b) {
+      font-weight: $unnnic-font-weight-bold;
+    }
   }
 }
 

--- a/src/components/Knowledge/ContentSites.vue
+++ b/src/components/Knowledge/ContentSites.vue
@@ -57,52 +57,50 @@
       @added-site="addedSites"
     />
 
-    <UnnnicModal
-      v-if="modalDeleteSite"
-      :text="$t('content_bases.sites.delete_site.title')"
-      :closeIcon="false"
-      class="delete-site-modal"
-      persistent
-      data-test="modal-remove-site"
+    <UnnnicDialog
+      data-testid="modal-remove-site"
+      :open="!!modalDeleteSite"
+      lazyMount
+      @update:open="onDeleteSiteModalOpenUpdate"
     >
-      <template #icon>
-        <UnnnicIcon
-          icon="error"
-          size="md"
-          scheme="red-10"
-        />
-      </template>
+      <UnnnicDialogContent v-if="modalDeleteSite">
+        <UnnnicDialogHeader type="warning">
+          <UnnnicDialogTitle>
+            {{ $t('content_bases.sites.delete_site.title') }}
+          </UnnnicDialogTitle>
+        </UnnnicDialogHeader>
 
-      <template #message>
-        <div
-          v-html="
-            $t('content_bases.sites.delete_site.description', {
-              name: modalDeleteSite.name,
-            })
-          "
-        ></div>
-      </template>
-      <template #options>
-        <UnnnicButton
-          class="create-repository__container__button"
-          type="tertiary"
-          data-test="button-cancel"
-          @click="closeModal"
+        <i18n-t
+          tag="p"
+          class="delete-site-modal__description"
+          keypath="content_bases.sites.delete_site.description"
         >
-          {{ $t('content_bases.sites.delete_site.cancel') }}
-        </UnnnicButton>
+          <template #name>
+            <b>{{ modalDeleteSite.name }}</b>
+          </template>
+        </i18n-t>
 
-        <UnnnicButton
-          class="create-repository__container__button attention-button"
-          type="warning"
-          :loading="modalDeleteSite.status === 'deleting'"
-          data-test="button-remove"
-          @click="remove"
-        >
-          {{ $t('content_bases.sites.delete_site.delete') }}
-        </UnnnicButton>
-      </template>
-    </UnnnicModal>
+        <UnnnicDialogFooter>
+          <UnnnicDialogClose>
+            <UnnnicButton
+              data-testid="button-cancel"
+              :text="$t('content_bases.sites.delete_site.cancel')"
+              type="tertiary"
+              :disabled="modalDeleteSite.status === 'deleting'"
+              @click="closeModal"
+            />
+          </UnnnicDialogClose>
+
+          <UnnnicButton
+            data-testid="button-remove"
+            :text="$t('content_bases.sites.delete_site.delete')"
+            type="warning"
+            :loading="modalDeleteSite.status === 'deleting'"
+            @click="remove"
+          />
+        </UnnnicDialogFooter>
+      </UnnnicDialogContent>
+    </UnnnicDialog>
   </section>
 </template>
 
@@ -158,7 +156,12 @@ const openDeleteSite = (siteUuid, siteURL) => {
 };
 
 const closeModal = () => {
+  if (modalDeleteSite.value?.status === 'deleting') return;
   modalDeleteSite.value = null;
+};
+
+const onDeleteSiteModalOpenUpdate = (open) => {
+  if (!open) closeModal();
 };
 
 const remove = () => {
@@ -170,7 +173,7 @@ const remove = () => {
     })
     .then(() => {
       alertStore.add({
-        type: 'default',
+        type: 'informational',
         text: i18n.global.t('content_bases.files.file_removed_from_base', {
           name: modalDeleteSite.value.name,
         }),
@@ -179,29 +182,22 @@ const remove = () => {
       props.items.removeItem({ uuid: modalDeleteSite.value.uuid });
     })
     .finally(() => {
-      closeModal();
+      modalDeleteSite.value = null;
     });
 };
 </script>
 
 <style lang="scss" scoped>
 .delete-site-modal {
-  :deep(.unnnic-modal-container-background-body-description-container) {
-    padding-bottom: $unnnic-spacing-xs;
-  }
+  &__description {
+    margin: $unnnic-space-6;
 
-  :deep(.unnnic-modal-container-background-body__icon-slot) {
-    display: flex;
-    justify-content: center;
-    margin-bottom: $unnnic-spacing-sm;
-  }
+    font: $unnnic-font-body;
+    color: $unnnic-color-fg-base;
 
-  :deep(.unnnic-modal-container-background-body-title) {
-    padding-bottom: $unnnic-spacing-sm;
-  }
-
-  :deep(.unnnic-modal-container-background-body) {
-    padding-top: $unnnic-spacing-giant;
+    :deep(b) {
+      font-weight: $unnnic-font-weight-bold;
+    }
   }
 }
 

--- a/src/components/Knowledge/__tests__/ContentFiles.spec.js
+++ b/src/components/Knowledge/__tests__/ContentFiles.spec.js
@@ -85,6 +85,11 @@ const setup = ({ files }) =>
     },
     global: {
       plugins: [pinia],
+      stubs: {
+        UnnnicDialogClose: {
+          template: '<div><slot /></div>',
+        },
+      },
     },
   });
 
@@ -110,9 +115,11 @@ describe('ContentFiles.vue', () => {
 
   describe('when the component is initialized', () => {
     it('does not show modal delete file', () => {
-      const modalDeleteFile = wrapper.find('[data-test="modal-remove-file"]');
+      const modalDeleteFile = wrapper.findComponent(
+        '[data-testid="modal-remove-file"]',
+      );
 
-      expect(modalDeleteFile.exists()).toBeFalsy();
+      expect(modalDeleteFile.props('open')).toBe(false);
     });
 
     it('registers events for drop files behavior', () => {
@@ -263,14 +270,16 @@ describe('ContentFiles.vue', () => {
     });
 
     it('shows modal delete file', async () => {
-      const modalRemoveFile = wrapper.find('[data-test="modal-remove-file"]');
+      const modalRemoveFile = wrapper.findComponent(
+        '[data-testid="modal-remove-file"]',
+      );
 
-      expect(modalRemoveFile.exists()).toBeTruthy();
+      expect(modalRemoveFile.props('open')).toBe(true);
     });
 
     describe('when user confirms', () => {
       it('should request to remove the file', async () => {
-        const buttonRemove = wrapper.find('[data-test="button-remove"]');
+        const buttonRemove = wrapper.find('[data-testid="button-remove"]');
 
         await buttonRemove.trigger('click');
 

--- a/src/components/Knowledge/__tests__/ContentSites.spec.js
+++ b/src/components/Knowledge/__tests__/ContentSites.spec.js
@@ -60,6 +60,11 @@ const setup = (items) =>
     },
     global: {
       plugins: [pinia],
+      stubs: {
+        UnnnicDialogClose: {
+          template: '<div><slot /></div>',
+        },
+      },
     },
   });
 
@@ -138,13 +143,15 @@ describe('ContentSites.vue', () => {
     });
 
     it('shows modal delete site', async () => {
-      const modalRemoveSite = wrapper.find('[data-test="modal-remove-site"]');
-      expect(modalRemoveSite.exists()).toBeTruthy();
+      const modalRemoveSite = wrapper.findComponent(
+        '[data-testid="modal-remove-site"]',
+      );
+      expect(modalRemoveSite.props('open')).toBe(true);
     });
 
     describe('when the user confirms removal', () => {
       it('should request to remove the file', async () => {
-        const buttonRemove = wrapper.find('[data-test="button-remove"]');
+        const buttonRemove = wrapper.find('[data-testid="button-remove"]');
         await buttonRemove.trigger('click');
         expect(nexusaiAPI.knowledge.sites.delete).toHaveBeenCalledWith({
           linkUuid: '2',
@@ -153,7 +160,7 @@ describe('ContentSites.vue', () => {
 
       it('removes the site from the items list', async () => {
         wrapper.vm.onRemove(items.data[2]);
-        const buttonRemove = wrapper.find('[data-test="button-remove"]');
+        const buttonRemove = wrapper.find('[data-testid="button-remove"]');
         await buttonRemove.trigger('click');
         expect(deleteRequest).toHaveBeenCalledWith(
           expect.objectContaining({
@@ -181,12 +188,12 @@ describe('ContentSites.vue', () => {
       wrapper.vm.onRemove(items.data[2]);
       wrapper.vm.openDeleteSite('1', 'https://website.com/pathname1');
       await wrapper.vm.$nextTick();
-      const buttonRemove = wrapper.find('[data-test="button-remove"]');
+      const buttonRemove = wrapper.find('[data-testid="button-remove"]');
       await buttonRemove.trigger('click');
       await wrapper.vm.$nextTick();
 
       expect(alertStore.add).toHaveBeenCalledWith({
-        type: 'default',
+        type: 'informational',
         text: expect.any(String),
       });
     });
@@ -195,7 +202,7 @@ describe('ContentSites.vue', () => {
       wrapper.vm.onRemove(items.data[2]);
       wrapper.vm.openDeleteSite('1', 'https://website.com/pathname1');
       await wrapper.vm.$nextTick();
-      const buttonRemove = wrapper.find('[data-test="button-remove"]');
+      const buttonRemove = wrapper.find('[data-testid="button-remove"]');
       await buttonRemove.trigger('click');
       await wrapper.vm.$nextTick();
 
@@ -263,7 +270,7 @@ describe('ContentSites.vue', () => {
       wrapper.vm.openDeleteSite('1', 'https://website.com/pathname1');
       await wrapper.vm.$nextTick();
 
-      const buttonCancel = wrapper.find('[data-test="button-cancel"]');
+      const buttonCancel = wrapper.find('[data-testid="button-cancel"]');
       await buttonCancel.trigger('click');
 
       expect(wrapper.vm.modalDeleteSite).toBeNull();

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -973,7 +973,7 @@
       "exceeds_limit": "File size exceeds the limit of {limitMB} MB",
       "delete_file": {
         "title": "Delete file",
-        "description": "Are you sure you want to delete the file <b>{name}</b>?<br /> The content of this file will be removed from the AI base.",
+        "description": "Are you sure you want to delete the file {name}? The content of this file will be removed from the AI base.",
         "cancel": "Cancel",
         "delete": "Delete"
       },
@@ -1023,7 +1023,7 @@
       "add_site": "Add site",
       "delete_site": {
         "title": "Delete site",
-        "description": "Are you sure you want to delete the site <b>{name}</b>?<br /> All content from this site will be removed from the AI base.",
+        "description": "Are you sure you want to delete the site {name}? All content from this site will be removed from the AI base.",
         "cancel": "Cancel",
         "delete": "Delete"
       },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -972,7 +972,7 @@
       "exceeds_limit": "El tamaño del archivo excede el límite de {limitMB} MB",
       "delete_file": {
         "title": "Eliminar archivo",
-        "description": "¿Realmente deseas eliminar el archivo <b>{name}</b>?<br />El contenido de este archivo se removerá de la base de la IA.",
+        "description": "¿Realmente deseas eliminar el archivo {name}? El contenido de este archivo se removerá de la base de la IA.",
         "cancel": "Cancelar",
         "delete": "Eliminar"
       },
@@ -1022,7 +1022,7 @@
       "add_site": "Agregar sitio web",
       "delete_site": {
         "title": "Eliminar sitio web",
-        "description": "¿Realmente deseas eliminar el sitio web <b>{name}</b>?<br />El contenido de este sitio web se removerá de la base de la IA.",
+        "description": "¿Realmente deseas eliminar el sitio web {name}? El contenido de este sitio web se removerá de la base de la IA.",
         "cancel": "Cancelar",
         "delete": "Eliminar"
       },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -972,7 +972,7 @@
       "exceeds_limit": "O tamanho do arquivo excede o limite de {limitMB} MB",
       "delete_file": {
         "title": "Excluir arquivo",
-        "description": "Tem certeza de que deseja excluir o arquivo <b>{name}</b>?<br />O conteúdo deste arquivo será removido da base da IA.",
+        "description": "Tem certeza de que deseja excluir o arquivo {name}? O conteúdo deste arquivo será removido da base da IA.",
         "cancel": "Cancelar",
         "delete": "Excluir"
       },
@@ -1022,7 +1022,7 @@
       "add_site": "Adicionar site",
       "delete_site": {
         "title": "Excluir site",
-        "description": "Tem certeza de que deseja excluir o site <b>{name}</b>?<br />O conteúdo deste site será removido da base da IA.",
+        "description": "Tem certeza de que deseja excluir o site {name}? O conteúdo deste site será removido da base da IA.",
         "cancel": "Cancelar",
         "delete": "Excluir"
       },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -971,7 +971,7 @@
       "exceeds_limit": "Dimensiunea fișierului depășește limita de {limitMB} MB",
       "delete_file": {
         "title": "Ștergere fișier",
-        "description": "Sigur dorești să ștergi fișierul <b>{name}</b>?<br /> Conținutul acestui fișier va fi eliminat din baza AI.",
+        "description": "Sigur dorești să ștergi fișierul {name}? Conținutul acestui fișier va fi eliminat din baza AI.",
         "cancel": "Anulează",
         "delete": "Ștergere"
       },
@@ -1021,7 +1021,7 @@
       "add_site": "Adaugă site",
       "delete_site": {
         "title": "Șterge site-ul",
-        "description": "Sigur dorești să ștergi site-ul <b>{name}</b>?<br /> Tot conținutul acestui site va fi eliminat din baza AI.",
+        "description": "Sigur dorești să ștergi site-ul {name}? Tot conținutul acestui site va fi eliminat din baza AI.",
         "cancel": "Anulează",
         "delete": "Ștergere"
       },


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The delete confirmation modals for files and sites were using the legacy `UnnnicModal` component. This change migrates them to the newer `UnnnicDialog` component to align with the current design system standards.

### Summary of Changes
- Replaced `UnnnicModal` with `UnnnicDialog` (along with `UnnnicDialogContent`, `UnnnicDialogHeader`, `UnnnicDialogTitle`, `UnnnicDialogFooter`, and `UnnnicDialogClose`) in both `ContentFiles.vue` and `ContentSites.vue` for the delete confirmation modals.
- Switched from `v-html` with inline HTML tags in locale strings to `i18n-t` with named slots, removing raw HTML (`<b>`, `<br />`) from translation strings across all locales (en, es, pt_br, ro). Bold formatting for the item name is now applied via a scoped `<b>` slot.
- Added `closeDeleteFileModal` and `onDeleteFileModalOpenUpdate` handlers to prevent closing the modal while a deletion is in progress.
- Updated the cancel button in `ContentSites.vue` to also guard against closing during an active deletion.
- Changed the alert type from `'default'` to `'informational'` after a successful deletion in both components.
- Updated test selectors from `data-test` to `data-testid` and adjusted modal existence checks to use `props('open')` instead of `exists()`. Added `UnnnicDialogClose` stub to the test setup.