### PR TITLE
refactor: Replace `UnnnicSelectSmart` with `UnnnicSelect`

### DIFF
--- a/src/components/AgentsTeam/AssignAgents/AgentsList/Filters.vue
+++ b/src/components/AgentsTeam/AssignAgents/AgentsList/Filters.vue
@@ -12,12 +12,12 @@
       data-testid="search-input"
     />
 
-    <UnnnicSelectSmart
+    <UnnnicSelect
       v-if="!isSystemCustom"
       v-model:modelValue="agentsTeamStore.assignAgentsFilters.category"
       :options="categoryOptions"
       :placeholder="$t('agents.assign_agents.filters.category.placeholder')"
-      orderedByIndex
+      clearable
       data-testid="category-select"
     />
   </section>
@@ -40,7 +40,6 @@ const categoryOptions = computed(() => {
     value: category,
   });
   return [
-    { label: 'Categories', value: '' },
     createCategoryOption('product_discovery_and_recommendations'),
     createCategoryOption('orders_status_and_tracking'),
     createCategoryOption('returns_exchanges_and_cancellations'),
@@ -69,9 +68,7 @@ watch(
   () => agentsTeamStore.assignAgentsFilters.search,
   debounce(loadAgents, 300),
 );
-watch(() => agentsTeamStore.assignAgentsFilters.category, loadAgents, {
-  deep: true,
-});
+watch(() => agentsTeamStore.assignAgentsFilters.category, loadAgents);
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/AgentsTeam/AssignAgents/AgentsList/__tests__/EmptyState.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/AgentsList/__tests__/EmptyState.spec.js
@@ -20,7 +20,7 @@ const mountEmptyState = (stateOverrides = {}) => {
         linkToCreateAgent: 'https://github.com/weni-ai/weni-cli',
         assignAgentsFilters: {
           search: '',
-          category: [],
+          category: '',
           system: 'ALL_OFFICIAL',
           ...assignAgentsFiltersOverrides,
         },

--- a/src/components/AgentsTeam/AssignAgents/Sidebar/__tests__/index.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/Sidebar/__tests__/index.spec.js
@@ -22,7 +22,7 @@ describe('AssignAgentsSidebar', () => {
         AgentsTeam: {
           assignAgentsFilters: {
             search: '',
-            category: [],
+            category: '',
             system: 'ALL_OFFICIAL',
           },
           availableSystems,

--- a/src/components/AgentsTeam/AssignAgents/__tests__/AssignAgentsHeader.spec.js
+++ b/src/components/AgentsTeam/AssignAgents/__tests__/AssignAgentsHeader.spec.js
@@ -19,7 +19,7 @@ const mountHeader = (stateOverrides = {}) => {
         },
         assignAgentsFilters: {
           search: '',
-          category: [],
+          category: '',
           system: 'ALL_OFFICIAL',
         },
         availableSystems: [],
@@ -53,7 +53,7 @@ describe('AssignAgentsHeader', () => {
     const { wrapper } = mountHeader({
       assignAgentsFilters: {
         search: '',
-        category: [],
+        category: '',
         system: 'vtex',
       },
       availableSystems: [

--- a/src/components/AgentsTeam/__tests__/AssignAgentsFilters.spec.js
+++ b/src/components/AgentsTeam/__tests__/AssignAgentsFilters.spec.js
@@ -66,9 +66,7 @@ describe('AgentsListFilters.vue', () => {
   });
 
   it('calls loadOfficialAgents when category changes', async () => {
-    await categorySelect().setValue([
-      { label: 'Payments and checkout', value: 'payments_and_checkout' },
-    ]);
+    await categorySelect().setValue('payments_and_checkout');
     await flushUpdates();
 
     expect(agentsTeamStore.loadOfficialAgents).toHaveBeenCalled();
@@ -77,7 +75,7 @@ describe('AgentsListFilters.vue', () => {
   it('computes localized category labels', () => {
     const options = wrapper.vm.categoryOptions;
 
-    expect(options[1].label).toBe(
+    expect(options[0].label).toBe(
       i18n.global.t(
         'agents.assign_agents.filters.category.product_discovery_and_recommendations',
       ),

--- a/src/components/Tunings/ChangesHistory.vue
+++ b/src/components/Tunings/ChangesHistory.vue
@@ -27,12 +27,11 @@
         </UnnnicIntelligenceText>
       </section>
 
-      <UnnnicSelectSmart
+      <UnnnicSelect
         v-model:modelValue="currentFilterOption"
         class="select-filter"
         data-test="select-filter"
         :options="filterOptions"
-        orderedByIndex
       />
     </section>
     <UnnnicTableNext
@@ -95,11 +94,11 @@ const filterOptions = computed(() => [
   },
 ]);
 
-const currentFilterOption = ref(filterOptions.value[0].value.value);
+const currentFilterOption = ref('all');
 
 const noChangesDetected = computed(() => {
   const noRows = table.value.rows.length === 0;
-  const isAllFilterSelected = currentFilterOption.value?.[0].value === 'all';
+  const isAllFilterSelected = currentFilterOption.value === 'all';
 
   return noRows && isAllFilterSelected && !isLoading.value;
 });
@@ -160,11 +159,11 @@ const getChangesHistoryData = async (page = 1, filter = '') => {
 };
 
 watch(pagination, (newPage) => {
-  getChangesHistoryData(newPage, currentFilterOption.value[0].value);
+  getChangesHistoryData(newPage, currentFilterOption.value);
 });
 
 watch(currentFilterOption, (option) => {
-  getChangesHistoryData(1, option[0].value);
+  getChangesHistoryData(1, option);
   pagination.value = 1;
 });
 
@@ -219,9 +218,5 @@ function formatTimeSince(dateString) {
 }
 .select-filter {
   min-width: 260px;
-  :deep(.input:focus) {
-    outline-color: $unnnic-color-weni-600;
-    outline-width: 1.5px;
-  }
 }
 </style>

--- a/src/components/Tunings/SettingsAgentsTeam/VoiceSettings.vue
+++ b/src/components/Tunings/SettingsAgentsTeam/VoiceSettings.vue
@@ -28,14 +28,14 @@
           </p>
 
           <section class="voice-settings__reproduction">
-            <UnnnicSelectSmart
+            <UnnnicSelect
               v-model:modelValue="selectedVoice"
               class="voice-settings__select"
               :options="voiceOptions"
               :disabled="!useVoice"
             />
             <AudioPlayerBar
-              :audio="selectedVoice[0]?.audio"
+              :audio="selectedVoiceAudio"
               :disabled="!useVoice"
             />
           </section>
@@ -102,7 +102,8 @@ const createVoiceOption = (voiceName) => ({
 });
 
 const voiceOptions = Object.keys(AUDIO_FILES).map(createVoiceOption);
-const selectedVoice = ref([voiceOptions[0]]);
+const selectedVoice = ref(voiceOptions[0].value);
+const selectedVoiceAudio = computed(() => AUDIO_FILES[selectedVoice.value]);
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Tunings/__tests__/ChangesHistory.spec.js
+++ b/src/components/Tunings/__tests__/ChangesHistory.spec.js
@@ -40,7 +40,7 @@ describe('ChangesHistory.vue', () => {
         plugins: [createTestingPinia()],
         stubs: {
           UnnnicIntelligenceText: { template: '<p><slot /></p>' },
-          UnnnicSelectSmart: true,
+          UnnnicSelect: true,
           UnnnicTableNext: true,
         },
       },
@@ -51,7 +51,11 @@ describe('ChangesHistory.vue', () => {
     wrapper.unmount();
   });
 
-  test('renders the correct header and sub-description text', () => {
+  test('renders the correct header and sub-description text', async () => {
+    wrapper.vm.table.rows = [{ id: 1 }];
+    wrapper.vm.isLoading = false;
+    await nextTick();
+
     const descriptionText = wrapper.findAll('p');
     expect(descriptionText[0].text()).toContain(
       wrapper.vm.$t('router.tunings.history.description'),
@@ -73,7 +77,7 @@ describe('ChangesHistory.vue', () => {
     );
 
     wrapper.vm.pagination = 2;
-    wrapper.vm.currentFilterOption = [{ value: 'all' }];
+    wrapper.vm.currentFilterOption = 'all';
     await nextTick();
 
     expect(nexusaiAPI.router.tunings.historyChanges.read).toHaveBeenCalledWith({
@@ -146,7 +150,7 @@ describe('ChangesHistory.vue', () => {
   });
 
   test('computes noChangesDetected correctly and renders no changes message when noChangesDetected is true', async () => {
-    wrapper.vm.currentFilterOption = [{ value: 'all' }];
+    wrapper.vm.currentFilterOption = 'all';
 
     await nextTick();
 
@@ -162,7 +166,7 @@ describe('ChangesHistory.vue', () => {
   });
 
   test('computes noChangesDetected correctly when rows are present', async () => {
-    wrapper.vm.currentFilterOption = [{ value: 'all' }];
+    wrapper.vm.currentFilterOption = 'all';
     wrapper.vm.table.rows = [{}];
 
     await nextTick();
@@ -171,7 +175,7 @@ describe('ChangesHistory.vue', () => {
   });
 
   test('renders description and filter select when there are changes', async () => {
-    wrapper.vm.currentFilterOption = [{ value: 'Customization' }];
+    wrapper.vm.currentFilterOption = 'Customization';
     wrapper.vm.table.rows = [{ id: 1, content: 'Change 1' }];
     wrapper.vm.isLoading = false;
 

--- a/src/store/AgentsTeam.ts
+++ b/src/store/AgentsTeam.ts
@@ -41,7 +41,7 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
 
   const assignAgentsFilters = reactive<AssignAgentsFilters>({
     search: '',
-    category: [],
+    category: '',
     system: 'ALL_OFFICIAL',
   });
 
@@ -123,7 +123,7 @@ export const useAgentsTeamStore = defineStore('AgentsTeam', () => {
       const { agents } = await nexusaiAPI.router.agents_team.listOfficialAgents(
         {
           name: search,
-          category: category?.[0]?.value ?? '',
+          category,
           system: system === 'ALL_OFFICIAL' ? '' : system,
         },
       );

--- a/src/store/types/Agents.types.ts
+++ b/src/store/types/Agents.types.ts
@@ -8,6 +8,7 @@ export type AgentCategory =
   | 'crm_and_lead_capture'
   | 'feedback_and_surveys'
   | 'utilities_and_monitoring'
+  | 'b2b'
   | 'others';
 
 export type AgentSystem = {
@@ -83,13 +84,8 @@ export interface Agent {
   last_updated?: string | null;
 }
 
-type SelectOption = {
-  label: string;
-  value: string;
-};
-
 export type AssignAgentsFilters = {
   search: string;
-  category: SelectOption[] | [];
+  category: string;
   system: string | 'ALL_OFFICIAL' | 'ALL_CUSTOM' | '';
 };


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [ ] Feature
    - [x] Code style update (formatting, local variables)
    - [x] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The `UnnnicSelectSmart` component was deprecated. Migrating to `UnnnicSelect` with a simpler string-based value simplifies state management and reduces boilerplate.

### Summary of Changes

- Replaced `UnnnicSelectSmart` with `UnnnicSelect` in `Filters.vue`, `ChangesHistory.vue`, and `VoiceSettings.vue`.
- Changed the `category` filter type in `AssignAgentsFilters` from `SelectOption[]` to a plain `string`, removing the need to unwrap array values when passing to the API.
- Removed the hardcoded empty "Categories" option from the category options list, replacing it with the `clearable` prop on `UnnnicSelect`.
- Updated `selectedVoice` in `VoiceSettings` to hold a string value instead of an array, and introduced a `selectedVoiceAudio` computed property to derive the audio file from the selected voice value.
- Simplified `currentFilterOption` in `ChangesHistory` to a plain string `'all'` instead of an array object, and updated all related watch handlers and computed properties accordingly.
- Removed the `deep: true` option from the category filter watcher since it is no longer watching an array.
- Added the `b2b` category to the `AgentCategory` type.
- Updated all related tests to reflect the new string-based filter values.