### PR TITLE
feat: Add `isAmazing` filter and "new" badge to improvements tab

### DIFF
--- a/src/api/adapters/supervisor/conversation.ts
+++ b/src/api/adapters/supervisor/conversation.ts
@@ -48,6 +48,7 @@ interface FilterData {
   status: string[];
   csat: string[];
   topics: string[];
+  isAmazing?: boolean | null;
 }
 
 interface ApiParams {
@@ -58,6 +59,7 @@ interface ApiParams {
   resolution: number[];
   csat: number[];
   topics: string[];
+  is_amazing?: boolean;
 }
 
 export const ConversationAdapter = {
@@ -124,6 +126,7 @@ export const ConversationAdapter = {
       status = [],
       csat = [],
       topics = [],
+      isAmazing,
     } = filterData;
 
     const statusMap = {
@@ -156,6 +159,7 @@ export const ConversationAdapter = {
           csat: csat.map((csatItem) => csatMap[csatItem]),
         }),
       ...(isArray(topics) && topics.length > 0 && { topics }),
+      ...(isAmazing === true && { is_amazing: true }),
     };
 
     return params;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -534,6 +534,11 @@
         "filter_conversations_drawer": "Filter conversations",
         "apply_filters": "Apply filters",
         "clear_filters": "Clear filters",
+        "analysis": {
+          "all_conversations": "All conversations",
+          "amazing_conversations": "Amazing conversations",
+          "label": "Analysis"
+        },
         "period": {
           "label": "Period"
         },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -534,6 +534,11 @@
         "filter_conversations_drawer": "Filtrar conversaciones",
         "apply_filters": "Aplicar filtros",
         "clear_filters": "Limpiar filtros",
+        "analysis": {
+          "all_conversations": "Todas las conversaciones",
+          "amazing_conversations": "Conversaciones increíbles",
+          "label": "Análisis"
+        },
         "period": {
           "label": "Periodo"
         },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -534,6 +534,11 @@
         "filter_conversations_drawer": "Filtrar conversas",
         "apply_filters": "Aplicar filtros",
         "clear_filters": "Limpar filtros",
+        "analysis": {
+          "all_conversations": "Todas as conversas",
+          "amazing_conversations": "Conversas incríveis",
+          "label": "Análise"
+        },
         "period": {
           "label": "Período"
         },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -533,6 +533,11 @@
         "filter_conversations_drawer": "Filtrează conversațiile",
         "apply_filters": "Aplicare filtre",
         "clear_filters": "Elimină filtrele",
+        "analysis": {
+          "all_conversations": "Toate conversațiile",
+          "amazing_conversations": "Conversații extraordinare",
+          "label": "Analiză"
+        },
         "period": {
           "label": "Perioadă"
         },

--- a/src/store/Supervisor.js
+++ b/src/store/Supervisor.js
@@ -46,9 +46,14 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
     status: [],
     csat: [],
     topics: [],
+    isAmazing: null,
   };
 
   const parseArray = (value) => value?.split(',').filter(Boolean) || null;
+  const parseBoolean = (value) => {
+    if (value === 'true' || value === true) return true;
+    return null;
+  };
   const filters = reactive({
     start: query?.start ?? defaultFilters.start,
     end: query?.end ?? defaultFilters.end,
@@ -56,6 +61,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
     status: parseArray(query?.status) || defaultFilters.status,
     csat: parseArray(query?.csat) || defaultFilters.csat,
     topics: parseArray(query?.topics) || defaultFilters.topics,
+    isAmazing: parseBoolean(query?.isAmazing) ?? defaultFilters.isAmazing,
   });
 
   const temporaryFilters = reactive({
@@ -65,6 +71,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
     status: filters.status,
     csat: filters.csat,
     topics: filters.topics,
+    isAmazing: filters.isAmazing,
   });
 
   const topics = ref([]);
@@ -73,7 +80,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
   const queryConversationUuid = ref(query?.uuid || '');
 
   function resetFilters() {
-    const { start, end, status, csat, topics } = defaultFilters;
+    const { start, end, status, csat, topics, isAmazing } = defaultFilters;
 
     [filters, temporaryFilters].forEach((filter) => {
       filter.start = start;
@@ -81,6 +88,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
       filter.status = status;
       filter.csat = csat;
       filter.topics = topics;
+      filter.isAmazing = isAmazing;
     });
   }
 
@@ -91,6 +99,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
     filters.status = temporaryFilters.status;
     filters.csat = temporaryFilters.csat;
     filters.topics = temporaryFilters.topics;
+    filters.isAmazing = temporaryFilters.isAmazing;
   }
 
   function getInitialSelectFilter(filter, filterOptions) {
@@ -134,6 +143,7 @@ export const useSupervisorStore = defineStore('Supervisor', () => {
       status: filters.status,
       csat: filters.csat,
       topics: filters.topics,
+      isAmazing: filters.isAmazing,
     };
 
     const paginationPayload = getPaginationPayload(

--- a/src/store/__tests__/Supervisor.unit.spec.js
+++ b/src/store/__tests__/Supervisor.unit.spec.js
@@ -93,6 +93,7 @@ describe('Supervisor Store', () => {
         status: [],
         csat: [],
         topics: [],
+        isAmazing: null,
       });
     });
   });
@@ -137,6 +138,7 @@ describe('Supervisor Store', () => {
             status: [],
             csat: [],
             topics: [],
+            isAmazing: null,
           },
         });
 
@@ -175,6 +177,7 @@ describe('Supervisor Store', () => {
             status: [],
             csat: [],
             topics: [],
+            isAmazing: null,
           },
         });
       });
@@ -184,6 +187,7 @@ describe('Supervisor Store', () => {
         store.filters.status = 'test status';
         store.filters.csat = 'test csat';
         store.filters.topics = 'test topics';
+        store.filters.isAmazing = true;
 
         nexusaiAPI.agent_builder.supervisor.conversations.list.mockResolvedValue(
           [],
@@ -205,6 +209,7 @@ describe('Supervisor Store', () => {
             status: 'test status',
             csat: 'test csat',
             topics: 'test topics',
+            isAmazing: true,
           },
         });
       });
@@ -543,6 +548,7 @@ describe('Supervisor Store', () => {
           status: [],
           csat: [],
           topics: [],
+          isAmazing: null,
         },
       });
     });

--- a/src/views/Supervisor/SupervisorConversations/ConversationsTable/index.vue
+++ b/src/views/Supervisor/SupervisorConversations/ConversationsTable/index.vue
@@ -114,6 +114,7 @@ watch(
     () => supervisorStore.filters.status,
     () => supervisorStore.filters.csat,
     () => supervisorStore.filters.topics,
+    () => supervisorStore.filters.isAmazing,
   ],
   (newValue, oldValue) => {
     const isInitialRun =

--- a/src/views/Supervisor/SupervisorFilters/FilterAnalysis.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterAnalysis.vue
@@ -1,0 +1,40 @@
+<template>
+  <UnnnicFormElement :label="$t('audit.conversations.filters.analysis.label')">
+    <UnnnicSelect
+      v-model:modelValue="analysisFilter"
+      data-testid="analysis-select"
+      :options="analysisOptions"
+      :optionsLines="2"
+    />
+  </UnnnicFormElement>
+</template>
+
+<script setup>
+import { computed } from 'vue';
+import i18n from '@/utils/plugins/i18n';
+
+import { useSupervisorStore } from '@/store/Supervisor';
+
+const supervisorStore = useSupervisorStore();
+
+const getAnalysisTranslation = (filter) =>
+  i18n.global.t(`audit.conversations.filters.analysis.${filter}`);
+
+const analysisOptions = computed(() =>
+  ['all_conversations', 'amazing_conversations'].map((value) => ({
+    label: getAnalysisTranslation(value),
+    value,
+  })),
+);
+
+const analysisFilter = computed({
+  get: () =>
+    supervisorStore.temporaryFilters.isAmazing
+      ? 'amazing_conversations'
+      : 'all_conversations',
+  set: (selected) => {
+    supervisorStore.temporaryFilters.isAmazing =
+      selected === 'amazing_conversations' ? true : null;
+  },
+});
+</script>

--- a/src/views/Supervisor/SupervisorFilters/__tests__/FilterAnalysis.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/FilterAnalysis.spec.js
@@ -1,0 +1,122 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+import { nextTick } from 'vue';
+
+import FilterAnalysis from '../FilterAnalysis.vue';
+import { useSupervisorStore } from '@/store/Supervisor';
+import i18n from '@/utils/plugins/i18n';
+
+vi.mock('vue-router', () => ({
+  useRoute: vi.fn().mockReturnValue({
+    query: {},
+  }),
+}));
+
+describe('FilterAnalysis.vue', () => {
+  let wrapper;
+  let store;
+
+  const analysisSelect = () =>
+    wrapper.findComponent('[data-testid="analysis-select"]');
+
+  const createWrapper = (isAmazing = null) => {
+    const pinia = createTestingPinia({
+      initialState: {
+        Supervisor: {
+          temporaryFilters: {
+            isAmazing,
+          },
+        },
+      },
+    });
+
+    store = useSupervisorStore();
+
+    wrapper = mount(FilterAnalysis, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+  };
+
+  beforeEach(() => {
+    createWrapper();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Component rendering', () => {
+    it('renders the analysis select', () => {
+      expect(analysisSelect().exists()).toBe(true);
+    });
+
+    it('initializes with all conversations when isAmazing is null', () => {
+      expect(analysisSelect().props('modelValue')).toBe('all_conversations');
+    });
+
+    it('initializes with amazing conversations when isAmazing is true', () => {
+      wrapper.unmount();
+      createWrapper(true);
+
+      expect(analysisSelect().props('modelValue')).toBe(
+        'amazing_conversations',
+      );
+    });
+
+    it('provides correct analysis options', () => {
+      const options = analysisSelect().props('options');
+
+      expect(options).toStrictEqual([
+        {
+          label: i18n.global.t(
+            'audit.conversations.filters.analysis.all_conversations',
+          ),
+          value: 'all_conversations',
+        },
+        {
+          label: i18n.global.t(
+            'audit.conversations.filters.analysis.amazing_conversations',
+          ),
+          value: 'amazing_conversations',
+        },
+      ]);
+    });
+  });
+
+  describe('Analysis selection functionality', () => {
+    it('sets isAmazing to true when amazing conversations is selected', async () => {
+      await analysisSelect().vm.$emit(
+        'update:modelValue',
+        'amazing_conversations',
+      );
+      await nextTick();
+
+      expect(store.temporaryFilters.isAmazing).toBe(true);
+    });
+
+    it('sets isAmazing to null when all conversations is selected', async () => {
+      wrapper.unmount();
+      createWrapper(true);
+
+      await analysisSelect().vm.$emit('update:modelValue', 'all_conversations');
+      await nextTick();
+
+      expect(store.temporaryFilters.isAmazing).toBeNull();
+    });
+
+    it('follows the store when isAmazing is reset externally', async () => {
+      wrapper.unmount();
+      createWrapper(true);
+
+      store.temporaryFilters.isAmazing = null;
+      await nextTick();
+
+      expect(analysisSelect().props('modelValue')).toBe('all_conversations');
+      expect(store.temporaryFilters.isAmazing).toBeNull();
+    });
+  });
+});

--- a/src/views/Supervisor/SupervisorFilters/__tests__/SupervisorFilters.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/SupervisorFilters.spec.js
@@ -5,11 +5,13 @@ import { createTestingPinia } from '@pinia/testing';
 import SupervisorFilters from '../index.vue';
 import Unnnic from '@weni/unnnic-system';
 import { useSupervisorStore } from '@/store/Supervisor';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 import i18n from '@/utils/plugins/i18n';
 
 describe('SupervisorFilters.vue', () => {
   let wrapper;
   let store;
+  let featureFlagsStore;
 
   beforeEach(() => {
     const pinia = createTestingPinia({
@@ -22,6 +24,9 @@ describe('SupervisorFilters.vue', () => {
             type: '',
           },
         },
+        FeatureFlags: {
+          activeFeatures: [],
+        },
       },
     });
 
@@ -32,6 +37,7 @@ describe('SupervisorFilters.vue', () => {
     });
 
     store = useSupervisorStore();
+    featureFlagsStore = useFeatureFlagsStore();
   });
 
   const findComponent = (dataTestId) =>
@@ -43,6 +49,7 @@ describe('SupervisorFilters.vue', () => {
   const filterStatus = () => findComponent('filter-status');
   const filterCsat = () => findComponent('filter-csat');
   const filterTopics = () => findComponent('filter-topics');
+  const filterAnalysis = () => findComponent('filter-analysis');
 
   describe('Component rendering', () => {
     it('renders filter text', () => {
@@ -68,6 +75,17 @@ describe('SupervisorFilters.vue', () => {
       expect(filterStatus().exists()).toBe(true);
       expect(filterCsat().exists()).toBe(true);
       expect(filterTopics().exists()).toBe(true);
+    });
+
+    it('does not render analysis filter when conversationsImprovements is disabled', () => {
+      expect(filterAnalysis().exists()).toBe(false);
+    });
+
+    it('renders analysis filter when conversationsImprovements is enabled', async () => {
+      featureFlagsStore.activeFeatures = ['improvements'];
+      await wrapper.vm.$nextTick();
+
+      expect(filterAnalysis().exists()).toBe(true);
     });
   });
 
@@ -99,6 +117,18 @@ describe('SupervisorFilters.vue', () => {
       await wrapper.vm.$nextTick();
 
       expect(buttonFilter().props('text')).toContain(countTranslation(3));
+    });
+
+    it('includes isAmazing in the applied filters count', async () => {
+      const countTranslation = (count) =>
+        i18n.global.t('audit.conversations.filters.count_applied_filters', {
+          count,
+        });
+
+      store.filters.isAmazing = true;
+      await wrapper.vm.$nextTick();
+
+      expect(buttonFilter().props('text')).toContain(countTranslation(1));
     });
 
     beforeEach(() => {

--- a/src/views/Supervisor/SupervisorFilters/index.vue
+++ b/src/views/Supervisor/SupervisorFilters/index.vue
@@ -28,6 +28,10 @@
         <FilterStatus data-testid="filter-status" />
         <FilterCsat data-testid="filter-csat" />
         <FilterTopics data-testid="filter-topics" />
+        <FilterAnalysis
+          v-if="featureFlagsStore.flags.conversationsImprovements"
+          data-testid="filter-analysis"
+        />
       </template>
     </UnnnicDrawer>
   </section>
@@ -40,14 +44,17 @@ import { isEqual } from 'lodash';
 import i18n from '@/utils/plugins/i18n';
 
 import { useSupervisorStore } from '@/store/Supervisor';
+import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 
 import FilterText from './FilterText.vue';
 import FilterDate from './FilterDate.vue';
 import FilterStatus from './FilterStatus.vue';
 import FilterCsat from './FilterCsat.vue';
 import FilterTopics from './FilterTopics.vue';
+import FilterAnalysis from './FilterAnalysis.vue';
 
 const supervisorStore = useSupervisorStore();
+const featureFlagsStore = useFeatureFlagsStore();
 
 const isFilterDrawerOpen = ref(false);
 const filterDrawerApplyButtonDisabled = computed(() =>
@@ -61,9 +68,13 @@ const filterDrawerClearButtonDisabled = computed(() =>
 const countAppliedFilters = computed(() => {
   const filtersToCount = ['status', 'csat', 'topics'];
 
-  return filtersToCount.reduce((total, filter) => {
+  const arrayFiltersCount = filtersToCount.reduce((total, filter) => {
     return total + supervisorStore.filters[filter].length;
   }, 0);
+
+  const isAmazingCount = supervisorStore.filters.isAmazing ? 1 : 0;
+
+  return arrayFiltersCount + isAmazingCount;
 });
 
 const filterButtonText = computed(() => {

--- a/src/views/Supervisor/SupervisorHeader.vue
+++ b/src/views/Supervisor/SupervisorHeader.vue
@@ -53,6 +53,12 @@
           </UnnnicTabsTrigger>
           <UnnnicTabsTrigger value="improvements">
             {{ $t('audit.improvements.title') }}
+            <span
+              class="supervisor-header__improvements-new-badge"
+              data-testid="improvements-new-badge"
+            >
+              {{ $t('new') }}
+            </span>
           </UnnnicTabsTrigger>
         </UnnnicTabsList>
       </UnnnicTabs>
@@ -112,6 +118,15 @@ function openExportModal() {
     align-items: center;
     gap: $unnnic-space-2;
     justify-content: flex-end;
+  }
+
+  &__improvements-new-badge {
+    background-color: $unnnic-color-bg-accent-plain;
+    color: $unnnic-color-fg-accent;
+    padding: $unnnic-space-05 $unnnic-space-1;
+    border-radius: $unnnic-radius-1;
+
+    @include unnnic-font-caption-1;
   }
 }
 </style>

--- a/src/views/Supervisor/__tests__/SupervisorHeader.spec.js
+++ b/src/views/Supervisor/__tests__/SupervisorHeader.spec.js
@@ -39,6 +39,8 @@ describe('SupervisorHeader', () => {
   const findExportButton = () => wrapper.find('[data-testid="export-button"]');
   const findExportModal = () => wrapper.find('[data-testid="export-modal"]');
   const findTabs = () => wrapper.findComponent({ name: 'UnnnicTabs' });
+  const findImprovementsNewBadge = () =>
+    wrapper.find('[data-testid="improvements-new-badge"]');
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -78,6 +80,8 @@ describe('SupervisorHeader', () => {
     expect(findTabs().exists()).toBe(true);
     expect(wrapper.text()).toContain(t('audit.conversations.title'));
     expect(wrapper.text()).toContain(t('audit.improvements.title'));
+    expect(findImprovementsNewBadge().exists()).toBe(true);
+    expect(findImprovementsNewBadge().text()).toBe(t('new'));
   });
 
   it('should not render tabs when conversationsImprovements flag is disabled', async () => {
@@ -91,6 +95,7 @@ describe('SupervisorHeader', () => {
     });
 
     expect(findTabs().exists()).toBe(false);
+    expect(findImprovementsNewBadge().exists()).toBe(false);
   });
 
   it('should show header details only on conversations tab', async () => {


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

Adds the ability to filter conversations by "amazing" status in the Supervisor view, allowing users to narrow down conversations that have been flagged as amazing. Additionally, a "New" badge is added to the Improvements tab to highlight the feature's availability.

### Summary of Changes

- Added a new `FilterAnalysis` component that provides a dropdown to select between "All conversations" and "Amazing conversations", updating the `isAmazing` temporary filter in the Supervisor store accordingly.
- Integrated `FilterAnalysis` into the `SupervisorFilters` drawer and included `isAmazing` in the applied filters count.
- Extended the Supervisor store with `isAmazing` support: default value, parsing from query params, reset logic, and propagation through `applyFilters`.
- Updated the `ConversationAdapter` to pass `is_amazing: true` to the API when the filter is active.
- Added the `isAmazing` filter as a watcher trigger in `ConversationsTable` so the table reloads when the filter changes.
- Added a styled "New" badge next to the Improvements tab trigger in `SupervisorHeader`.
- Added locale strings for the analysis filter label and options in English, Spanish, Portuguese (BR), and Romanian.
- Added unit tests for `FilterAnalysis`, updated `SupervisorFilters` and `SupervisorHeader` specs, and updated `Supervisor` store tests to cover the new `isAmazing` filter behavior.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/8ec2f5b7-81c5-4ecc-b131-008179c45d2e.png)

![image.png](https://app.graphite.com/user-attachments/assets/86f8c8e4-02c5-4812-95a8-c15dd3d62d9b.png)

