### PR TITLE
refactor: Replace `UnnnicSelectSmart` with `UnnnicMultiSelect`

### DIFF
--- a/src/components/Preview/PreviewLogsFilters.vue
+++ b/src/components/Preview/PreviewLogsFilters.vue
@@ -44,12 +44,14 @@
           class="search__input"
         />
 
-        <UnnnicSelectSmart
+        <UnnnicMultiSelect
           v-model:modelValue="selectedCategories"
           :options="categoryOptions"
-          autocomplete
-          autocompleteClearOnFocus
-          multiple
+          :placeholder="
+            $t('agent_builder.traces.filter_logs.categories.placeholder')
+          "
+          enableSearch
+          clearable
           data-testid="logs-category-filter"
         />
       </section>
@@ -88,22 +90,12 @@ const categoryOptions = computed(() => {
     'applying_guardrails',
   ];
 
-  const placeholder = {
-    value: '',
+  return categories.map((category) => ({
+    value: category,
     label: i18n.global.t(
-      'agent_builder.traces.filter_logs.categories.placeholder',
+      `agent_builder.traces.filter_logs.categories.${category}`,
     ),
-  };
-
-  return [
-    placeholder,
-    ...categories.map((category) => ({
-      value: category,
-      label: i18n.global.t(
-        `agent_builder.traces.filter_logs.categories.${category}`,
-      ),
-    })),
-  ];
+  }));
 });
 
 function toggleFilters() {
@@ -113,9 +105,7 @@ function toggleFilters() {
 function emitFiltersChanged() {
   emit('filters-changed', {
     searchTerm: searchTerm.value,
-    selectedCategories: selectedCategories.value.map(
-      (category) => category.value,
-    ),
+    selectedCategories: selectedCategories.value,
   });
 }
 

--- a/src/components/Preview/__tests__/PreviewLogsFilters.spec.js
+++ b/src/components/Preview/__tests__/PreviewLogsFilters.spec.js
@@ -153,15 +153,8 @@ describe('PreviewLogsFilters.vue', () => {
 
       const categoryOptions = wrapper.vm.categoryOptions;
 
-      expect(categoryOptions[0]).toEqual({
-        value: '',
-        label: i18n.global.t(
-          'agent_builder.traces.filter_logs.categories.placeholder',
-        ),
-      });
-
       expectedCategories.forEach((category, index) => {
-        expect(categoryOptions[index + 1]).toEqual({
+        expect(categoryOptions[index]).toEqual({
           value: category,
           label: i18n.global.t(
             `agent_builder.traces.filter_logs.categories.${category}`,
@@ -171,8 +164,7 @@ describe('PreviewLogsFilters.vue', () => {
     });
 
     it('emits filters-changed event when categories change', async () => {
-      const testCategories = [{ value: 'knowledge' }, { value: 'thinking' }];
-      wrapper.vm.selectedCategories = testCategories;
+      wrapper.vm.selectedCategories = ['knowledge', 'thinking'];
       await nextTick();
 
       expect(wrapper.emitted('filters-changed')).toBeTruthy();
@@ -190,7 +182,7 @@ describe('PreviewLogsFilters.vue', () => {
     it('emits filters-changed with correct structure', async () => {
       await filterButton().trigger('click');
       await searchInput().setValue('test');
-      wrapper.vm.selectedCategories = [{ value: 'knowledge' }];
+      wrapper.vm.selectedCategories = ['knowledge'];
       await nextTick();
 
       const emittedEvent = wrapper.emitted('filters-changed').slice(-1)[0][0];
@@ -215,10 +207,9 @@ describe('PreviewLogsFilters.vue', () => {
     it('computes categoryOptions correctly', () => {
       const options = wrapper.vm.categoryOptions;
 
-      expect(options.length).toBe(10);
-      expect(options[0].value).toBe('');
-      expect(options[1].value).toBe('knowledge');
-      expect(options[2].value).toBe('thinking');
+      expect(options.length).toBe(9);
+      expect(options[0].value).toBe('knowledge');
+      expect(options[1].value).toBe('thinking');
     });
   });
 
@@ -232,13 +223,13 @@ describe('PreviewLogsFilters.vue', () => {
     it('maintains state when filters are toggled', async () => {
       await filterButton().trigger('click');
       await searchInput().setValue('persistent search');
-      wrapper.vm.selectedCategories = [{ value: 'knowledge' }];
+      wrapper.vm.selectedCategories = ['knowledge'];
 
       await filterButton().trigger('click');
       await filterButton().trigger('click');
 
       expect(wrapper.vm.searchTerm).toBe('persistent search');
-      expect(wrapper.vm.selectedCategories).toEqual([{ value: 'knowledge' }]);
+      expect(wrapper.vm.selectedCategories).toEqual(['knowledge']);
     });
   });
 

--- a/src/store/Supervisor.js
+++ b/src/store/Supervisor.js
@@ -94,13 +94,17 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
   }
 
   function getInitialSelectFilter(filter, filterOptions) {
-    return temporaryFilters[filter].map((item) => {
-      if (item === '') return { label: '', value: '' };
+    return temporaryFilters[filter]
+      .map((item) => {
+        if (item === '') return '';
 
-      return filterOptions.value.find(
-        (option) => option.value === item || option.label === item,
-      );
-    });
+        const option = filterOptions.value.find(
+          (option) => option.value === item || option.label === item,
+        );
+
+        return option?.value;
+      })
+      .filter((value) => value !== undefined);
   }
 
   async function loadConversations(page = 1) {

--- a/src/views/Supervisor/SupervisorFilters/FilterCsat.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterCsat.vue
@@ -1,13 +1,11 @@
 <template>
   <UnnnicFormElement :label="$t('audit.conversations.filters.csat.csat')">
-    <UnnnicSelectSmart
+    <UnnnicMultiSelect
       v-model:modelValue="csatFilter"
       data-testid="csat-select"
       :options="csatOptions"
-      orderedByIndex
-      multiple
-      multipleWithoutSelectsMessage
-      autocomplete
+      :placeholder="$t('audit.conversations.filters.csat.csat')"
+      clearable
     />
   </UnnnicFormElement>
 </template>
@@ -29,33 +27,29 @@ const CSAT_SCALE = [
 ] as const;
 
 type CsatScaleValue = (typeof CSAT_SCALE)[number]['value'];
-type CsatFilterValue = '' | CsatScaleValue;
 type SelectOption = {
   label: string;
-  value: CsatFilterValue;
+  value: CsatScaleValue;
 };
 
 const translateCsat = (filter: string) =>
   i18n.global.t(`audit.conversations.filters.csat.${filter}`);
 
-const csatOptions = computed<SelectOption[]>(() => [
-  { label: translateCsat('csat'), value: '' },
-  ...CSAT_SCALE.map(({ value, score }) => ({
+const csatOptions = computed<SelectOption[]>(() =>
+  CSAT_SCALE.map(({ value, score }) => ({
     label: `${translateCsat(value)} | CSAT: ${score}`,
     value,
   })),
-]);
+);
 
-const csatFilter = ref<SelectOption[]>(
+const csatFilter = ref<string[]>(
   supervisorStore.getInitialSelectFilter('csat', csatOptions),
 );
 
 watch(
   csatFilter,
   (selected) => {
-    supervisorStore.temporaryFilters.csat = selected.map(
-      (option) => option?.value ?? '',
-    );
+    supervisorStore.temporaryFilters.csat = [...selected];
   },
   { immediate: true, deep: true },
 );

--- a/src/views/Supervisor/SupervisorFilters/FilterStatus.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterStatus.vue
@@ -2,14 +2,12 @@
   <UnnnicFormElement
     :label="$t('audit.conversations.filters.status.conversations')"
   >
-    <UnnnicSelectSmart
+    <UnnnicMultiSelect
       v-model:modelValue="statusFilter"
       data-testid="status-select"
       :options="statusOptions"
-      orderedByIndex
-      multiple
-      multipleWithoutSelectsMessage
-      autocomplete
+      :placeholder="$t('audit.conversations.filters.status.conversations')"
+      clearable
     />
   </UnnnicFormElement>
 </template>
@@ -25,9 +23,8 @@ const supervisorStore = useSupervisorStore();
 const getStatusTranslation = (filter) =>
   i18n.global.t(`audit.conversations.filters.status.${filter}`);
 
-const statusOptions = computed(() => [
-  { label: getStatusTranslation('conversations'), value: '' },
-  ...[
+const statusOptions = computed(() =>
+  [
     'optimized_resolution',
     'other_conclusion',
     'transferred_to_human_support',
@@ -37,18 +34,16 @@ const statusOptions = computed(() => [
     label: getStatusTranslation(value),
     value,
   })),
-]);
+);
 
 const statusFilter = ref(
   supervisorStore.getInitialSelectFilter('status', statusOptions),
 );
 
 watch(
-  () => statusFilter.value,
-  () => {
-    supervisorStore.temporaryFilters.status = statusFilter.value.map(
-      (status) => status?.value || '',
-    );
+  statusFilter,
+  (selected) => {
+    supervisorStore.temporaryFilters.status = [...selected];
   },
   { immediate: true, deep: true },
 );

--- a/src/views/Supervisor/SupervisorFilters/FilterTopics.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterTopics.vue
@@ -1,13 +1,12 @@
 <template>
   <UnnnicFormElement :label="$t('audit.conversations.filters.topic.topic')">
-    <UnnnicSelectSmart
+    <UnnnicMultiSelect
       v-model:modelValue="topicFilter"
       data-testid="topic-select"
       :options="topicOptions"
-      orderedByIndex
-      multiple
-      multipleWithoutSelectsMessage
-      autocomplete
+      :placeholder="$t('audit.conversations.filters.topic.topic')"
+      enableSearch
+      clearable
     />
   </UnnnicFormElement>
 </template>
@@ -26,26 +25,23 @@ const UNCLASSIFIED_TOPIC = {
 };
 
 const topicOptions = computed(() => [
-  {
-    label: i18n.global.t(`audit.conversations.filters.topic.topic`),
-    value: '',
-  },
   UNCLASSIFIED_TOPIC,
   ...supervisorStore.topics,
 ]);
+
 const topicFilter = ref(
   supervisorStore.getInitialSelectFilter('topics', topicOptions),
 );
 
 watch(
-  () => topicFilter.value,
-  () => {
-    supervisorStore.temporaryFilters.topics = topicFilter.value.map(
-      (subject) =>
-        subject?.value === UNCLASSIFIED_TOPIC.value
-          ? subject.value
-          : subject?.label || '',
-    );
+  topicFilter,
+  (selectedValues) => {
+    supervisorStore.temporaryFilters.topics = selectedValues.map((value) => {
+      if (value === UNCLASSIFIED_TOPIC.value) return value;
+
+      const option = topicOptions.value.find((topic) => topic.value === value);
+      return option?.label || '';
+    });
   },
   { immediate: true, deep: true },
 );

--- a/src/views/Supervisor/SupervisorFilters/__tests__/FilterCsat.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/FilterCsat.spec.js
@@ -34,10 +34,9 @@ describe('FilterCsat.vue', () => {
 
     store = useSupervisorStore();
 
-    store.getInitialSelectFilter = vi.fn().mockReturnValue([
-      { label: 'Very Satisfied', value: 'very_satisfied' },
-      { label: 'Satisfied', value: 'satisfied' },
-    ]);
+    store.getInitialSelectFilter = vi
+      .fn()
+      .mockReturnValue(['very_satisfied', 'satisfied']);
 
     wrapper = mount(FilterCsat, {
       global: {
@@ -54,10 +53,7 @@ describe('FilterCsat.vue', () => {
   describe('Component rendering', () => {
     it('renders with correct props', () => {
       expect(csatSelect().exists()).toBe(true);
-      expect(csatSelect().props('orderedByIndex')).toBe(true);
-      expect(csatSelect().props('multiple')).toBe(true);
-      expect(csatSelect().props('multipleWithoutSelectsMessage')).toBeDefined();
-      expect(csatSelect().props('autocomplete')).toBe(true);
+      expect(csatSelect().props('clearable')).toBe(true);
     });
 
     it('initializes with store csat values', () => {
@@ -72,16 +68,13 @@ describe('FilterCsat.vue', () => {
       const options = csatSelect().props('options');
       expect(options).toStrictEqual(wrapper.vm.csatOptions);
       expect(Array.isArray(options)).toBe(true);
-      expect(options.length).toBe(6); // 1 default + 5 csat options
+      expect(options.length).toBe(5);
     });
   });
 
   describe('CSAT selection functionality', () => {
     it('updates local csat filter when select changes', async () => {
-      const newCsatSelection = [
-        { label: 'Neutral', value: 'neutral' },
-        { label: 'Dissatisfied', value: 'dissatisfied' },
-      ];
+      const newCsatSelection = ['neutral', 'dissatisfied'];
 
       await csatSelect().vm.$emit('update:modelValue', newCsatSelection);
       await nextTick();
@@ -90,10 +83,7 @@ describe('FilterCsat.vue', () => {
     });
 
     it('updates store temporary filters when csat changes', async () => {
-      const newCsatSelection = [
-        { label: 'Very Dissatisfied', value: 'very_dissatisfied' },
-        { label: 'Neutral', value: 'neutral' },
-      ];
+      const newCsatSelection = ['very_dissatisfied', 'neutral'];
 
       await csatSelect().vm.$emit('update:modelValue', newCsatSelection);
       await nextTick();
@@ -105,20 +95,14 @@ describe('FilterCsat.vue', () => {
     });
 
     it('handles empty csat selection', async () => {
-      const emptySelection = [];
-
-      await csatSelect().vm.$emit('update:modelValue', emptySelection);
+      await csatSelect().vm.$emit('update:modelValue', []);
       await nextTick();
 
       expect(store.temporaryFilters.csat).toEqual([]);
     });
 
     it('handles single csat selection', async () => {
-      const singleSelection = [
-        { label: 'Very Satisfied', value: 'very_satisfied' },
-      ];
-
-      await csatSelect().vm.$emit('update:modelValue', singleSelection);
+      await csatSelect().vm.$emit('update:modelValue', ['very_satisfied']);
       await nextTick();
 
       expect(store.temporaryFilters.csat).toEqual(['very_satisfied']);
@@ -129,7 +113,6 @@ describe('FilterCsat.vue', () => {
     it('includes all expected csat options', () => {
       const options = csatSelect().props('options');
       const expectedValues = [
-        '',
         'very_satisfied',
         'satisfied',
         'neutral',
@@ -141,18 +124,6 @@ describe('FilterCsat.vue', () => {
       expectedValues.forEach((expectedValue) => {
         expect(actualValues).toContain(expectedValue);
       });
-    });
-
-    it('handles csat options with empty values', async () => {
-      const selectionWithEmpty = [
-        { label: 'CSAT', value: '' },
-        { label: 'Very Satisfied', value: 'very_satisfied' },
-      ];
-
-      await csatSelect().vm.$emit('update:modelValue', selectionWithEmpty);
-      await nextTick();
-
-      expect(store.temporaryFilters.csat).toEqual(['', 'very_satisfied']);
     });
   });
 });

--- a/src/views/Supervisor/SupervisorFilters/__tests__/FilterStatus.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/FilterStatus.spec.js
@@ -35,10 +35,9 @@ describe('FilterStatus.vue', () => {
 
     store = useSupervisorStore();
 
-    store.getInitialSelectFilter = vi.fn().mockReturnValue([
-      { label: 'Optimized Resolution', value: 'optimized_resolution' },
-      { label: 'Other Conclusion', value: 'other_conclusion' },
-    ]);
+    store.getInitialSelectFilter = vi
+      .fn()
+      .mockReturnValue(['optimized_resolution', 'other_conclusion']);
 
     wrapper = mount(FilterStatus, {
       global: {
@@ -55,12 +54,7 @@ describe('FilterStatus.vue', () => {
   describe('Component rendering', () => {
     it('renders with correct props', () => {
       expect(statusSelect().exists()).toBe(true);
-      expect(statusSelect().props('orderedByIndex')).toBe(true);
-      expect(statusSelect().props('multiple')).toBe(true);
-      expect(
-        statusSelect().props('multipleWithoutSelectsMessage'),
-      ).toBeDefined();
-      expect(statusSelect().props('autocomplete')).toBe(true);
+      expect(statusSelect().props('clearable')).toBe(true);
     });
 
     it('initializes with store status values', () => {
@@ -75,16 +69,13 @@ describe('FilterStatus.vue', () => {
       const options = statusSelect().props('options');
       expect(options).toStrictEqual(wrapper.vm.statusOptions);
       expect(Array.isArray(options)).toBe(true);
-      expect(options.length).toBe(6); // 1 default + 5 status options
+      expect(options.length).toBe(5);
     });
   });
 
   describe('Status selection functionality', () => {
     it('updates local status filter when select changes', async () => {
-      const newStatusSelection = [
-        { label: 'Optimized Resolution', value: 'optimized_resolution' },
-        { label: 'In Progress', value: 'in_progress' },
-      ];
+      const newStatusSelection = ['optimized_resolution', 'in_progress'];
 
       await statusSelect().vm.$emit('update:modelValue', newStatusSelection);
       await nextTick();
@@ -94,11 +85,8 @@ describe('FilterStatus.vue', () => {
 
     it('updates store temporary filters when status changes', async () => {
       const newStatusSelection = [
-        {
-          label: 'Transferred to Human Support',
-          value: 'transferred_to_human_support',
-        },
-        { label: 'Unclassified', value: 'unclassified' },
+        'transferred_to_human_support',
+        'unclassified',
       ];
 
       await statusSelect().vm.$emit('update:modelValue', newStatusSelection);
@@ -111,20 +99,14 @@ describe('FilterStatus.vue', () => {
     });
 
     it('handles empty status selection', async () => {
-      const emptySelection = [];
-
-      await statusSelect().vm.$emit('update:modelValue', emptySelection);
+      await statusSelect().vm.$emit('update:modelValue', []);
       await nextTick();
 
       expect(store.temporaryFilters.status).toEqual([]);
     });
 
     it('handles single status selection', async () => {
-      const singleSelection = [
-        { label: 'Other Conclusion', value: 'other_conclusion' },
-      ];
-
-      await statusSelect().vm.$emit('update:modelValue', singleSelection);
+      await statusSelect().vm.$emit('update:modelValue', ['other_conclusion']);
       await nextTick();
 
       expect(store.temporaryFilters.status).toEqual(['other_conclusion']);
@@ -135,7 +117,6 @@ describe('FilterStatus.vue', () => {
     it('includes all expected status options', () => {
       const options = statusSelect().props('options');
       const expectedValues = [
-        '',
         'optimized_resolution',
         'other_conclusion',
         'transferred_to_human_support',
@@ -147,21 +128,6 @@ describe('FilterStatus.vue', () => {
       expectedValues.forEach((expectedValue) => {
         expect(actualValues).toContain(expectedValue);
       });
-    });
-
-    it('handles status options with empty values', async () => {
-      const selectionWithEmpty = [
-        { label: 'Conversations', value: '' },
-        { label: 'Optimized Resolution', value: 'optimized_resolution' },
-      ];
-
-      await statusSelect().vm.$emit('update:modelValue', selectionWithEmpty);
-      await nextTick();
-
-      expect(store.temporaryFilters.status).toEqual([
-        '',
-        'optimized_resolution',
-      ]);
     });
   });
 });

--- a/src/views/Supervisor/SupervisorFilters/__tests__/FilterTopics.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/FilterTopics.spec.js
@@ -41,10 +41,9 @@ describe('FilterTopics.vue', () => {
 
     store = useSupervisorStore();
 
-    store.getInitialSelectFilter = vi.fn().mockReturnValue([
-      { label: 'Billing', value: 'billing' },
-      { label: 'Support', value: 'support' },
-    ]);
+    store.getInitialSelectFilter = vi
+      .fn()
+      .mockReturnValue(['billing', 'support']);
 
     wrapper = mount(FilterTopics, {
       global: {
@@ -61,12 +60,8 @@ describe('FilterTopics.vue', () => {
   describe('Component rendering', () => {
     it('renders with correct props', () => {
       expect(topicSelect().exists()).toBe(true);
-      expect(topicSelect().props('orderedByIndex')).toBe(true);
-      expect(topicSelect().props('multiple')).toBe(true);
-      expect(
-        topicSelect().props('multipleWithoutSelectsMessage'),
-      ).toBeDefined();
-      expect(topicSelect().props('autocomplete')).toBe(true);
+      expect(topicSelect().props('enableSearch')).toBe(true);
+      expect(topicSelect().props('clearable')).toBe(true);
     });
 
     it('initializes with store topic values', () => {
@@ -81,7 +76,7 @@ describe('FilterTopics.vue', () => {
       const options = topicSelect().props('options');
       expect(options).toStrictEqual(wrapper.vm.topicOptions);
       expect(Array.isArray(options)).toBe(true);
-      expect(options.length).toBe(6); // 1 default + 1 unclassified + 4 topic options
+      expect(options.length).toBe(5); // 1 unclassified + 4 topic options
     });
 
     it('provides a fixed unclassified topic option', () => {
@@ -99,10 +94,7 @@ describe('FilterTopics.vue', () => {
 
   describe('Topic selection functionality', () => {
     it('updates local topic filter when select changes', async () => {
-      const newTopicSelection = [
-        { label: 'Technical', value: 'technical' },
-        { label: 'General', value: 'general' },
-      ];
+      const newTopicSelection = ['technical', 'general'];
 
       await topicSelect().vm.$emit('update:modelValue', newTopicSelection);
       await nextTick();
@@ -111,10 +103,7 @@ describe('FilterTopics.vue', () => {
     });
 
     it('updates store temporary filters when topics change', async () => {
-      const newTopicSelection = [
-        { label: 'Technical', value: 'technical' },
-        { label: 'General', value: 'general' },
-      ];
+      const newTopicSelection = ['technical', 'general'];
 
       await topicSelect().vm.$emit('update:modelValue', newTopicSelection);
       await nextTick();
@@ -123,42 +112,37 @@ describe('FilterTopics.vue', () => {
     });
 
     it('handles empty topic selection', async () => {
-      const emptySelection = [];
-
-      await topicSelect().vm.$emit('update:modelValue', emptySelection);
+      await topicSelect().vm.$emit('update:modelValue', []);
       await nextTick();
 
       expect(store.temporaryFilters.topics).toEqual([]);
     });
 
     it('handles single topic selection', async () => {
-      const singleSelection = [{ label: 'Billing', value: 'billing' }];
-
-      await topicSelect().vm.$emit('update:modelValue', singleSelection);
+      await topicSelect().vm.$emit('update:modelValue', ['billing']);
       await nextTick();
 
       expect(store.temporaryFilters.topics).toEqual(['Billing']);
     });
 
     it('stores the unclassified topic by its id', async () => {
-      const selection = [{ label: 'Not classified', value: 'unclassified' }];
-
-      await topicSelect().vm.$emit('update:modelValue', selection);
+      await topicSelect().vm.$emit('update:modelValue', ['unclassified']);
       await nextTick();
 
       expect(store.temporaryFilters.topics).toEqual(['unclassified']);
     });
 
     it('stores the unclassified topic by id alongside regular topics by label', async () => {
-      const selection = [
-        { label: 'Not classified', value: 'unclassified' },
-        { label: 'Billing', value: 'billing' },
-      ];
-
-      await topicSelect().vm.$emit('update:modelValue', selection);
+      await topicSelect().vm.$emit('update:modelValue', [
+        'unclassified',
+        'billing',
+      ]);
       await nextTick();
 
-      expect(store.temporaryFilters.topics).toEqual(['unclassified', 'Billing']);
+      expect(store.temporaryFilters.topics).toEqual([
+        'unclassified',
+        'Billing',
+      ]);
     });
   });
 
@@ -166,8 +150,7 @@ describe('FilterTopics.vue', () => {
     it('includes all expected topic options', () => {
       const options = topicSelect().props('options');
       const expectedLabels = [
-        'Topic', // default option
-        'Not classified', // fixed unclassified option
+        'Not classified',
         'Billing',
         'Support',
         'Technical',
@@ -180,26 +163,10 @@ describe('FilterTopics.vue', () => {
       });
     });
 
-    it('handles topic options with empty values', async () => {
-      const selectionWithEmpty = [
-        { label: 'Topic', value: '' },
-        { label: 'Billing', value: 'billing' },
-      ];
-
-      await topicSelect().vm.$emit('update:modelValue', selectionWithEmpty);
-      await nextTick();
-
-      expect(store.temporaryFilters.topics).toEqual(['Topic', 'Billing']);
-    });
-
     it('handles rapid consecutive topic changes', async () => {
-      const selection1 = [{ label: 'Support', value: 'support' }];
-      const selection2 = [{ label: 'Billing', value: 'billing' }];
-      const selection3 = [{ label: 'Technical', value: 'technical' }];
-
-      await topicSelect().vm.$emit('update:modelValue', selection1);
-      await topicSelect().vm.$emit('update:modelValue', selection2);
-      await topicSelect().vm.$emit('update:modelValue', selection3);
+      await topicSelect().vm.$emit('update:modelValue', ['support']);
+      await topicSelect().vm.$emit('update:modelValue', ['billing']);
+      await topicSelect().vm.$emit('update:modelValue', ['technical']);
       await nextTick();
 
       expect(store.temporaryFilters.topics).toEqual(['Technical']);


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [x] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
The filter components (`FilterCsat`, `FilterStatus`, `FilterTopics`, and `PreviewLogsFilters`) were using `UnnnicSelectSmart` with object-based model values (`{ label, value }`). Migrating to `UnnnicMultiSelect` simplifies the data model by working directly with primitive string values, removing the need to wrap and unwrap option objects throughout the codebase.

### Summary of Changes
- Replaced `UnnnicSelectSmart` with `UnnnicMultiSelect` across `FilterCsat`, `FilterStatus`, `FilterTopics`, and `PreviewLogsFilters`, using `clearable` and `enableSearch` props where appropriate.
- Removed the placeholder empty-value option (`{ value: '', label: '...' }`) that was previously prepended to each options list, since `UnnnicMultiSelect` handles placeholder text via a dedicated prop.
- Filter model values are now plain string arrays (e.g., `['knowledge', 'thinking']`) instead of arrays of option objects, eliminating the need to `.map((option) => option.value)` when reading selected values.
- Updated `getInitialSelectFilter` in the Supervisor store to return option value strings directly and filter out any `undefined` entries, aligning with the new string-based model.
- Updated the `FilterTopics` watcher to resolve topic labels from the options list using the selected string values, preserving the existing behavior of storing the unclassified topic by its ID and regular topics by their label.
- Updated all related tests to reflect the new string array format for selected values and the removal of the placeholder option.