### PR TITLE
refactor: Simplify conversation and message API data structures

### DIFF
--- a/src/api/adapters/supervisor/conversation.ts
+++ b/src/api/adapters/supervisor/conversation.ts
@@ -1,23 +1,7 @@
 import { isArray } from 'lodash';
 import { Conversation } from '@/store/types/Conversations.types';
 
-interface ApiDataLegacy {
-  results: {
-    urn: string;
-    uuid: string;
-    external_id: string | null;
-    csat: string | null;
-    nps: string | null;
-    topic: string | null;
-    start_date: string;
-    end_date: string;
-    resolution: string;
-    name: string;
-    is_amazing?: boolean;
-  }[];
-}
-
-interface ApiDataV2 {
+interface ApiData {
   results: {
     uuid: string;
     contact_urn: string;
@@ -32,12 +16,17 @@ interface ApiDataV2 {
     nps: string | null;
     created_at: string;
     classification: string | null;
+    topic?: string | null;
     is_amazing?: boolean;
   }[];
+  count?: number;
+  next?: string | null;
 }
 
 interface ConversationResponse {
   results: Conversation[];
+  count?: number;
+  next?: string | null;
 }
 
 interface FilterData {
@@ -66,7 +55,7 @@ export const ConversationAdapter = {
    * @param {Object} apiData - Raw API response data
    * @returns {Object} Transformed data for frontend use
    */
-  fromApi(apiData: ApiDataLegacy | ApiDataV2): ConversationResponse {
+  fromApi(apiData: ApiData): ConversationResponse {
     const statusMap = {
       0: 'optimized_resolution',
       1: 'other_conclusion',
@@ -89,11 +78,11 @@ export const ConversationAdapter = {
         results: apiData.results.map(
           (result): Conversation => ({
             uuid: result.uuid,
-            id: result.external_id || result.uuid,
+            id: result.uuid,
             start: result.start_date,
             end: result.end_date,
-            username: result.name || result.contact_name,
-            urn: result.urn || result.contact_urn,
+            username: result.contact_name,
+            urn: result.contact_urn,
             status: statusMap[result.resolution] || 'in_progress',
             csat:
               result.csat !== null

--- a/src/api/adapters/supervisor/conversation.ts
+++ b/src/api/adapters/supervisor/conversation.ts
@@ -1,24 +1,26 @@
 import { isArray } from 'lodash';
 import { Conversation } from '@/store/types/Conversations.types';
 
+interface ApiConversation {
+  uuid: string;
+  contact_urn: string;
+  contact_name: string;
+  status: string;
+  resolution: number;
+  start_date: string;
+  end_date: string;
+  channel_uuid: string;
+  has_chats_room: boolean;
+  csat: string | null;
+  nps: string | null;
+  created_at: string;
+  classification: string | null;
+  topic?: string | null;
+  is_amazing?: boolean;
+}
+
 interface ApiData {
-  results: {
-    uuid: string;
-    contact_urn: string;
-    contact_name: string;
-    status: string;
-    resolution: number;
-    start_date: string;
-    end_date: string;
-    channel_uuid: string;
-    has_chats_room: boolean;
-    csat: string | null;
-    nps: string | null;
-    created_at: string;
-    classification: string | null;
-    topic?: string | null;
-    is_amazing?: boolean;
-  }[];
+  results?: ApiConversation[];
   count?: number;
   next?: string | null;
 }
@@ -43,66 +45,80 @@ interface ApiParams {
   page: number;
   start_date: string;
   end_date: string;
-  search: string;
-  resolution: number[];
-  csat: number[];
-  topics: string[];
+  search?: string;
+  resolution?: number[];
+  csat?: number[];
+  topics?: string[];
 }
+
+const STATUS_BY_RESOLUTION: Record<number, string> = {
+  0: 'optimized_resolution',
+  1: 'other_conclusion',
+  2: 'in_progress',
+  3: 'unclassified',
+  4: 'transferred_to_human_support',
+};
+
+const CSAT_BY_SCORE: Record<string, string> = {
+  1: 'very_dissatisfied',
+  2: 'dissatisfied',
+  3: 'neutral',
+  4: 'satisfied',
+  5: 'very_satisfied',
+};
+
+const RESOLUTION_BY_STATUS: Record<string, number> = {
+  optimized_resolution: 0,
+  other_conclusion: 1,
+  in_progress: 2,
+  unclassified: 3,
+  transferred_to_human_support: 4,
+};
+
+const SCORE_BY_CSAT: Record<string, number> = {
+  very_dissatisfied: 1,
+  dissatisfied: 2,
+  neutral: 3,
+  satisfied: 4,
+  very_satisfied: 5,
+};
 
 export const ConversationAdapter = {
   /**
    * Transform API response data to frontend format
-   * @param {Object} apiData - Raw API response data
-   * @returns {Object} Transformed data for frontend use
    */
   fromApi(apiData: ApiData): ConversationResponse {
-    const statusMap = {
-      0: 'optimized_resolution',
-      1: 'other_conclusion',
-      2: 'in_progress',
-      3: 'unclassified',
-      4: 'transferred_to_human_support',
-    };
-
-    const csatMap = {
-      1: 'very_dissatisfied',
-      2: 'dissatisfied',
-      3: 'neutral',
-      4: 'satisfied',
-      5: 'very_satisfied',
-    };
-
-    if (apiData.results) {
-      return {
-        ...apiData,
-        results: apiData.results.map(
-          (result): Conversation => ({
-            uuid: result.uuid,
-            id: result.uuid,
-            start: result.start_date,
-            end: result.end_date,
-            username: result.contact_name,
-            urn: result.contact_urn,
-            status: statusMap[result.resolution] || 'in_progress',
-            csat:
-              result.csat !== null
-                ? {
-                    score: parseInt(result.csat),
-                    id: csatMap[result.csat],
-                  }
-                : null,
-            topics: result.topic,
-            isAmazing: Boolean(result.is_amazing),
-          }),
-        ),
-      };
+    if (!apiData.results) {
+      return { results: [] };
     }
+
+    return {
+      ...apiData,
+      results: apiData.results.map(
+        (result): Conversation => ({
+          uuid: result.uuid,
+          id: result.uuid,
+          start: result.start_date,
+          end: result.end_date,
+          username: result.contact_name,
+          urn: result.contact_urn,
+          status: STATUS_BY_RESOLUTION[result.resolution] || 'in_progress',
+          csat:
+            result.csat !== null
+              ? {
+                  score: parseInt(result.csat, 10),
+                  id: CSAT_BY_SCORE[result.csat],
+                }
+              : null,
+          topics: result.topic ?? '',
+          isAmazing: Boolean(result.is_amazing),
+        }),
+      ),
+    };
   },
 
   /**
    * Transform frontend filter parameters to API format
-   * @param {Object} filterData - Frontend filter parameters
-   * @returns {Object} Transformed parameters for API request
    */
   toApi(filterData: FilterData): ApiParams {
     const {
@@ -115,38 +131,22 @@ export const ConversationAdapter = {
       topics = [],
     } = filterData;
 
-    const statusMap = {
-      optimized_resolution: 0,
-      other_conclusion: 1,
-      in_progress: 2,
-      unclassified: 3,
-      transferred_to_human_support: 4,
-    };
-
-    const csatMap = {
-      very_dissatisfied: 1,
-      dissatisfied: 2,
-      neutral: 3,
-      satisfied: 4,
-      very_satisfied: 5,
-    };
-
-    const params = {
+    return {
       page,
       start_date: start,
       end_date: end,
       ...(search && { search }),
       ...(isArray(status) &&
         status.length > 0 && {
-          resolution: status.map((statusItem) => statusMap[statusItem]),
+          resolution: status.map(
+            (statusItem) => RESOLUTION_BY_STATUS[statusItem],
+          ),
         }),
       ...(isArray(csat) &&
         csat.length > 0 && {
-          csat: csat.map((csatItem) => csatMap[csatItem]),
+          csat: csat.map((csatItem) => SCORE_BY_CSAT[csatItem]),
         }),
       ...(isArray(topics) && topics.length > 0 && { topics }),
     };
-
-    return params;
   },
 };

--- a/src/api/adapters/supervisor/conversationMessage.ts
+++ b/src/api/adapters/supervisor/conversationMessage.ts
@@ -2,8 +2,7 @@ interface ConversationMessageResponse {
   id: number;
   uuid: string;
   text: string;
-  source?: 'incoming' | 'outgoing'; // v2 endpoint
-  source_type?: 'user' | 'agent'; // legacy endpoint
+  source?: 'incoming' | 'outgoing';
   created_at: string;
 }
 
@@ -15,29 +14,11 @@ interface ConversationMessage {
   createdAt: string;
 }
 
-interface ConversationMessagesResponseV2 {
+interface ConversationMessagesResponse {
   messages: {
     results: ConversationMessageResponse[];
     next: string | null;
   };
-}
-
-interface ConversationMessagesResponseLegacy {
-  next: string | null;
-  previous: string | null;
-  results: ConversationMessageResponse[];
-}
-
-interface FilterData {
-  start: string;
-  end: string;
-  urn: string;
-}
-
-interface ApiParams {
-  start: string;
-  end: string;
-  contact_urn: string;
 }
 
 export const ConversationMessageAdapter = {
@@ -46,42 +27,21 @@ export const ConversationMessageAdapter = {
    * @param {Object} apiData - Raw API response data
    * @returns {Object} Transformed data for frontend use
    */
-  fromApi(
-    apiData:
-      | ConversationMessagesResponseV2
-      | ConversationMessagesResponseLegacy,
-  ): {
+  fromApi(apiData: ConversationMessagesResponse): {
     results: ConversationMessage[];
     next: string | null;
   } {
-    const messages =
-      'messages' in apiData ? apiData.messages?.results : apiData.results;
-    const next =
-      'messages' in apiData ? apiData.messages?.next : apiData?.next || null;
+    const messages = apiData.messages?.results ?? [];
+    const next = apiData.messages?.next ?? null;
 
-    const results = (messages ?? []).map((result) => ({
+    const results = messages.map((result) => ({
       id: result.id,
       uuid: result.uuid,
       text: result.text,
-      type:
-        result.source_type || (result.source === 'incoming' ? 'user' : 'agent'),
+      type: result.source === 'incoming' ? 'user' : 'agent',
       createdAt: result.created_at,
     }));
 
     return { results, next };
-  },
-
-  /**
-   * Transform frontend filter parameters to API format
-   * @param {Object} filterData - Frontend filter parameters
-   * @returns {Object} Transformed parameters for API request
-   */
-  toApiLegacy(filterData: FilterData): ApiParams {
-    const { start, end, urn } = filterData;
-    return {
-      start,
-      end,
-      contact_urn: urn,
-    };
   },
 };

--- a/src/api/adapters/supervisor/conversationMessage.ts
+++ b/src/api/adapters/supervisor/conversationMessage.ts
@@ -24,8 +24,6 @@ interface ConversationMessagesResponse {
 export const ConversationMessageAdapter = {
   /**
    * Transform API response data to frontend format
-   * @param {Object} apiData - Raw API response data
-   * @returns {Object} Transformed data for frontend use
    */
   fromApi(apiData: ConversationMessagesResponse): {
     results: ConversationMessage[];
@@ -34,7 +32,7 @@ export const ConversationMessageAdapter = {
     const messages = apiData.messages?.results ?? [];
     const next = apiData.messages?.next ?? null;
 
-    const results = messages.map((result) => ({
+    const results: ConversationMessage[] = messages.map((result) => ({
       id: result.id,
       uuid: result.uuid,
       text: result.text,

--- a/src/api/adapters/supervisor/conversationSources.js
+++ b/src/api/adapters/supervisor/conversationSources.js
@@ -1,7 +1,5 @@
 /**
- * Centralizes logic for "new" (v2) and "legacy" conversation endpoints.
- * Since 06/02/2026, conversations come from the v2 endpoint; before that, from the legacy endpoint.
- * When the range crosses the date, both are used with independent pagination.
+ * Fetches conversations from the v2 endpoint, including date formatting and pagination.
  */
 
 import { endOfDay, startOfDay } from 'date-fns';
@@ -9,41 +7,7 @@ import { endOfDay, startOfDay } from 'date-fns';
 import nexusRequest from '@/api/nexusaiRequest';
 import { ConversationAdapter } from './conversation';
 
-/** Data from which conversations come from the v2 endpoint (28/03/2026) */
-export const CONVERSATIONS_SWITCH_DATE = new Date(Date.UTC(2026, 2, 28));
-
-export const LEGACY_SOURCE = 'legacy';
-export const NEW_SOURCE = 'v2';
-
-/** @typedef {'legacy' | 'new' | 'combined'} ConversationMode */
-
-/**
- * Parses string dd-mm-yyyy to Date UTC
- * @param {string} value - Date in format dd-mm-yyyy
- * @returns {Date | null}
- */
-export function parseDateParam(value) {
-  if (!value) return null;
-
-  const [day, month, year] = value.split('-').map(Number);
-
-  if (!day || !month || !year) return null;
-
-  return new Date(Date.UTC(year, month - 1, day));
-}
-
-/**
- * Formats Date to string dd-mm-yyyy
- * @param {Date} date
- * @returns {string}
- */
-export function formatDateParam(date) {
-  const day = String(date.getUTCDate()).padStart(2, '0');
-  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
-  const year = date.getUTCFullYear();
-
-  return `${day}-${month}-${year}`;
-}
+const ENDPOINT_PATH = (projectUuid) => `/api/v2/${projectUuid}/conversations`;
 
 /**
  * Converts date (dd-mm-yyyy) to ISO UTC (Z), representing start/end of day
@@ -65,11 +29,12 @@ function formatDateWithTimezone(dateStr, isEndOfDay = false) {
 }
 
 /**
- * Converts params to the expected format for the new endpoint (start_date/end_date in ISO with user timezone)
+ * Converts params to the expected format for the v2 endpoint
+ * (start_date/end_date in ISO with user timezone)
  * @param {Object} params - { start_date?, end_date?, ... }
  * @returns {Object}
  */
-function buildNewEndpointParams(params) {
+function buildEndpointParams(params) {
   const { start_date, end_date, ...rest } = params;
 
   return {
@@ -84,149 +49,34 @@ function buildNewEndpointParams(params) {
 }
 
 /**
- * Determines which search mode to use based on the filter dates
- * @param {Date | null} startDate
- * @param {Date | null} endDate
- * @returns {ConversationMode}
- */
-export function getConversationMode(startDate, endDate) {
-  if (!startDate || !endDate) return 'legacy';
-  if (endDate < CONVERSATIONS_SWITCH_DATE) return 'legacy';
-  if (startDate >= CONVERSATIONS_SWITCH_DATE) return 'new';
-  return 'combined';
-}
-
-/**
- * Adds source to each result for sorting and separator in the UI
- * @param {Object} data - { results, count?, next? }
- * @param {string} source - LEGACY_SOURCE ou NEW_SOURCE
- * @returns {Object}
- */
-export function addSourceToResults(data, source) {
-  return {
-    ...data,
-    results: data.results?.map((result) => ({ ...result, source })) || [],
-  };
-}
-
-/**
- * Sorts results: v2 first, legacy second (to display the correct separator)
- * @param {Array} results
- * @returns {Array}
- */
-export function normalizeConversationsBySource(results) {
-  const newResults = [];
-  const legacyResults = [];
-
-  (results || []).forEach((conversation) => {
-    if (conversation?.source === NEW_SOURCE) {
-      newResults.push(conversation);
-    } else {
-      legacyResults.push(conversation);
-    }
-  });
-
-  return [...newResults, ...legacyResults];
-}
-
-/**
- * Checks if there is an actual next-page URL.
- * @param {Object} data - { next?, newNext?, legacyNext? }
- * @returns {boolean}
- */
-export function hasNextPageUrl(data) {
-  const { next, newNext, legacyNext } = data || {};
-  return !!(next || newNext || legacyNext);
-}
-
-/**
- * Checks if there are more pages to load (any endpoint).
- * In combined mode: considers "legacy initial" when new is exhausted and legacy hasn't been loaded yet.
- * @param {Object} data - { next?, newNext?, legacyNext? }
+ * Checks if there are more pages to load.
+ * @param {Object} data - { next? }
  * @param {string} status - loading status
- * @param {Array} [results] - current results to detect legacy initial in combined mode
  * @returns {boolean}
  */
-export function hasMoreToLoad(data, status, results = []) {
-  const { next, newNext, legacyNext } = data || {};
-  const hasNext = next || newNext || legacyNext;
-  const needsLegacyInitial = needsLegacyInitialLoad(data, results);
+export function hasMoreToLoad(data, status) {
+  const hasNext = !!data?.next;
   const isLoading = status === 'loading';
   const hasError = status === 'error';
 
-  return (!!hasNext || needsLegacyInitial) && !isLoading && !hasError;
+  return hasNext && !isLoading && !hasError;
 }
 
 /**
- * In combined mode: new is exhausted (newNext null) and legacy hasn't been loaded yet
- * @param {Object} data - { newNext?, legacyNext?, legacyInitialAttempted? }
- * @param {Array} results
- * @returns {boolean}
- */
-export function needsLegacyInitialLoad(data, results = []) {
-  const { newNext, legacyNext, legacyInitialAttempted = false } = data || {};
-  const hasNewResults = (results || []).some((r) => r?.source === NEW_SOURCE);
-  const hasLegacyResults = (results || []).some(
-    (r) => r?.source === LEGACY_SOURCE,
-  );
-
-  return (
-    !newNext &&
-    !legacyNext &&
-    !legacyInitialAttempted &&
-    hasNewResults &&
-    !hasLegacyResults
-  );
-}
-
-/**
- * Returns pagination payload for load more (only one endpoint at a time).
- * Priority: newNext, then legacyNext, then legacy initial (when new is exhausted).
+ * Returns the next-page URL for load more, when available.
  * @param {number} page
- * @param {Object} data - { newNext?, legacyNext? }
- * @param {Array} [results] - to detect need for legacy initial
- * @returns {{ pagination?: { source: string, next: string }; onlyLegacy?: true } | null}
+ * @param {Object} data - { next? }
+ * @returns {{ next: string } | null}
  */
-export function getPaginationPayload(page, data, results = []) {
-  if (page <= 1) return null;
+export function getPaginationPayload(page, data) {
+  if (page <= 1 || !data?.next) return null;
 
-  const { newNext, legacyNext } = data || {};
-
-  if (newNext) {
-    return { pagination: { source: NEW_SOURCE, next: newNext } };
-  }
-  if (legacyNext) {
-    return { pagination: { source: LEGACY_SOURCE, next: legacyNext } };
-  }
-  if (needsLegacyInitialLoad(data, results)) {
-    return { onlyLegacy: true };
-  }
-
-  return null;
-}
-
-/**
- * Key of data to update after pagination response
- * @param {string} paginationSource - NEW_SOURCE or LEGACY_SOURCE
- * @returns {'newNext' | 'legacyNext'}
- */
-export function getPaginationKey(paginationSource) {
-  return paginationSource === NEW_SOURCE ? 'newNext' : 'legacyNext';
-}
-
-/**
- * End date of legacy range (one day before the switch)
- * @returns {Date}
- */
-export function getLegacyEndDate() {
-  const date = new Date(CONVERSATIONS_SWITCH_DATE);
-  date.setUTCDate(date.getUTCDate() - 1);
-  return date;
+  return { next: data.next };
 }
 
 /**
  * Extracts the path from the next URL for use with the client HTTP baseUrl
- * @param {string} nextUrl - URL completa ou path
+ * @param {string} nextUrl - Full URL or path
  * @returns {string | null}
  */
 export function extractPathFromNextUrl(nextUrl) {
@@ -237,89 +87,8 @@ export function extractPathFromNextUrl(nextUrl) {
 }
 
 /**
- * Checks if the pagination payload is valid for the request
- * @param {{ source?: string; next?: string } | null} pagination
- * @returns {boolean}
- */
-export function isValidPaginationPayload(pagination) {
-  return Boolean(pagination?.source && pagination?.next);
-}
-
-/**
- * Returns the pagination state (next, newNext, legacyNext) from the API response.
- * Used by the store to update conversations.data after each load.
- * @param {Object} responseData - API response (can come from initial load or pagination)
- * @param {Object} currentData - current state { next?, newNext?, legacyNext? }
- * @returns {{ next: string | null; newNext: string | null; legacyNext: string | null } | null}
- */
-export function getPaginationStateFromResponse(responseData, currentData = {}) {
-  if (
-    responseData?.newNext !== undefined ||
-    responseData?.legacyNext !== undefined
-  ) {
-    return {
-      next: null,
-      newNext: responseData.newNext ?? null,
-      legacyNext: responseData.legacyNext ?? null,
-    };
-  }
-
-  if (responseData?.next !== undefined && !responseData?._paginationSource) {
-    return {
-      next: responseData.next ?? null,
-      newNext: null,
-      legacyNext: null,
-    };
-  }
-
-  if (responseData?._paginationSource) {
-    const key = getPaginationKey(responseData._paginationSource);
-    return {
-      next: null,
-      newNext:
-        key === 'newNext'
-          ? (responseData.next ?? null)
-          : (currentData.newNext ?? null),
-      legacyNext:
-        key === 'legacyNext'
-          ? (responseData.next ?? null)
-          : (currentData.legacyNext ?? null),
-    };
-  }
-
-  return null;
-}
-
-const LEGACY_ENDPOINT_PATH = (projectUuid) => `/api/${projectUuid}/supervisor/`;
-const NEW_ENDPOINT_PATH = (projectUuid) =>
-  `/api/v2/${projectUuid}/conversations`;
-
-async function fetchConversations({ url, params, config, source }) {
-  const { data } = await nexusRequest.$http.get(
-    `${url}?${new URLSearchParams(params)}`,
-    config,
-  );
-
-  const adaptedData = ConversationAdapter.fromApi(data) || { results: [] };
-
-  return addSourceToResults(adaptedData, source);
-}
-
-async function fetchByNextUrl({ nextUrl, config, source }) {
-  const path = extractPathFromNextUrl(nextUrl);
-  if (!path) return addSourceToResults({ results: [] }, source);
-
-  const { data } = await nexusRequest.$http.get(path, config);
-
-  const adaptedData = ConversationAdapter.fromApi(data) || { results: [] };
-
-  return addSourceToResults(adaptedData, source);
-}
-
-/**
- * Executes the list of conversations (legacy, new or combined).
- * Centralizes all endpoint and pagination logic.
- * @param {Object} filterData - { projectUuid, signal, hideGenericErrorAlert?, filters?, pagination?, onlyLegacy? }
+ * Lists conversations from the v2 endpoint.
+ * @param {Object} filterData - { projectUuid, signal, hideGenericErrorAlert?, filters?, pagination? }
  * @returns {Promise<Object>}
  */
 export async function fetchConversationList(filterData) {
@@ -329,88 +98,23 @@ export async function fetchConversationList(filterData) {
     hideGenericErrorAlert = false,
     filters = {},
     pagination = null,
-    onlyLegacy = false,
   } = filterData;
 
   const config = { signal, hideGenericErrorAlert };
-  const legacyEndpoint = LEGACY_ENDPOINT_PATH(projectUuid);
-  const newEndpoint = NEW_ENDPOINT_PATH(projectUuid);
 
-  if (isValidPaginationPayload(pagination)) {
-    const result = await fetchByNextUrl({
-      nextUrl: pagination.next,
-      config,
-      source: pagination.source,
-    });
-    return { ...result, _paginationSource: pagination.source };
+  if (pagination?.next) {
+    const path = extractPathFromNextUrl(pagination.next);
+    if (!path) return { results: [], next: null };
+
+    const { data } = await nexusRequest.$http.get(path, config);
+    return ConversationAdapter.fromApi(data) || { results: [], next: null };
   }
 
-  const params = ConversationAdapter.toApi({ ...filters });
+  const params = buildEndpointParams(ConversationAdapter.toApi({ ...filters }));
+  const { data } = await nexusRequest.$http.get(
+    `${ENDPOINT_PATH(projectUuid)}?${new URLSearchParams(params)}`,
+    config,
+  );
 
-  const fetchLegacy = (paramsToUse) =>
-    fetchConversations({
-      url: legacyEndpoint,
-      params: paramsToUse,
-      config,
-      source: LEGACY_SOURCE,
-    });
-
-  const fetchLegacyWithParams = async () => {
-    const legacyEndDate = getLegacyEndDate();
-    const legacyParams = {
-      ...params,
-      end_date: formatDateParam(legacyEndDate),
-    };
-    return fetchLegacy(legacyParams);
-  };
-
-  const fetchNew = (paramsToUse) =>
-    fetchConversations({
-      url: newEndpoint,
-      params: paramsToUse,
-      config,
-      source: NEW_SOURCE,
-    });
-
-  const startDate = parseDateParam(params.start_date);
-  const endDate = parseDateParam(params.end_date);
-  const mode = getConversationMode(startDate, endDate);
-
-  if (mode === 'legacy') {
-    const result = await fetchLegacy(params);
-    return { ...result, _paginationSource: LEGACY_SOURCE };
-  }
-  if (mode === 'new') {
-    const result = await fetchNew(buildNewEndpointParams(params));
-    return {
-      ...result,
-      _paginationSource: NEW_SOURCE,
-      legacyInitialAttempted: true,
-    };
-  }
-
-  if (onlyLegacy) {
-    const result = await fetchLegacyWithParams();
-    return { ...result, _paginationSource: LEGACY_SOURCE };
-  }
-
-  const newParams = buildNewEndpointParams({
-    ...params,
-    start_date: formatDateParam(CONVERSATIONS_SWITCH_DATE),
-  });
-  const result = await fetchNew(newParams);
-
-  const isNewResponseEmpty =
-    result.results?.length === 0 && result.next === null;
-
-  if (isNewResponseEmpty) {
-    const legacyResult = await fetchLegacyWithParams();
-    return {
-      ...legacyResult,
-      newNext: null,
-      legacyNext: legacyResult.next ?? null,
-    };
-  }
-
-  return { ...result, _paginationSource: NEW_SOURCE };
+  return ConversationAdapter.fromApi(data) || { results: [], next: null };
 }

--- a/src/api/nexus/Supervisor.js
+++ b/src/api/nexus/Supervisor.js
@@ -12,26 +12,16 @@ export const Supervisor = {
       return fetchConversationList(filterData);
     },
 
-    async getById({ projectUuid, start, end, urn, next, source, uuid }) {
-      const legacyParams = ConversationMessageAdapter.toApiLegacy({
-        start,
-        end,
-        urn,
-      });
-
+    async getById({ projectUuid, next, uuid }) {
       const timezone = Intl?.DateTimeFormat?.().resolvedOptions?.()?.timeZone;
-      const isLegacy = source === 'legacy';
 
-      let url = isLegacy
-        ? `/api/${projectUuid}/conversations/?${new URLSearchParams(legacyParams)}`
-        : `/api/v2/${projectUuid}/conversations/${uuid}`;
+      let url = `/api/v2/${projectUuid}/conversations/${uuid}`;
 
       if (next) {
         url = next.slice(next.indexOf('/api'));
       }
 
-      if (!isLegacy && !url.includes('timezone')) {
-        // Add timezone to url
+      if (!url.includes('timezone')) {
         const separator = url.includes('?') ? '&' : '?';
         url += `${separator}${new URLSearchParams({ timezone }).toString()}`;
       }

--- a/src/api/nexus/__tests__/Supervisor.spec.js
+++ b/src/api/nexus/__tests__/Supervisor.spec.js
@@ -83,23 +83,6 @@ describe('Supervisor.js', () => {
       },
     };
 
-    /** Legacy API shape: results + next (ConversationMessageAdapter.fromApi) */
-    const mockLegacyResponse = {
-      data: {
-        results: [
-          {
-            id: 1,
-            uuid: 'msg-1',
-            text: 'Hello',
-            source_type: 'user',
-            created_at: '2023-01-15T12:30:00Z',
-          },
-        ],
-        next: null,
-        previous: null,
-      },
-    };
-
     it('should get conversation by id (v2) without next param', async () => {
       nexusRequest.$http.get.mockResolvedValue(mockV2Response);
 
@@ -164,48 +147,11 @@ describe('Supervisor.js', () => {
       await Supervisor.conversations.getById({
         projectUuid,
         uuid,
-        source: 'v2',
-        timezone,
       });
 
       const callUrl = nexusRequest.$http.get.mock.calls[0][0];
       expect(callUrl).toContain(`/api/v2/${projectUuid}/conversations/${uuid}`);
       expect(callUrl).toContain(new URLSearchParams({ timezone }).toString());
-    });
-
-    it('should get conversation by id with source legacy', async () => {
-      nexusRequest.$http.get.mockResolvedValue(mockLegacyResponse);
-
-      const projectUuid = 'project-123';
-      const start = '01-01-2023';
-      const end = '15-01-2023';
-      const urn = 'tel:+123456789';
-
-      const result = await Supervisor.conversations.getById({
-        projectUuid,
-        source: 'legacy',
-        start,
-        end,
-        urn,
-      });
-
-      const expectedPath = `/api/${projectUuid}/conversations/`;
-      expect(nexusRequest.$http.get).toHaveBeenCalledWith(
-        expect.stringContaining(expectedPath),
-      );
-      const callUrl = nexusRequest.$http.get.mock.calls[0][0];
-      expect(callUrl).toContain('contact_urn=tel%3A%2B123456789');
-      expect(callUrl).toContain('start=01-01-2023');
-      expect(callUrl).toContain('end=15-01-2023');
-      expect(result.results).toHaveLength(1);
-      expect(result.results[0]).toMatchObject({
-        id: 1,
-        uuid: 'msg-1',
-        text: 'Hello',
-        type: 'user',
-        createdAt: '2023-01-15T12:30:00Z',
-      });
-      expect(result.next).toBeNull();
     });
 
     it('should handle error when getting conversation by id', async () => {

--- a/src/components/ConversationsImprovements/DrawerDetails/AffectedConversationsSection.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/AffectedConversationsSection.vue
@@ -114,7 +114,6 @@ async function handleViewFullConversation(conversation: AffectedConversation) {
     uuid: conversation.uuid,
     urn: conversation.contactUrn,
     username: conversation.contactName,
-    source: 'v2',
     data: { status: null },
   };
 

--- a/src/components/ConversationsImprovements/DrawerDetails/AffectedConversationsSection.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/AffectedConversationsSection.vue
@@ -45,7 +45,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
+import { useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 
 import {
@@ -57,6 +57,7 @@ import { useSupervisorStore } from '@/store/Supervisor';
 import ImprovementDrawerSection from './ImprovementDrawerSection.vue';
 import AffectedConversationItem from './AffectedConversationItem.vue';
 
+import type { SelectedConversation } from '@/store/types/Conversations.types';
 import type { AffectedConversation } from '@/store/types/Improvements.types';
 
 const props = defineProps<{
@@ -68,7 +69,6 @@ const emit = defineEmits<{
   'close-drawer': [];
 }>();
 
-const route = useRoute();
 const router = useRouter();
 const improvementsStore = useImprovementsStore();
 const supervisorStore = useSupervisorStore();
@@ -110,12 +110,14 @@ function handlePageUpdate(newPage: number) {
 }
 
 async function handleViewFullConversation(conversation: AffectedConversation) {
-  supervisorStore.selectedConversation = {
+  const selectedConversation: SelectedConversation = {
     uuid: conversation.uuid,
     urn: conversation.contactUrn,
     username: conversation.contactName,
     data: { status: null },
   };
+
+  supervisorStore.selectedConversation = selectedConversation;
 
   emit('close-drawer');
 

--- a/src/components/ConversationsImprovements/DrawerDetails/__tests__/AffectedConversationsSection.spec.js
+++ b/src/components/ConversationsImprovements/DrawerDetails/__tests__/AffectedConversationsSection.spec.js
@@ -225,7 +225,6 @@ describe('AffectedConversationsSection.vue', () => {
       uuid: 'conversation-uuid-1',
       urn: 'whatsapp:5511999999999',
       username: 'Alessandra',
-      source: 'v2',
       data: { status: null },
     });
     expect(supervisorStore.queryConversationUuid).toBe('conversation-uuid-1');

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -509,8 +509,6 @@
       "hide_logs": "Hide logs",
       "search": "Search",
       "conversations_empty": "No conversations found",
-      "conversations_separator": "Conversations below were classified using the legacy system",
-      "conversations_v2_disclaimer": "Starting on March {day}, conversations are organized into 24-hour windows (resetting at midnight) powered by our new classification system",
       "no_messages_found": {
         "title": "No messages found in this conversation",
         "description": "If the message was sent by human support or triggered an automatic action, you can find it in {studio_link}.",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -509,8 +509,6 @@
       "hide_logs": "Ocultar logs",
       "search": "Buscar",
       "conversations_empty": "No se encontraron conversaciones",
-      "conversations_separator": "Las conversaciones a continuación se clasificaron utilizando el sistema heredado",
-      "conversations_v2_disclaimer": "Comenzando el {day} de marzo, las conversas se organizan en ventanas de 24 horas (reseteando a medianoche) usando nuestro nuevo sistema de clasificación",
       "no_messages_found": {
         "title": "No se encontraron mensajes en esta conversación",
         "description": "Si el soporte humano envió el mensaje o activó una acción automática, lo puedes ver en {studio_link}.",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -509,8 +509,6 @@
       "hide_logs": "Ocultar logs",
       "search": "Buscar",
       "conversations_empty": "Nenhuma conversa encontrada",
-      "conversations_separator": "As conversas abaixo foram classificadas usando o sistema legado",
-      "conversations_v2_disclaimer": "Começando em {day} de março, as conversas são organizadas em janelas de 24 horas (resetando à meia-noite) usando nosso novo sistema de classificação",
       "no_messages_found": {
         "title": "Nenhuma mensagem encontrada nesta conversa",
         "description": "Se a mensagem foi enviada pelo suporte humano ou ativou uma ação automática, você pode encontrá-la no {studio_link}.",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -508,8 +508,6 @@
       "hide_logs": "Ascunde jurnalele",
       "search": "Căutare",
       "conversations_empty": "Nu s-au găsit conversații",
-      "conversations_separator": "Conversațiile de mai jos au fost clasificate folosind sistemul anterior",
-      "conversations_v2_disclaimer": "Începând cu {day} martie, conversațiile sunt organizate în ferestre de 24 de ore (cu resetare la miezul nopții) folosind noul nostru sistem de clasificare",
       "no_messages_found": {
         "title": "Nu s-au găsit mesaje în această conversație",
         "description": "Dacă mesajul a fost trimis de asistența umană sau a declanșat o acțiune automată, îl poți găsi în {studio_link}.",

--- a/src/store/Supervisor.js
+++ b/src/store/Supervisor.js
@@ -7,11 +7,7 @@ import { useProjectStore } from './Project';
 
 import nexusaiAPI from '@/api/nexusaiAPI';
 
-import {
-  getPaginationPayload,
-  getPaginationStateFromResponse,
-  normalizeConversationsBySource,
-} from '@/api/adapters/supervisor/conversationSources';
+import { getPaginationPayload } from '@/api/adapters/supervisor/conversationSources';
 
 import i18n from '@/utils/plugins/i18n';
 
@@ -29,9 +25,6 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
     data: {
       results: [],
       next: null,
-      newNext: null,
-      legacyNext: null,
-      legacyInitialAttempted: false,
     },
   });
 
@@ -114,9 +107,6 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
     if (page === 1) {
       conversations.data.results = [];
       conversations.data.next = null;
-      conversations.data.newNext = null;
-      conversations.data.legacyNext = null;
-      conversations.data.legacyInitialAttempted = false;
     }
 
     const formatDateParam = (date) =>
@@ -132,21 +122,15 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
       topics: filters.topics,
     };
 
-    const paginationPayload = getPaginationPayload(
-      page,
-      conversations.data,
-      conversations.data.results,
-    );
+    const pagination = getPaginationPayload(page, conversations.data);
 
     try {
-      const currentConversationsData = { ...conversations.data };
       const requestPayload = {
         projectUuid: projectUuid.value,
         signal: conversationsAbortController.signal,
         hideGenericErrorAlert: true,
-        filters: paginationPayload ? { ...baseFilters, page: 1 } : baseFilters,
-        pagination: paginationPayload?.pagination,
-        onlyLegacy: paginationPayload?.onlyLegacy,
+        filters: pagination ? { ...baseFilters, page: 1 } : baseFilters,
+        pagination,
       };
 
       const response = await supervisorApi.conversations.list(requestPayload);
@@ -158,32 +142,15 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
         : [];
 
       const mergedResults = [...conversations.data.results, ...responseResults];
-      const normalizedResults = normalizeConversationsBySource(mergedResults);
-      const count = responseData?.count ?? normalizedResults.length;
+      const count = responseData?.count ?? mergedResults.length;
 
       conversations.status = 'complete';
       conversations.data = {
         ...responseData,
         count,
-        results: normalizedResults,
-        legacyInitialAttempted:
-          responseData.legacyInitialAttempted ||
-          currentConversationsData.legacyInitialAttempted,
+        results: mergedResults,
+        next: responseData.next ?? null,
       };
-
-      const paginationState = getPaginationStateFromResponse(
-        responseData,
-        currentConversationsData,
-      );
-      if (paginationState) {
-        conversations.data.next = paginationState.next;
-        conversations.data.newNext = paginationState.newNext;
-        conversations.data.legacyNext = paginationState.legacyNext;
-      }
-
-      if (paginationPayload?.onlyLegacy) {
-        conversations.data.legacyInitialAttempted = true;
-      }
     } catch (error) {
       if (error.code === 'ERR_CANCELED') return;
 
@@ -210,10 +177,6 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
 
       const params = {
         projectUuid: projectUuid.value,
-        start: selectedConversation.value.start,
-        end: selectedConversation.value.end,
-        urn: selectedConversation.value.urn,
-        source: selectedConversation.value.source,
         uuid: selectedConversation.value.uuid,
         next: next ? selectedConversation.value.data.next : null,
       };

--- a/src/store/__tests__/Supervisor.unit.spec.js
+++ b/src/store/__tests__/Supervisor.unit.spec.js
@@ -69,9 +69,6 @@ describe('Supervisor Store', () => {
         data: {
           results: [],
           next: null,
-          newNext: null,
-          legacyNext: null,
-          legacyInitialAttempted: false,
         },
       });
     });
@@ -138,14 +135,15 @@ describe('Supervisor Store', () => {
             csat: [],
             topics: [],
           },
+          pagination: null,
         });
 
         expect(store.conversations.status).toBe('complete');
         expect(store.conversations.data).toEqual({
           ...mockApiResponse,
           count: 2,
-          legacyInitialAttempted: false,
           results: mockApiResponse.results,
+          next: null,
         });
       });
 
@@ -176,6 +174,7 @@ describe('Supervisor Store', () => {
             csat: [],
             topics: [],
           },
+          pagination: null,
         });
       });
 
@@ -206,6 +205,7 @@ describe('Supervisor Store', () => {
             csat: 'test csat',
             topics: 'test topics',
           },
+          pagination: null,
         });
       });
 
@@ -220,9 +220,6 @@ describe('Supervisor Store', () => {
         expect(store.conversations.data).toEqual({
           results: [],
           next: null,
-          newNext: null,
-          legacyNext: null,
-          legacyInitialAttempted: false,
         });
       });
     });
@@ -277,6 +274,7 @@ describe('Supervisor Store', () => {
       beforeEach(() => {
         store.selectedConversation = {
           id: 1,
+          uuid: 'conversation-uuid-1',
           created_on: '2023-01-01',
           urn: 'urn:test',
           start: '2023-01-01',
@@ -338,9 +336,7 @@ describe('Supervisor Store', () => {
           nexusaiAPI.agent_builder.supervisor.conversations.getById,
         ).toHaveBeenCalledWith({
           projectUuid: 'test-project-uuid',
-          start: '2023-01-01',
-          end: '2023-01-31',
-          urn: 'urn:test',
+          uuid: 'conversation-uuid-1',
           next: null,
         });
 
@@ -376,9 +372,7 @@ describe('Supervisor Store', () => {
           nexusaiAPI.agent_builder.supervisor.conversations.getById,
         ).toHaveBeenCalledWith({
           projectUuid: 'test-project-uuid',
-          start: '2023-01-01',
-          end: '2023-01-31',
-          urn: 'urn:test',
+          uuid: 'conversation-uuid-1',
           next: 'existing-token',
         });
 
@@ -544,6 +538,7 @@ describe('Supervisor Store', () => {
           csat: [],
           topics: [],
         },
+        pagination: null,
       });
     });
   });

--- a/src/store/types/Conversations.types.ts
+++ b/src/store/types/Conversations.types.ts
@@ -14,5 +14,4 @@ export interface Conversation {
   status: string;
   csat: Csat | null;
   topics: string;
-  source?: 'legacy' | 'v2';
 }

--- a/src/store/types/Conversations.types.ts
+++ b/src/store/types/Conversations.types.ts
@@ -15,3 +15,15 @@ export interface Conversation {
   csat: Csat | null;
   topics: string;
 }
+
+export interface SelectedConversationData {
+  status: 'loading' | 'complete' | 'error' | null;
+  results?: unknown[];
+  next?: string | null;
+  count?: number;
+}
+
+export type SelectedConversation = Partial<Conversation> & {
+  uuid: string;
+  data: SelectedConversationData;
+};

--- a/src/views/Supervisor/SupervisorConversations/ConversationsTable/__tests__/index.spec.js
+++ b/src/views/Supervisor/SupervisorConversations/ConversationsTable/__tests__/index.spec.js
@@ -6,7 +6,6 @@ import { nextTick } from 'vue';
 
 import ConversationsTable from '../index.vue';
 import ConversationRow from '../ConversationRow.vue';
-import { NEW_SOURCE } from '@/api/adapters/supervisor/conversationSources';
 
 vi.mock('@/api/nexusaiAPI', () => ({
   default: {
@@ -50,20 +49,18 @@ vi.mock('vue-router', () => ({
   }),
 }));
 
-const mockResultsWithSource = [
+const mockResults = [
   {
     uuid: '1',
     urn: 'conversation-123',
     last_message: 'This is the last message',
     start: '2023-05-15T14:30:00Z',
-    source: NEW_SOURCE,
   },
   {
     uuid: '2',
     urn: 'conversation-456',
     last_message: 'Another message',
     start: '2023-05-16T10:00:00Z',
-    source: NEW_SOURCE,
   },
 ];
 
@@ -78,8 +75,7 @@ describe('ConversationsTable.vue', () => {
   const setConversations = (results, status = 'complete') => {
     supervisorStore.conversations.data.results = [...results];
     supervisorStore.conversations.data.count = results.length;
-    supervisorStore.conversations.data.newNext = null;
-    supervisorStore.conversations.data.legacyNext = null;
+    supervisorStore.conversations.data.next = null;
     supervisorStore.conversations.status = status;
   };
 
@@ -87,7 +83,7 @@ describe('ConversationsTable.vue', () => {
     supervisorStore = useSupervisorStore();
     supervisorStore.filters.start = '2023-01-01';
     supervisorStore.filters.end = '2023-01-31';
-    setConversations(mockResultsWithSource, conversationsStatus);
+    setConversations(mockResults, conversationsStatus);
 
     wrapper = mount(ConversationsTable, {
       global: {
@@ -96,7 +92,7 @@ describe('ConversationsTable.vue', () => {
     });
 
     await flushPromises();
-    setConversations(mockResultsWithSource);
+    setConversations(mockResults);
     await nextTick();
   };
 

--- a/src/views/Supervisor/index.vue
+++ b/src/views/Supervisor/index.vue
@@ -87,7 +87,6 @@ function hasMoreConversationsToLoad() {
   return hasMoreToLoad(
     supervisorStore.conversations.data,
     supervisorStore.conversations.status,
-    supervisorStore.conversations.data.results,
   );
 }
 


### PR DESCRIPTION
## Description
### Type of Change
* * [ ] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [x] Refactoring (no functional changes, no api changes)
* * [ ] Tests
* * [ ] Other

### Motivation and Context
The legacy conversation endpoint and the dual-source (legacy/v2) pagination logic are no longer needed. All conversations now come exclusively from the v2 endpoint, so the compatibility layer that handled both sources, date-based switching, and combined pagination can be removed.

### Summary of Changes
- Removed the `ApiDataLegacy` and `ApiDataV2` interfaces in the conversation adapter, replacing them with a single `ApiConversation` and `ApiData` interface. The `fromApi` method now maps only v2 fields (`contact_name`, `contact_urn`, `uuid`), dropping legacy fallbacks like `external_id`, `name`, and `urn`.
- Extracted `STATUS_BY_RESOLUTION`, `CSAT_BY_SCORE`, `RESOLUTION_BY_STATUS`, and `SCORE_BY_CSAT` as module-level constants instead of inline objects recreated on every call.
- Removed `ConversationMessageAdapter.toApiLegacy` and the legacy `ConversationMessagesResponseLegacy` interface. `fromApi` now reads exclusively from `apiData.messages`.
- Removed all legacy/combined-mode logic from `conversationSources.js`: `parseDateParam`, `formatDateParam`, `getConversationMode`, `addSourceToResults`, `normalizeConversationsBySource`, `needsLegacyInitialLoad`, `getPaginationKey`, `getPaginationStateFromResponse`, `isValidPaginationPayload`, `getLegacyEndDate`, `CONVERSATIONS_SWITCH_DATE`, `LEGACY_SOURCE`, `NEW_SOURCE`, and the `fetchConversations`/`fetchByNextUrl` helpers. `fetchConversationList` now makes a single request to the v2 endpoint, with simple next-page URL support.
- `getPaginationPayload` and `hasMoreToLoad` are simplified to work with a single `next` field instead of `newNext`/`legacyNext`.
- The Supervisor store no longer tracks `newNext`, `legacyNext`, or `legacyInitialAttempted`. `loadConversations` passes a flat `pagination` object and merges results without source-based sorting.
- `Supervisor.conversations.getById` no longer accepts `start`, `end`, `urn`, or `source` parameters and always calls the v2 endpoint.
- The `source` field is removed from the `Conversation` type. A new `SelectedConversation` type and `SelectedConversationData` interface are introduced in `Conversations.types.ts`.
- Removed the `conversations_separator` and `conversations_v2_disclaimer` locale keys from all language files.
- Updated all related tests to reflect the removal of legacy parameters and source-tagged results.