### PR TITLE
feat: Enhance category validation by adding default instructions key and corresponding tests

### DIFF
--- a/src/components/Instructions/NewInstructionDrawer/IssuesFound.vue
+++ b/src/components/Instructions/NewInstructionDrawer/IssuesFound.vue
@@ -30,7 +30,7 @@ const classification = computed<{
       `agents.instructions.new_instruction_drawer.ai_analysis.issues_types.${key}`,
     );
 
-  const titleMappings = {
+  const titleMappings: Partial<Record<Classification['name'], string>> = {
     duplicate: getTranslation('duplicate'),
     conflicting: getTranslation('conflicts'),
     ambiguity: getTranslation('ambiguity'),
@@ -43,13 +43,13 @@ const classification = computed<{
     const resultList = results.map((result: Classification) => ({
       ...result,
       type: 'attention' as const,
-      name: titleMappings[result.name] || result.reason,
+      name: titleMappings[result.name] || '',
     }));
 
     return {
       type: 'attention' as const,
       name: formatListToReadable(
-        resultList.map((result: Classification) => result.name),
+        resultList.map((result) => result.name).filter(Boolean),
       ),
       reason: resultList[0].reason,
     };

--- a/src/components/Instructions/NewInstructionDrawer/__tests__/useCategoryValidation.spec.ts
+++ b/src/components/Instructions/NewInstructionDrawer/__tests__/useCategoryValidation.spec.ts
@@ -124,6 +124,34 @@ describe('useCategoryValidation', () => {
     });
   });
 
+  it('blocks the fixed default instructions name in every locale', () => {
+    const reservedNames = i18n.global.availableLocales.map((locale) =>
+      String(
+        i18n.global.t(
+          'agents.instructions.view.default_instructions',
+          {},
+          { locale },
+        ),
+      ),
+    );
+
+    expect(reservedNames).toEqual(
+      expect.arrayContaining([
+        'Default instructions',
+        'Instruções padrão',
+        'Instrucciones predeterminadas',
+        'Instrucțiuni implicite',
+      ]),
+    );
+
+    reservedNames.forEach((reservedName) => {
+      const { validation } = setup(reservedName);
+
+      expect(validation.error.value).toBe(validationT('already_exists'));
+      expect(validation.isValid.value).toBe(false);
+    });
+  });
+
   it('reacts when the existing names list changes', () => {
     const { existing, validation } = setup('Sales', []);
 

--- a/src/components/Instructions/NewInstructionDrawer/useCategoryValidation.ts
+++ b/src/components/Instructions/NewInstructionDrawer/useCategoryValidation.ts
@@ -6,14 +6,18 @@ import i18n from '@/utils/plugins/i18n';
 
 const ALLOWED_CHARS = /^[\p{L}\p{N}\s-]+$/u;
 const UNCATEGORIZED_KEY = 'agents.instructions.view.uncategorized';
+const DEFAULT_INSTRUCTIONS_KEY =
+  'agents.instructions.view.default_instructions';
 
 function namesMatch(a: string, b: string) {
   return a.localeCompare(b, undefined, { sensitivity: 'base' }) === 0;
 }
 
 function getReservedCategoryNames(): string[] {
-  return i18n.global.availableLocales.map((locale) =>
-    String(i18n.global.t(UNCATEGORIZED_KEY, {}, { locale })),
+  const reservedKeys = [UNCATEGORIZED_KEY, DEFAULT_INSTRUCTIONS_KEY];
+
+  return i18n.global.availableLocales.flatMap((locale) =>
+    reservedKeys.map((key) => String(i18n.global.t(key, {}, { locale }))),
   );
 }
 


### PR DESCRIPTION
## Description

### Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Tests
- [ ] Other

### Motivation and Context

When the AI analysis returned an unrecognized classification name, the raw `result.reason` text was being used as the display label, which could expose unformatted or unexpected content to users. Additionally, the "Default instructions" category name was not treated as a reserved name, allowing users to create instruction categories with that name and potentially causing conflicts.

### Summary of Changes

- When an AI analysis classification name has no matching translation key, the label now falls back to an empty string and is filtered out, rather than displaying the raw `result.reason` value.
- Added a proper TypeScript type (`Partial<Record<Classification['name'], string>>`) to the `titleMappings` object to improve type safety.
- The "Default instructions" category name is now treated as a reserved name in `useCategoryValidation`, blocking users from creating a category with that name in any supported locale.
- Added a test to verify that the "Default instructions" reserved name is correctly blocked across all available locales (English, Spanish, Portuguese, Romanian).