### PR TITLE
fix: Inconsistent CI break in PreviewLogs

### DIFF
--- a/src/components/Preview/PreviewLogs.vue
+++ b/src/components/Preview/PreviewLogs.vue
@@ -93,7 +93,14 @@
 </template>
 
 <script setup>
-import { ref, onMounted, nextTick, computed, watch } from 'vue';
+import {
+  ref,
+  onMounted,
+  onBeforeUnmount,
+  nextTick,
+  computed,
+  watch,
+} from 'vue';
 
 import PreviewLogsDetailsModal from './PreviewLogsDetailsModal.vue';
 
@@ -113,11 +120,13 @@ const props = defineProps({
   },
 });
 
+const logList = ref(null);
 const showDetailsModal = ref(false);
 const selectedLog = ref({
   summary: '',
   log: '',
 });
+const progressBarTimeoutIds = new Set();
 
 const processedLogs = computed(() => {
   return props.logs.reduce((logsByAgent, log) => {
@@ -179,6 +188,11 @@ onMounted(() => {
   });
 });
 
+onBeforeUnmount(() => {
+  progressBarTimeoutIds.forEach(clearTimeout);
+  progressBarTimeoutIds.clear();
+});
+
 function openModalLogFullDetails(summary, log) {
   selectedLog.value = { summary, log };
   showDetailsModal.value = true;
@@ -187,16 +201,18 @@ function openModalLogFullDetails(summary, log) {
 const logTranslateY = 24;
 
 function updateProgressBarHeight(type = 'agent') {
-  setTimeout(() => {
+  const timeoutId = setTimeout(() => {
+    progressBarTimeoutIds.delete(timeoutId);
+
     if (!['mount', 'agent', 'step'].includes(type)) {
       throw new Error('Invalid type passed to updateProgressHeight function');
     }
 
-    const logList = document.querySelector('.preview-logs');
-    if (!logList) return;
+    const logListEl = logList.value;
+    if (!logListEl) return;
 
-    const firstLog = logList.querySelector('.log__agent-name:first-child');
-    const lastLog = logList.querySelector(
+    const firstLog = logListEl.querySelector('.log__agent-name:first-child');
+    const lastLog = logListEl.querySelector(
       '.logs__log:last-child .steps__step:last-child p',
     );
 
@@ -214,6 +230,8 @@ function updateProgressBarHeight(type = 'agent') {
 
     emit('scroll-to-bottom');
   }, 200);
+
+  progressBarTimeoutIds.add(timeoutId);
 }
 
 watch(

--- a/src/components/Preview/__tests__/PreviewLogs.spec.js
+++ b/src/components/Preview/__tests__/PreviewLogs.spec.js
@@ -88,8 +88,9 @@ describe('PreviewLogs.vue', () => {
   });
 
   afterEach(() => {
-    wrapper.unmount();
+    wrapper?.unmount();
     vi.clearAllMocks();
+    vi.useRealTimers();
   });
 
   describe('Component rendering', () => {
@@ -134,6 +135,9 @@ describe('PreviewLogs.vue', () => {
 
       expect(leftWrapper.props('logsSide')).toBe('left');
       expect(rightWrapper.props('logsSide')).toBe('right');
+
+      leftWrapper.unmount();
+      rightWrapper.unmount();
     });
 
     it('applies correct CSS classes based on logsSide prop', async () => {


### PR DESCRIPTION
## Description
### Type of Change
* * [x] Bugfix
* * [ ] Feature
* * [ ] Code style update (formatting, local variables)
* * [ ] Refactoring (no functional changes, no api changes)
* * [x] Tests
* * [ ] Other

### Motivation and Context
Pending `setTimeout` calls in `PreviewLogs` could execute after the component was unmounted, potentially causing errors by attempting to access DOM elements that no longer exist.

### Summary of Changes
- Replaced the direct `document.querySelector('.preview-logs')` call with a template ref (`logList`) to safely access the log list element.
- Introduced a `progressBarTimeoutIds` Set to track active `setTimeout` IDs created by `updateProgressBarHeight`.
- Added an `onBeforeUnmount` hook that clears all pending timeouts and empties the Set when the component is destroyed, preventing post-unmount execution.
- Updated tests to use optional chaining on `wrapper?.unmount()`, restore real timers with `vi.useRealTimers()` in `afterEach`, and explicitly unmount wrappers created within individual test cases to avoid state leakage.