### PR TITLE
feat: Enhance AgentsPreview and SettingsField components with tooltips and disabled states

### DIFF
--- a/src/components/Tunings/SettingsAgentsTeam/AgentsPreview.vue
+++ b/src/components/Tunings/SettingsAgentsTeam/AgentsPreview.vue
@@ -12,6 +12,7 @@
         v-model="tuningsStore.settings.data.components"
         data-testid="components"
         :disabled="isComponentsDisabled"
+        :tooltip="componentsTooltip"
         :textRight="
           $t(
             'router.tunings.settings.agents_preview.multiple_message_format.title',
@@ -29,6 +30,12 @@
         v-if="showProgressiveFeedback"
         v-model="tuningsStore.settings.data.progressiveFeedback"
         data-testid="progressive-feedback"
+        :disabled="isProgressiveFeedbackDisabled"
+        :tooltip="
+          $t(
+            'router.tunings.settings.agents_preview.agents_progressive_feedback.tooltip',
+          )
+        "
         :textRight="
           $t(
             'router.tunings.settings.agents_preview.agents_progressive_feedback.title',
@@ -48,6 +55,7 @@
 <script setup>
 import { computed, watch } from 'vue';
 import { storeToRefs } from 'pinia';
+import { useI18n } from 'vue-i18n';
 
 import { useTuningsStore } from '@/store/Tunings';
 import { useProjectStore } from '@/store/Project';
@@ -56,6 +64,7 @@ import { useEngineSourceStore } from '@/store/EngineSource';
 
 import SettingsField from './SettingsField.vue';
 
+const { t } = useI18n();
 const tuningsStore = useTuningsStore();
 const projectStore = useProjectStore();
 const managerSelectorStore = useManagerSelectorStore();
@@ -75,7 +84,15 @@ const showProgressiveFeedback = computed(() => {
   return !useProjectStore().details?.backend?.toLowerCase().includes('openai');
 });
 
+const isProgressiveFeedbackDisabled = computed(() => {
+  return tuningsStore.settings.data.components === true;
+});
+
 const isComponentsDisabled = computed(() => {
+  if (tuningsStore.settings.data.progressiveFeedback) {
+    return true;
+  }
+
   if (engineSourceStore.engineType === 'custom') {
     return !engineSourceStore.selectedProviderAcceptsComponents;
   }
@@ -87,9 +104,25 @@ const isComponentsDisabled = computed(() => {
   );
 });
 
+const componentsTooltip = computed(() => {
+  if (!tuningsStore.settings.data.progressiveFeedback) {
+    return '';
+  }
+
+  return t(
+    'router.tunings.settings.agents_preview.multiple_message_format.tooltip',
+  );
+});
+
 watch(isComponentsDisabled, (disabled) => {
   if (disabled) {
     tuningsStore.settings.data.components = false;
+  }
+});
+
+watch(isProgressiveFeedbackDisabled, (disabled) => {
+  if (disabled) {
+    tuningsStore.settings.data.progressiveFeedback = false;
   }
 });
 </script>

--- a/src/components/Tunings/SettingsAgentsTeam/SettingsField.vue
+++ b/src/components/Tunings/SettingsAgentsTeam/SettingsField.vue
@@ -12,13 +12,25 @@
     class="form__field"
     data-testid="field"
   >
-    <UnnnicSwitch
-      data-testid="switch"
-      :disabled="disabled"
-      :modelValue="modelValue"
-      :textRight="textRight"
-      @update:model-value="emit('update:modelValue', $event)"
-    />
+    <UnnnicToolTip
+      side="top"
+      maxWidth="240px"
+      :text="tooltip"
+      :contentProps="{
+        align: 'start',
+        side: 'left',
+      }"
+      :enabled="Boolean(tooltip) && disabled"
+      data-testid="tooltip"
+    >
+      <UnnnicSwitch
+        data-testid="switch"
+        :disabled="disabled"
+        :modelValue="modelValue"
+        :textRight="textRight"
+        @update:model-value="emit('update:modelValue', $event)"
+      />
+    </UnnnicToolTip>
 
     <UnnnicIntelligenceText
       data-testid="description"
@@ -56,6 +68,10 @@ defineProps({
   disabled: {
     type: Boolean,
     default: false,
+  },
+  tooltip: {
+    type: String,
+    default: '',
   },
 });
 </script>

--- a/src/components/Tunings/SettingsAgentsTeam/__tests__/AgentsPreview.spec.js
+++ b/src/components/Tunings/SettingsAgentsTeam/__tests__/AgentsPreview.spec.js
@@ -92,6 +92,12 @@ describe('AgentsPreview.vue', () => {
       const field = progressiveFeedbackField();
 
       expect(field.props('modelValue')).toBe(false);
+      expect(field.props('disabled')).toBe(true);
+      expect(field.props('tooltip')).toBe(
+        i18n.global.t(
+          'router.tunings.settings.agents_preview.agents_progressive_feedback.tooltip',
+        ),
+      );
       expect(field.props('textRight')).toBe(
         i18n.global.t(
           'router.tunings.settings.agents_preview.agents_progressive_feedback.title',
@@ -133,6 +139,9 @@ describe('AgentsPreview.vue', () => {
 
   describe('Store integration', () => {
     it('updates store when progressive feedback field changes', async () => {
+      store.settings.data.components = false;
+      await nextTick();
+
       const field = progressiveFeedbackField();
 
       await field.vm.$emit('update:modelValue', true);
@@ -163,6 +172,9 @@ describe('AgentsPreview.vue', () => {
 
   describe('Form interactions', () => {
     it('handles multiple field updates correctly', async () => {
+      store.settings.data.components = false;
+      await nextTick();
+
       const progressiveField = progressiveFeedbackField();
       const messageFormatField = multipleMessageFormatField();
 
@@ -173,20 +185,63 @@ describe('AgentsPreview.vue', () => {
       expect(store.settings.data.components).toBe(false);
     });
 
-    it('maintains independent field states', async () => {
-      await progressiveFeedbackField().vm.$emit('update:modelValue', true);
+    it('disables progressive feedback when multiple message format is enabled', async () => {
+      store.settings.data.components = true;
+      await nextTick();
 
-      expect(store.settings.data.progressiveFeedback).toBe(true);
-      expect(store.settings.data.components).toBe(true);
+      expect(progressiveFeedbackField().props('disabled')).toBe(true);
+      expect(progressiveFeedbackField().props('tooltip')).toBe(
+        i18n.global.t(
+          'router.tunings.settings.agents_preview.agents_progressive_feedback.tooltip',
+        ),
+      );
+    });
+
+    it('disables multiple message format when progressive feedback is enabled', async () => {
+      store.settings.data.components = false;
+      store.settings.data.progressiveFeedback = true;
+      await nextTick();
+
+      expect(multipleMessageFormatField().props('disabled')).toBe(true);
+      expect(multipleMessageFormatField().props('tooltip')).toBe(
+        i18n.global.t(
+          'router.tunings.settings.agents_preview.multiple_message_format.tooltip',
+        ),
+      );
+    });
+
+    it('turns off progressive feedback when multiple message format is enabled', async () => {
+      store.settings.data.components = false;
+      store.settings.data.progressiveFeedback = true;
+      await nextTick();
+
+      store.settings.data.components = true;
+      await nextTick();
+
+      expect(store.settings.data.progressiveFeedback).toBe(false);
+    });
+
+    it('turns off multiple message format when progressive feedback is enabled', async () => {
+      store.settings.data.components = true;
+      store.settings.data.progressiveFeedback = false;
+      await nextTick();
+
+      store.settings.data.progressiveFeedback = true;
+      await nextTick();
+
+      expect(store.settings.data.components).toBe(false);
     });
   });
 
   describe('Store reactivity', () => {
     it('responds to external store changes', async () => {
+      store.settings.data.components = false;
+      await nextTick();
+
       expect(progressiveFeedbackField().props('modelValue')).toBe(false);
 
       store.settings.data.progressiveFeedback = true;
-      await wrapper.vm.$nextTick();
+      await nextTick();
 
       expect(progressiveFeedbackField().props('modelValue')).toBe(true);
     });

--- a/src/components/Tunings/SettingsAgentsTeam/__tests__/SettingsField.spec.js
+++ b/src/components/Tunings/SettingsAgentsTeam/__tests__/SettingsField.spec.js
@@ -1,4 +1,4 @@
-import { shallowMount } from '@vue/test-utils';
+import { mount } from '@vue/test-utils';
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 import SettingsField from '../SettingsField.vue';
@@ -11,6 +11,8 @@ describe('SettingsField.vue', () => {
   const descriptionText = () =>
     wrapper.findComponent('[data-testid="description"]');
   const fieldContainer = () => wrapper.find('[data-testid="field"]');
+  const tooltipComponent = () =>
+    wrapper.findComponent({ name: 'UnnnicTooltip' });
 
   const defaultProps = {
     modelValue: false,
@@ -19,11 +21,21 @@ describe('SettingsField.vue', () => {
   };
 
   beforeEach(() => {
-    wrapper = shallowMount(SettingsField, {
+    wrapper = mount(SettingsField, {
       props: defaultProps,
       global: {
         stubs: {
           UnnnicIntelligenceText: Text,
+          UnnnicTooltip: {
+            name: 'UnnnicTooltip',
+            props: ['text', 'enabled', 'side', 'maxWidth'],
+            template: '<div data-testid="tooltip"><slot /></div>',
+          },
+          UnnnicToolTip: {
+            name: 'UnnnicTooltip',
+            props: ['text', 'enabled', 'side', 'maxWidth'],
+            template: '<div data-testid="tooltip"><slot /></div>',
+          },
         },
       },
     });
@@ -129,7 +141,7 @@ describe('SettingsField.vue', () => {
   });
 
   describe('Component integration', () => {
-    it('maintains proper component structure and hierarchy', () => {
+    it('renders switch and description inside the field', () => {
       const container = fieldContainer();
       const switchComp = switchComponent();
       const descriptionComp = descriptionText();
@@ -137,18 +149,24 @@ describe('SettingsField.vue', () => {
       expect(container.exists()).toBe(true);
       expect(switchComp.exists()).toBe(true);
       expect(descriptionComp.exists()).toBe(true);
-
       expect(container.element.contains(switchComp.element)).toBe(true);
       expect(container.element.contains(descriptionComp.element)).toBe(true);
     });
 
-    it('renders all components in the correct order', () => {
-      const container = fieldContainer();
-      const children = container.element.children;
+    it('passes tooltip props to UnnnicTooltip when disabled', async () => {
+      const tooltip = tooltipComponent();
 
-      expect(children).toHaveLength(2);
-      expect(children[0].tagName.toLowerCase()).toBe('unnnic-switch-stub');
-      expect(children[1].tagName.toLowerCase()).toBe('p');
+      expect(tooltip.exists()).toBe(true);
+      expect(tooltip.props('text')).toBe('');
+      expect(tooltip.props('enabled')).toBe(false);
+
+      await wrapper.setProps({
+        disabled: true,
+        tooltip: 'Feature unavailable',
+      });
+
+      expect(tooltip.props('text')).toBe('Feature unavailable');
+      expect(tooltip.props('enabled')).toBe(true);
     });
   });
 });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -852,12 +852,14 @@
         "agents_preview": {
           "title": "Agent preview",
           "agents_progressive_feedback": {
+            "description": "The agent can provide brief updates while formulating the final response, helping the contact follow the process in real time.",
             "title": "Agent progressive feedback (only available for Shopping Assistant)",
-            "description": "The agent can provide brief updates while formulating the final response, helping the contact follow the process in real time."
+            "tooltip": "Disable Multiple message format to enable this feature"
           },
           "multiple_message_format": {
+            "description": "The agent can send multiple formatted messages, such as quick responses, lists, CTAs, and catalogs.",
             "title": "Multiple message format",
-            "description": "The agent can send multiple formatted messages, such as quick responses, lists, CTAs, and catalogs."
+            "tooltip": "Disable Agent progressive feedback to enable this feature"
           }
         },
         "human_support": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -852,12 +852,14 @@
         "agents_preview": {
           "title": "Vista previa de los agentes",
           "agents_progressive_feedback": {
+            "description": "El agente puede proporcionar actualizaciones breves mientras formula la respuesta final. Esto ayuda al contacto a seguir el proceso en tiempo real.",
             "title": "Feedback progresivo de los agentes (disponible únicamente para Shopping Assistant)",
-            "description": "El agente puede proporcionar actualizaciones breves mientras formula la respuesta final. Esto ayuda al contacto a seguir el proceso en tiempo real."
+            "tooltip": "Desactiva el formato de mensaje múltiple para activar esta función"
           },
           "multiple_message_format": {
+            "description": "El agente puede enviar varios mensajes formateados, como respuestas rápidas, listas, CTAs y catálogos.",
             "title": "Formato de mensaje múltiple",
-            "description": "El agente puede enviar varios mensajes formateados, como respuestas rápidas, listas, CTAs y catálogos."
+            "tooltip": "Desactiva el feedback progresivo de los agentes para activar esta función"
           }
         },
         "human_support": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -852,12 +852,14 @@
         "agents_preview": {
           "title": "Prévia dos agentes",
           "agents_progressive_feedback": {
+            "description": "O agente pode fornecer atualizações breves enquanto formula a resposta final, ajudando o contato a acompanhar o processo em tempo real.",
             "title": "Feedback progressivo dos agentes (disponível somente para o Shopping Assistant)",
-            "description": "O agente pode fornecer atualizações breves enquanto formula a resposta final, ajudando o contato a acompanhar o processo em tempo real."
+            "tooltip": "Desative o formato de mensagem múltipla para ativar este recurso"
           },
           "multiple_message_format": {
+            "description": "O agente pode enviar várias mensagens formatadas, como respostas rápidas, listas, CTAs e catálogos.",
             "title": "Formato de mensagem múltipla",
-            "description": "O agente pode enviar várias mensagens formatadas, como respostas rápidas, listas, CTAs e catálogos."
+            "tooltip": "Desative o feedback progressivo dos agentes para ativar este recurso"
           }
         },
         "human_support": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -851,12 +851,14 @@
         "agents_preview": {
           "title": "Previzualizare agent",
           "agents_progressive_feedback": {
+            "description": "Agentul poate oferi actualizări sumare în timp ce formulează răspunsul final, ajutând contactul să urmărească procesul în timp real.",
             "title": "Feedback progresiv agent (disponibil doar pentru Shopping Assistant)",
-            "description": "Agentul poate oferi actualizări sumare în timp ce formulează răspunsul final, ajutând contactul să urmărească procesul în timp real."
+            "tooltip": "Dezactivează formatul multiplu de mesaje pentru a activa această funcție"
           },
           "multiple_message_format": {
+            "description": "Agentul poate trimite mai multe mesaje formatate, cum ar fi răspunsuri rapide, liste, CTA-uri și cataloage.",
             "title": "Format multiplu de mesaje",
-            "description": "Agentul poate trimite mai multe mesaje formatate, cum ar fi răspunsuri rapide, liste, CTA-uri și cataloage."
+            "tooltip": "Dezactivează feedbackul progresiv agent pentru a activa această funcție"
           }
         },
         "human_support": {


### PR DESCRIPTION
## Description

### Type of Change

    - [ ] Bugfix
    - [x] Feature
    - [ ] Code style update (formatting, local variables)
    - [ ] Refactoring (no functional changes, no api changes)
    - [x] Tests
    - [ ] Other

### Motivation and Context

The "Multiple message format" and "Agent progressive feedback" toggles were previously independent, but enabling both simultaneously leads to conflicting behavior. A mutual exclusivity constraint is needed to prevent users from enabling both options at the same time.

### Summary of Changes

- Made "Multiple message format" and "Agent progressive feedback" mutually exclusive: enabling one automatically disables the other.
- Added a `tooltip` prop to `SettingsField` that displays an explanatory message via `UnnnicToolTip` when a toggle is disabled due to the other being active.
- Added computed properties `isProgressiveFeedbackDisabled` and `componentsTooltip` to drive the disabled state and tooltip content for each toggle.
- Added watchers to automatically reset the conflicting toggle's value to `false` when the other is enabled.
- Added localized tooltip strings in English, Spanish, Portuguese (BR), and Romanian, instructing users to disable the conflicting option to enable the desired one.
- Updated tests to cover the mutual exclusivity behavior, tooltip prop rendering, and automatic value reset when toggling between the two options.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/860e2f16-e3ec-439e-83f9-105a2ea794cf.png)

