### PR TITLE
feat: Update date filter component with new options and disclaimer for archived conversations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@tsparticles/slim": "^3.9.1",
         "@tsparticles/vue3": "^3.0.1",
         "@vueuse/core": "^10.11.0",
-        "@weni/unnnic-system": "^3.30.0",
+        "@weni/unnnic-system": "^3.31.1-alpha.0",
         "axios": "^1.7.2",
         "cross-env": "^7.0.3",
         "date-fns": "^4.1.0",
@@ -4732,9 +4732,9 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.30.0.tgz",
-      "integrity": "sha512-Lty9gfDK1I5/l8WEOlFZqzrMTGSe1CA1ynnofyllrjNVOjFMfItQi1s4TB6oRsQlDPcC+aY+z5da9zOPuXOcJg==",
+      "version": "3.31.1-alpha.0",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.31.1-alpha.0.tgz",
+      "integrity": "sha512-VV6CoMGWvkgiXr4LSIOv+kvR5qY/cdstsG4y0VdAytzczY0oDafrClACgRljhDb7HSjYUNeyPJe8Go7K61NQZw==",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@tsparticles/slim": "^3.9.1",
         "@tsparticles/vue3": "^3.0.1",
         "@vueuse/core": "^10.11.0",
-        "@weni/unnnic-system": "^3.31.1-alpha.0",
+        "@weni/unnnic-system": "^3.31.0",
         "axios": "^1.7.2",
         "cross-env": "^7.0.3",
         "date-fns": "^4.1.0",
@@ -4732,9 +4732,9 @@
       }
     },
     "node_modules/@weni/unnnic-system": {
-      "version": "3.31.1-alpha.0",
-      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.31.1-alpha.0.tgz",
-      "integrity": "sha512-VV6CoMGWvkgiXr4LSIOv+kvR5qY/cdstsG4y0VdAytzczY0oDafrClACgRljhDb7HSjYUNeyPJe8Go7K61NQZw==",
+      "version": "3.31.0",
+      "resolved": "https://registry.npmjs.org/@weni/unnnic-system/-/unnnic-system-3.31.0.tgz",
+      "integrity": "sha512-EErofYQJ1poFL+5Q0FPhwXdHldeIKOrpq8TgJaesNlEg2iY61BeB455VLM0YdNxwcPzPw7kAAt6Q7tzvfZxWUw==",
       "dependencies": {
         "@iconify/vue": "^5.0.0",
         "@vueuse/components": "^10.4.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tsparticles/slim": "^3.9.1",
     "@tsparticles/vue3": "^3.0.1",
     "@vueuse/core": "^10.11.0",
-    "@weni/unnnic-system": "^3.31.1-alpha.0",
+    "@weni/unnnic-system": "^3.31.0",
     "axios": "^1.7.2",
     "cross-env": "^7.0.3",
     "date-fns": "^4.1.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@tsparticles/slim": "^3.9.1",
     "@tsparticles/vue3": "^3.0.1",
     "@vueuse/core": "^10.11.0",
-    "@weni/unnnic-system": "^3.30.0",
+    "@weni/unnnic-system": "^3.31.1-alpha.0",
     "axios": "^1.7.2",
     "cross-env": "^7.0.3",
     "date-fns": "^4.1.0",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -536,7 +536,16 @@
         "apply_filters": "Apply filters",
         "clear_filters": "Clear filters",
         "period": {
-          "label": "Period"
+          "disclaimer": "Conversations older than 90 days are archived and can't be shown. To access them, contact support.",
+          "label": "Period",
+          "options": {
+            "current_month": "Current month",
+            "custom": "Custom",
+            "last_14_days": "Last 14 days",
+            "last_30_days": "Last 30 days",
+            "last_7_days": "Last 7 days",
+            "last_90_days": "Last 90 days"
+          }
         },
         "status": {
           "conversations": "Conversations",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -536,7 +536,16 @@
         "apply_filters": "Aplicar filtros",
         "clear_filters": "Limpiar filtros",
         "period": {
-          "label": "Periodo"
+          "disclaimer": "Las conversaciones con más de 90 días se archivan y no se pueden mostrar. Para acceder a ellas, comunícate con el soporte.",
+          "label": "Periodo",
+          "options": {
+            "current_month": "Mes actual",
+            "custom": "Personalizar",
+            "last_14_days": "Últimos 14 días",
+            "last_30_days": "Últimos 30 días",
+            "last_7_days": "Últimos 7 días",
+            "last_90_days": "Últimos 90 días"
+          }
         },
         "status": {
           "conversations": "Conversaciones",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -536,7 +536,16 @@
         "apply_filters": "Aplicar filtros",
         "clear_filters": "Limpar filtros",
         "period": {
-          "label": "Período"
+          "disclaimer": "Conversas com mais de 90 dias são arquivadas e não podem ser exibidas. Para acessá-las, entre em contato com o suporte.",
+          "label": "Período",
+          "options": {
+            "current_month": "Mês atual",
+            "custom": "Personalizar",
+            "last_14_days": "Últimos 14 dias",
+            "last_30_days": "Últimos 30 dias",
+            "last_7_days": "Últimos 7 dias",
+            "last_90_days": "Últimos 90 dias"
+          }
         },
         "status": {
           "conversations": "Conversas",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -535,7 +535,16 @@
         "apply_filters": "Aplicare filtre",
         "clear_filters": "Elimină filtrele",
         "period": {
-          "label": "Perioadă"
+          "disclaimer": "Conversațiile mai vechi de 90 de zile sunt arhivate și nu pot fi afișate. Pentru a le accesa, contactează asistența.",
+          "label": "Perioadă",
+          "options": {
+            "current_month": "Luna curentă",
+            "custom": "Personalizează",
+            "last_14_days": "Ultimele 14 zile",
+            "last_30_days": "Ultimele 30 de zile",
+            "last_7_days": "Ultimele 7 zile",
+            "last_90_days": "Ultimele 90 de zile"
+          }
         },
         "status": {
           "conversations": "Conversații",

--- a/src/views/Supervisor/SupervisorFilters/FilterDate.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterDate.vue
@@ -1,24 +1,57 @@
 <template>
-  <UnnnicFormElement :label="$t('audit.conversations.filters.period.label')">
+  <UnnnicFormElement
+    :label="$t('audit.conversations.filters.period.label')"
+    class="supervisor-filter-date"
+  >
     <UnnnicInputDatePicker
       v-model="dateFilter"
       position="right"
-      class="supervisor-filter-date"
+      class="supervisor-filter-date__picker"
+      :minDate="minDate"
       :maxDate="today"
+      :options="datePickerOptions"
       data-testid="date-picker"
-    />
+    >
+      <template #footer>
+        <UnnnicDisclaimer
+          type="neutral"
+          :description="$t('audit.conversations.filters.period.disclaimer')"
+          data-testid="date-filter-disclaimer"
+        />
+      </template>
+    </UnnnicInputDatePicker>
   </UnnnicFormElement>
 </template>
 
 <script setup>
-import { ref, watch } from 'vue';
-import { format } from 'date-fns';
+import { ref, watch, computed } from 'vue';
+import { format, subDays } from 'date-fns';
 
+import i18n from '@/utils/plugins/i18n';
 import { useSupervisorStore } from '@/store/Supervisor';
+
+const ARCHIVE_RETENTION_DAYS = 90;
 
 const supervisorStore = useSupervisorStore();
 
 const today = format(new Date(), 'yyyy-MM-dd');
+const minDate = format(
+  subDays(new Date(), ARCHIVE_RETENTION_DAYS - 1),
+  'yyyy-MM-dd',
+);
+
+const getPeriodOptionTranslation = (option) =>
+  i18n.global.t(`audit.conversations.filters.period.options.${option}`);
+
+const datePickerOptions = computed(() => [
+  { name: getPeriodOptionTranslation('last_7_days'), id: 'last-7-days' },
+  { name: getPeriodOptionTranslation('last_14_days'), id: 'last-14-days' },
+  { name: getPeriodOptionTranslation('last_30_days'), id: 'last-30-days' },
+  { name: getPeriodOptionTranslation('last_90_days'), id: 'last-90-days' },
+  { name: getPeriodOptionTranslation('current_month'), id: 'current-month' },
+  { name: getPeriodOptionTranslation('custom'), id: 'custom' },
+]);
+
 const dateFilter = ref({
   start: supervisorStore.temporaryFilters.start,
   end: supervisorStore.temporaryFilters.end,
@@ -36,10 +69,12 @@ watch(
 
 <style lang="scss" scoped>
 .supervisor-filter-date {
-  width: 100%;
-
-  :deep(.input) {
+  &__picker {
     width: 100%;
+
+    :deep(.input) {
+      width: 100%;
+    }
   }
 }
 </style>

--- a/src/views/Supervisor/SupervisorFilters/FilterDate.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterDate.vue
@@ -36,7 +36,7 @@ const supervisorStore = useSupervisorStore();
 
 const today = format(new Date(), 'yyyy-MM-dd');
 const minDate = format(
-  subDays(new Date(), ARCHIVE_RETENTION_DAYS - 1),
+  subDays(new Date(), ARCHIVE_RETENTION_DAYS),
   'yyyy-MM-dd',
 );
 

--- a/src/views/Supervisor/SupervisorFilters/__tests__/FilterDate.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/FilterDate.spec.js
@@ -66,7 +66,7 @@ describe('FilterDate.vue', () => {
   describe('Component rendering', () => {
     it('renders UnnnicInputDatePicker with correct props', () => {
       const expectedToday = format(new Date(), 'yyyy-MM-dd');
-      const expectedMinDate = format(subDays(new Date(), 89), 'yyyy-MM-dd');
+      const expectedMinDate = format(subDays(new Date(), 90), 'yyyy-MM-dd');
 
       expect(datePicker().exists()).toBe(true);
       expect(datePicker().props('position')).toBe('right');

--- a/src/views/Supervisor/SupervisorFilters/__tests__/FilterDate.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/FilterDate.spec.js
@@ -1,9 +1,8 @@
-import { mount } from '@vue/test-utils';
+import { shallowMount } from '@vue/test-utils';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { createTestingPinia } from '@pinia/testing';
 import { nextTick } from 'vue';
-
-import Unnnic from '@weni/unnnic-system';
+import { format, subDays } from 'date-fns';
 
 import FilterDate from '../FilterDate.vue';
 import { useSupervisorStore } from '@/store/Supervisor';
@@ -23,8 +22,10 @@ describe('FilterDate.vue', () => {
   let store;
 
   const datePicker = () => wrapper.findComponent('[data-testid="date-picker"]');
+  const disclaimer = () =>
+    wrapper.findComponent('[data-testid="date-filter-disclaimer"]');
 
-  beforeEach(() => {
+  const createWrapper = () => {
     const pinia = createTestingPinia({
       initialState: {
         Supervisor: {
@@ -36,16 +37,25 @@ describe('FilterDate.vue', () => {
       },
     });
 
-    wrapper = mount(FilterDate, {
+    wrapper = shallowMount(FilterDate, {
       global: {
-        plugins: [pinia, i18n],
+        plugins: [pinia],
+        // shallowMount stubs skip slots by default; keep only what forwards them
         stubs: {
-          UnnnicInputDatePicker: Unnnic.unnnicInputDatePicker,
+          UnnnicFormElement: { template: '<div><slot /></div>' },
+          UnnnicInputDatePicker: {
+            props: ['modelValue', 'position', 'minDate', 'maxDate', 'options'],
+            template: '<div><slot name="footer" /></div>',
+          },
         },
       },
     });
 
     store = useSupervisorStore();
+  };
+
+  beforeEach(() => {
+    createWrapper();
   });
 
   afterEach(() => {
@@ -55,9 +65,62 @@ describe('FilterDate.vue', () => {
 
   describe('Component rendering', () => {
     it('renders UnnnicInputDatePicker with correct props', () => {
+      const expectedToday = format(new Date(), 'yyyy-MM-dd');
+      const expectedMinDate = format(subDays(new Date(), 89), 'yyyy-MM-dd');
+
       expect(datePicker().exists()).toBe(true);
       expect(datePicker().props('position')).toBe('right');
-      expect(datePicker().props('maxDate')).toBeDefined();
+      expect(datePicker().props('maxDate')).toBe(expectedToday);
+      expect(datePicker().props('minDate')).toBe(expectedMinDate);
+    });
+
+    it('passes limited period options to the date picker', () => {
+      expect(datePicker().props('options')).toEqual([
+        {
+          name: i18n.global.t(
+            'audit.conversations.filters.period.options.last_7_days',
+          ),
+          id: 'last-7-days',
+        },
+        {
+          name: i18n.global.t(
+            'audit.conversations.filters.period.options.last_14_days',
+          ),
+          id: 'last-14-days',
+        },
+        {
+          name: i18n.global.t(
+            'audit.conversations.filters.period.options.last_30_days',
+          ),
+          id: 'last-30-days',
+        },
+        {
+          name: i18n.global.t(
+            'audit.conversations.filters.period.options.last_90_days',
+          ),
+          id: 'last-90-days',
+        },
+        {
+          name: i18n.global.t(
+            'audit.conversations.filters.period.options.current_month',
+          ),
+          id: 'current-month',
+        },
+        {
+          name: i18n.global.t(
+            'audit.conversations.filters.period.options.custom',
+          ),
+          id: 'custom',
+        },
+      ]);
+    });
+
+    it('renders the archive retention disclaimer', () => {
+      expect(disclaimer().exists()).toBe(true);
+      expect(disclaimer().props('type')).toBe('neutral');
+      expect(disclaimer().props('description')).toBe(
+        i18n.global.t('audit.conversations.filters.period.disclaimer'),
+      );
     });
 
     it('initializes with store date values', () => {
@@ -92,13 +155,6 @@ describe('FilterDate.vue', () => {
 
       expect(store.temporaryFilters.start).toBe('2023-03-01');
       expect(store.temporaryFilters.end).toBe('2023-03-31');
-    });
-
-    it('starts with filters from query', () => {
-      expect(datePicker().props('modelValue')).toEqual({
-        start: '2023-01-01',
-        end: '2023-01-31',
-      });
     });
   });
 });


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

Conversations older than 90 days are archived and cannot be displayed. The date filter in the Supervisor view had no restrictions to prevent users from selecting dates beyond this retention window, and no feedback was provided to inform them of this limitation.

### Summary of Changes

- Upgraded `@weni/unnnic-system` to `3.31.0` to support the new `UnnnicDisclaimer` component and updated date picker slot/options API.
- Added a `minDate` constraint to the date picker, restricting selection to the last 90 days (the archive retention period).
- Added predefined period options to the date picker: Last 7 days, Last 14 days, Last 30 days, Last 90 days, Current month, and Custom.
- Added a disclaimer in the date picker footer informing users that conversations older than 90 days are archived and inaccessible, with guidance to contact support.
- Added translations for the new period options and disclaimer across all supported locales (English, Spanish, Portuguese, Romanian).
- Added test coverage for the `minDate` prop, period options, and the disclaimer component.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/f80c1683-86be-46d2-aaaf-58a50b5a69ed.png)

