### PR TITLE
fix: Tunings use backend error message only when local value is empty

### DIFF
--- a/src/components/AgentsTeam/MyAgents/EditManagerProfileDrawer.vue
+++ b/src/components/AgentsTeam/MyAgents/EditManagerProfileDrawer.vue
@@ -125,7 +125,9 @@ async function save() {
       hasError = true;
       let errorText = i18n.global.t('router.tunings.settings.save_error');
 
-      if (tuningsStore.lastErrorMessageSaveFailed) {
+      if (tuningsStore.lastSaveForbidden) {
+        errorText = i18n.global.t('unauthorized');
+      } else if (tuningsStore.lastErrorMessageSaveFailed) {
         errorText = i18n.global.t(
           'agent_builder.tunings.system_messages.error_message.save_error',
         );

--- a/src/components/AgentsTeam/MyAgents/__tests__/EditManagerProfileDrawer.spec.js
+++ b/src/components/AgentsTeam/MyAgents/__tests__/EditManagerProfileDrawer.spec.js
@@ -307,11 +307,38 @@ describe('EditManagerProfileDrawer.vue', () => {
       tuningsStore.settings.data = { ...defaultSettingsData, manager: 'other' };
       tuningsStore.saveSettings.mockResolvedValue(false);
       tuningsStore.lastErrorMessageSaveFailed = false;
+      tuningsStore.lastSaveForbidden = false;
       const alertSpy = vi.spyOn(alertStore, 'add');
 
       await wrapper.vm.save();
 
       expect(alertSpy).toHaveBeenCalledWith({
+        text: i18n.global.t('router.tunings.settings.save_error'),
+        type: 'error',
+      });
+      expect(wrapper.vm.modelValue).toBe(true);
+    });
+
+    it('shows unauthorized alert when settings save fails with 403', async () => {
+      profileStore.name.current = profileStore.name.old;
+      profileStore.role.current = profileStore.role.old;
+      profileStore.personality.current = profileStore.personality.old;
+      profileStore.goal.current = profileStore.goal.old;
+
+      tuningsStore.initialSettings = { ...defaultSettingsData };
+      tuningsStore.settings.data = { ...defaultSettingsData, manager: 'other' };
+      tuningsStore.saveSettings.mockResolvedValue(false);
+      tuningsStore.lastErrorMessageSaveFailed = false;
+      tuningsStore.lastSaveForbidden = true;
+      const alertSpy = vi.spyOn(alertStore, 'add');
+
+      await wrapper.vm.save();
+
+      expect(alertSpy).toHaveBeenCalledWith({
+        text: i18n.global.t('unauthorized'),
+        type: 'error',
+      });
+      expect(alertSpy).not.toHaveBeenCalledWith({
         text: i18n.global.t('router.tunings.settings.save_error'),
         type: 'error',
       });
@@ -331,6 +358,7 @@ describe('EditManagerProfileDrawer.vue', () => {
       };
       tuningsStore.saveSettings.mockResolvedValue(false);
       tuningsStore.lastErrorMessageSaveFailed = true;
+      tuningsStore.lastSaveForbidden = false;
       const alertSpy = vi.spyOn(alertStore, 'add');
 
       await wrapper.vm.save();

--- a/src/store/Tunings.js
+++ b/src/store/Tunings.js
@@ -33,6 +33,7 @@ export const useTuningsStore = defineStore('Tunings', () => {
 
   const initialSettings = ref(null);
   const lastErrorMessageSaveFailed = ref(false);
+  const lastSaveForbidden = ref(false);
   const settings = reactive({
     status: null,
     data: {
@@ -225,6 +226,7 @@ export const useTuningsStore = defineStore('Tunings', () => {
 
   async function saveSettings() {
     lastErrorMessageSaveFailed.value = false;
+    lastSaveForbidden.value = false;
 
     try {
       settings.status = 'loading';
@@ -277,8 +279,9 @@ export const useTuningsStore = defineStore('Tunings', () => {
         }
       }
 
+      const errorMessage = settings.data.errorMessage ?? '';
       const hasErrorMessageChanges =
-        initialSettings.value.errorMessage !== settings.data.errorMessage;
+        initialSettings.value.errorMessage !== errorMessage;
 
       if (hasErrorMessageChanges) {
         try {
@@ -286,30 +289,36 @@ export const useTuningsStore = defineStore('Tunings', () => {
             await nexusaiAPI.router.tunings.apiErrorMessage.edit({
               projectUuid: projectUuid.value,
               data: {
-                errorMessage: settings.data.errorMessage,
+                errorMessage,
               },
               requestOptions: {
                 hideGenericErrorAlert: true,
               },
             });
 
-          settings.data.errorMessage = savedErrorMessage ?? '';
-        } catch {
-          lastErrorMessageSaveFailed.value = true;
+          settings.data.errorMessage =
+            errorMessage === '' ? savedErrorMessage : errorMessage;
+        } catch (error) {
+          if (error?.response?.status === 403) {
+            lastSaveForbidden.value = true;
+          } else {
+            lastErrorMessageSaveFailed.value = true;
+          }
         }
       }
 
       const nextInitialSettings = cloneDeep(settings.data);
 
-      if (lastErrorMessageSaveFailed.value) {
+      if (lastErrorMessageSaveFailed.value || lastSaveForbidden.value) {
         nextInitialSettings.errorMessage = initialSettings.value.errorMessage;
       }
 
       initialSettings.value = nextInitialSettings;
       settings.status = 'success';
 
-      return !lastErrorMessageSaveFailed.value;
+      return !lastErrorMessageSaveFailed.value && !lastSaveForbidden.value;
     } catch (error) {
+      lastSaveForbidden.value = error?.response?.status === 403;
       settings.status = 'error';
       return false;
     }
@@ -353,7 +362,16 @@ export const useTuningsStore = defineStore('Tunings', () => {
       if (settings.status === 'error') {
         hasSettingsError = true;
         alertStore.add({
-          text: i18n.global.t('router.tunings.settings.save_error'),
+          text: i18n.global.t(
+            lastSaveForbidden.value
+              ? 'unauthorized'
+              : 'router.tunings.settings.save_error',
+          ),
+          type: 'error',
+        });
+      } else if (lastSaveForbidden.value) {
+        alertStore.add({
+          text: i18n.global.t('unauthorized'),
           type: 'error',
         });
       } else if (lastErrorMessageSaveFailed.value) {
@@ -369,7 +387,8 @@ export const useTuningsStore = defineStore('Tunings', () => {
     if (
       !hasCredentialsError &&
       !hasSettingsError &&
-      !lastErrorMessageSaveFailed.value
+      !lastErrorMessageSaveFailed.value &&
+      !lastSaveForbidden.value
     ) {
       alertStore.add({
         text: i18n.global.t('router.tunings.save_success'),
@@ -387,6 +406,7 @@ export const useTuningsStore = defineStore('Tunings', () => {
     initialCredentials,
     initialSettings,
     lastErrorMessageSaveFailed,
+    lastSaveForbidden,
     getCredentialIndex,
     updateCredential,
     fetchCredentials,

--- a/src/store/__tests__/Tunings.unit.spec.js
+++ b/src/store/__tests__/Tunings.unit.spec.js
@@ -509,6 +509,19 @@ describe('Tunings Store', () => {
         const result = await store.saveSettings();
 
         expect(store.settings.status).toBe('error');
+        expect(store.lastSaveForbidden).toBe(false);
+        expect(result).toBe(false);
+      });
+
+      it('should mark lastSaveForbidden when save settings fails with 403', async () => {
+        nexusaiAPI.router.tunings.editProgressiveFeedback.mockRejectedValue({
+          response: { status: 403 },
+        });
+
+        const result = await store.saveSettings();
+
+        expect(store.settings.status).toBe('error');
+        expect(store.lastSaveForbidden).toBe(true);
         expect(result).toBe(false);
       });
 
@@ -578,7 +591,7 @@ describe('Tunings Store', () => {
         expect(store.settings.data.errorMessage).toBe('Updated error message');
       });
 
-      it('should reset to default after clearing error message', async () => {
+      it('should use endpoint error message when local value is empty', async () => {
         store.settings.data = cloneDeep(store.initialSettings);
         store.initialSettings.errorMessage = 'Custom saved message';
         store.settings.data.errorMessage = '';
@@ -607,8 +620,29 @@ describe('Tunings Store', () => {
 
         expect(result).toBe(false);
         expect(store.lastErrorMessageSaveFailed).toBe(true);
+        expect(store.lastSaveForbidden).toBe(false);
         expect(store.settings.status).toBe('success');
         expect(store.initialSettings.components).toBe(true);
+        expect(store.initialSettings.errorMessage).toBe(
+          backendDefaultErrorMessage,
+        );
+      });
+
+      it('should mark lastSaveForbidden when error message save fails with 403', async () => {
+        store.settings.data.errorMessage = 'Updated error message';
+        nexusaiAPI.router.tunings.editProgressiveFeedback.mockResolvedValue();
+        nexusaiAPI.router.tunings.editComponents.mockResolvedValue();
+        nexusaiAPI.router.tunings.apiErrorMessage.edit.mockRejectedValue({
+          response: { status: 403 },
+        });
+        vi.spyOn(managerSelectorStore, 'saveManager').mockResolvedValue(true);
+
+        const result = await store.saveSettings();
+
+        expect(result).toBe(false);
+        expect(store.lastSaveForbidden).toBe(true);
+        expect(store.lastErrorMessageSaveFailed).toBe(false);
+        expect(store.settings.status).toBe('success');
         expect(store.initialSettings.errorMessage).toBe(
           backendDefaultErrorMessage,
         );
@@ -658,11 +692,13 @@ describe('Tunings Store', () => {
           components: true,
           progressiveFeedback: false,
           manager: 'manager-2.5',
+          errorMessage: backendDefaultErrorMessage,
         };
         store.initialSettings = {
           components: false,
           progressiveFeedback: false,
           manager: 'manager-2.5',
+          errorMessage: backendDefaultErrorMessage,
         };
         managerSelectorStore.options.currentManager = 'manager-2.5';
         managerSelectorStore.selectedManager = 'manager-2.5';
@@ -707,6 +743,28 @@ describe('Tunings Store', () => {
         await store.saveTunings();
 
         expect(alertStore.add).toHaveBeenCalledWith({
+          text: 'router.tunings.settings.save_error',
+          type: 'error',
+        });
+        expect(alertStore.add).not.toHaveBeenCalledWith({
+          text: 'router.tunings.save_success',
+          type: 'success',
+        });
+      });
+
+      it('should show unauthorized error for settings failure with 403', async () => {
+        nexusaiAPI.router.tunings.editCredentials.mockResolvedValue();
+        nexusaiAPI.router.tunings.editComponents.mockRejectedValue({
+          response: { status: 403 },
+        });
+
+        await store.saveTunings();
+
+        expect(alertStore.add).toHaveBeenCalledWith({
+          text: 'unauthorized',
+          type: 'error',
+        });
+        expect(alertStore.add).not.toHaveBeenCalledWith({
           text: 'router.tunings.settings.save_error',
           type: 'error',
         });


### PR DESCRIPTION
## Description

### Type of Change

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Tests
- [ ] Other

### Summary of Changes

After saving, the local `settings.data.errorMessage` is only replaced by the API's returned value (`savedErrorMessage`) when the submitted value was empty — otherwise, the locally submitted value is kept. The test description was also updated to better reflect the actual behavior being verified, and `errorMessage` was added to the relevant test fixtures to ensure consistent state.