### PR TITLE
feat: Redirect improvements CTAs to new tab

### DIFF
--- a/src/components/ConversationsImprovements/DrawerDetails/AffectedConversationsSection.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/AffectedConversationsSection.vue
@@ -45,17 +45,17 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
-import { useRoute, useRouter } from 'vue-router';
 import { storeToRefs } from 'pinia';
 
 import {
   AFFECTED_CONVERSATIONS_PAGE_SIZE,
   useImprovementsStore,
 } from '@/store/Improvements';
-import { useSupervisorStore } from '@/store/Supervisor';
 
 import ImprovementDrawerSection from './ImprovementDrawerSection.vue';
 import AffectedConversationItem from './AffectedConversationItem.vue';
+
+import { redirectInParent } from '@/utils/parentRedirect';
 
 import type { AffectedConversation } from '@/store/types/Improvements.types';
 
@@ -64,14 +64,7 @@ const props = defineProps<{
   improvementUuid: string | null;
 }>();
 
-const emit = defineEmits<{
-  'close-drawer': [];
-}>();
-
-const route = useRoute();
-const router = useRouter();
 const improvementsStore = useImprovementsStore();
-const supervisorStore = useSupervisorStore();
 
 const { affectedConversations } = storeToRefs(improvementsStore);
 
@@ -109,22 +102,12 @@ function handlePageUpdate(newPage: number) {
   fetchConversations(newPage);
 }
 
-async function handleViewFullConversation(conversation: AffectedConversation) {
-  supervisorStore.selectedConversation = {
-    uuid: conversation.uuid,
-    urn: conversation.contactUrn,
-    username: conversation.contactName,
-    source: 'v2',
-    data: { status: null },
-  };
-
-  emit('close-drawer');
-
-  await router.replace({
-    name: 'conversations',
+function handleViewFullConversation(conversation: AffectedConversation) {
+  redirectInParent({
+    path: 'aiConversations:conversations',
+    query: { uuid: conversation.uuid },
+    openInNew: true,
   });
-
-  supervisorStore.queryConversationUuid = conversation.uuid;
 }
 
 watch(

--- a/src/components/ConversationsImprovements/DrawerDetails/ImprovementDrawer.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/ImprovementDrawer.vue
@@ -50,7 +50,6 @@
         <AffectedConversationsSection
           :open="drawerOpen"
           :improvementUuid="improvement?.uuid ?? null"
-          @close-drawer="drawerOpen = false"
         />
       </section>
 

--- a/src/components/ConversationsImprovements/DrawerDetails/SuggestedSolutionSection.vue
+++ b/src/components/ConversationsImprovements/DrawerDetails/SuggestedSolutionSection.vue
@@ -56,6 +56,7 @@ import { useImprovementsStore } from '@/store/Improvements';
 
 import ImprovementDrawerSection from './ImprovementDrawerSection.vue';
 import { getImprovementTypeTag } from '@/utils/improvements/getImprovementTypeTag';
+import { redirectInParent } from '@/utils/parentRedirect';
 import { useProfileStore } from '@/store/Profile.js';
 import { UnnnicDisclaimer } from '@weni/unnnic-system';
 
@@ -115,21 +116,15 @@ const getInstructionById = (id: number) => {
 
 function handleCtaClick() {
   if (improvementCategory.value === 'knowledge') {
-    window.parent.postMessage(
-      {
-        event: 'redirect',
-        path: 'aiBuild:knowledge',
-      },
-      '*',
-    );
+    redirectInParent({
+      path: 'aiBuild:knowledge',
+      openInNew: true,
+    });
   } else if (improvementCategory.value === 'behavior') {
-    window.parent.postMessage(
-      {
-        event: 'redirect',
-        path: 'aiAgents:agents/instructions',
-      },
-      '*',
-    );
+    redirectInParent({
+      path: 'aiAgents:agents/instructions',
+      openInNew: true,
+    });
   } else if (improvementCategory.value === 'technical_issue') {
     emit('open-contact-support');
   }

--- a/src/components/ConversationsImprovements/DrawerDetails/__tests__/AffectedConversationsSection.spec.js
+++ b/src/components/ConversationsImprovements/DrawerDetails/__tests__/AffectedConversationsSection.spec.js
@@ -5,30 +5,17 @@ import { createTestingPinia } from '@pinia/testing';
 
 import i18n from '@/utils/plugins/i18n';
 import { useImprovementsStore } from '@/store/Improvements';
-import { useSupervisorStore } from '@/store/Supervisor';
+import { redirectInParent } from '@/utils/parentRedirect';
 
 import AffectedConversationsSection from '../AffectedConversationsSection.vue';
 
-const mockReplace = vi.fn().mockResolvedValue(undefined);
-
-vi.mock('vue-router', async (importOriginal) => {
-  const actual = await importOriginal();
-
-  return {
-    ...actual,
-    useRouter: () => ({
-      replace: mockReplace,
-    }),
-    useRoute: () => ({
-      query: {},
-    }),
-  };
-});
+vi.mock('@/utils/parentRedirect', () => ({
+  redirectInParent: vi.fn(),
+}));
 
 describe('AffectedConversationsSection.vue', () => {
   let wrapper;
   let improvementsStore;
-  let supervisorStore;
 
   const baseConversation = {
     uuid: 'conversation-uuid-1',
@@ -51,7 +38,6 @@ describe('AffectedConversationsSection.vue', () => {
     });
 
     improvementsStore = useImprovementsStore(pinia);
-    supervisorStore = useSupervisorStore(pinia);
 
     vi.spyOn(improvementsStore, 'fetchAffectedConversations');
     vi.spyOn(improvementsStore, 'resetAffectedConversations');
@@ -208,7 +194,7 @@ describe('AffectedConversationsSection.vue', () => {
     );
   });
 
-  it('navigates to conversations and closes the drawer on view full', async () => {
+  it('opens the full conversation in a new tab via the parent', async () => {
     createWrapper();
 
     improvementsStore.affectedConversations.status = 'complete';
@@ -221,17 +207,10 @@ describe('AffectedConversationsSection.vue', () => {
     await elements.items()[0].trigger('click');
     await nextTick();
 
-    expect(supervisorStore.selectedConversation).toEqual({
-      uuid: 'conversation-uuid-1',
-      urn: 'whatsapp:5511999999999',
-      username: 'Alessandra',
-      source: 'v2',
-      data: { status: null },
+    expect(redirectInParent).toHaveBeenCalledWith({
+      path: 'aiConversations:conversations',
+      query: { uuid: 'conversation-uuid-1' },
+      openInNew: true,
     });
-    expect(supervisorStore.queryConversationUuid).toBe('conversation-uuid-1');
-    expect(mockReplace).toHaveBeenCalledWith({
-      name: 'conversations',
-    });
-    expect(wrapper.emitted('close-drawer')).toEqual([[]]);
   });
 });

--- a/src/components/ConversationsImprovements/DrawerDetails/__tests__/ImprovementDrawer.spec.js
+++ b/src/components/ConversationsImprovements/DrawerDetails/__tests__/ImprovementDrawer.spec.js
@@ -65,9 +65,8 @@ describe('ImprovementDrawer.vue', () => {
           },
           AffectedConversationsSection: {
             template:
-              '<section data-testid="improvement-drawer-affected-conversations-section"><h2 data-testid="improvement-drawer-affected-conversations-title">{{ $t(\'audit.improvements.drawer.affected_conversations_title\') }}</h2><button data-testid="emit-close-drawer" @click="$emit(\'close-drawer\')" /></section>',
+              '<section data-testid="improvement-drawer-affected-conversations-section"><h2 data-testid="improvement-drawer-affected-conversations-title">{{ $t(\'audit.improvements.drawer.affected_conversations_title\') }}</h2></section>',
             props: ['open', 'improvementUuid'],
-            emits: ['close-drawer'],
           },
           UnnnicDrawerContent: {
             template: '<div><slot /></div>',
@@ -401,15 +400,6 @@ describe('ImprovementDrawer.vue', () => {
       createWrapper();
 
       await wrapper.find('[data-testid="emit-success"]').trigger('click');
-      await nextTick();
-
-      expect(wrapper.emitted('update:open')).toEqual([[false]]);
-    });
-
-    it('closes the drawer when affected conversations emits close-drawer', async () => {
-      createWrapper();
-
-      await wrapper.find('[data-testid="emit-close-drawer"]').trigger('click');
       await nextTick();
 
       expect(wrapper.emitted('update:open')).toEqual([[false]]);

--- a/src/components/ConversationsImprovements/DrawerDetails/__tests__/SuggestedSolutionSection.spec.js
+++ b/src/components/ConversationsImprovements/DrawerDetails/__tests__/SuggestedSolutionSection.spec.js
@@ -1,0 +1,107 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTestingPinia } from '@pinia/testing';
+
+import i18n from '@/utils/plugins/i18n';
+import { useImprovementsStore } from '@/store/Improvements';
+import { redirectInParent } from '@/utils/parentRedirect';
+
+import SuggestedSolutionSection from '../SuggestedSolutionSection.vue';
+
+vi.mock('@/utils/parentRedirect', () => ({
+  redirectInParent: vi.fn(),
+}));
+
+describe('SuggestedSolutionSection.vue', () => {
+  let wrapper;
+  let improvementsStore;
+
+  const createWrapper = () => {
+    const pinia = createTestingPinia({
+      stubActions: true,
+    });
+
+    improvementsStore = useImprovementsStore(pinia);
+
+    wrapper = mount(SuggestedSolutionSection, {
+      global: {
+        plugins: [pinia],
+      },
+    });
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  const elements = {
+    cta: () => wrapper.findComponent('[data-testid="suggested-solution-cta"]'),
+  };
+
+  it('opens the knowledge base in a new tab when the CTA is clicked', async () => {
+    createWrapper();
+
+    improvementsStore.improvementDetail.data = {
+      type: 'missing_static_knowledge',
+      suggestedSolution: 'Add missing knowledge',
+      affectedInstructions: [],
+    };
+
+    await wrapper.vm.$nextTick();
+
+    expect(elements.cta().props('text')).toBe(
+      i18n.global.t('audit.improvements.drawer.go_to_knowledge_base'),
+    );
+
+    await elements.cta().trigger('click');
+
+    expect(redirectInParent).toHaveBeenCalledWith({
+      path: 'aiBuild:knowledge',
+      openInNew: true,
+    });
+  });
+
+  it('opens instructions in a new tab when the CTA is clicked', async () => {
+    createWrapper();
+
+    improvementsStore.improvementDetail.data = {
+      type: 'wrong_behavior_due_to_instructions',
+      suggestedSolution: 'Update instructions',
+      affectedInstructions: [],
+    };
+
+    await wrapper.vm.$nextTick();
+
+    expect(elements.cta().props('text')).toBe(
+      i18n.global.t('audit.improvements.drawer.go_to_instructions'),
+    );
+
+    await elements.cta().trigger('click');
+
+    expect(redirectInParent).toHaveBeenCalledWith({
+      path: 'aiAgents:agents/instructions',
+      openInNew: true,
+    });
+  });
+
+  it('emits open-contact-support for technical issue CTAs', async () => {
+    createWrapper();
+
+    improvementsStore.improvementDetail.data = {
+      type: 'poor_product_search_results',
+      suggestedSolution: 'Contact support',
+      affectedInstructions: [],
+    };
+
+    await wrapper.vm.$nextTick();
+
+    await elements.cta().trigger('click');
+
+    expect(wrapper.emitted('open-contact-support')).toEqual([[]]);
+    expect(redirectInParent).not.toHaveBeenCalled();
+  });
+});

--- a/src/utils/__tests__/parentRedirect.spec.js
+++ b/src/utils/__tests__/parentRedirect.spec.js
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { redirectInParent } from '@/utils/parentRedirect';
+
+describe('parentRedirect', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(window.parent, 'postMessage').mockImplementation(() => {});
+  });
+
+  it('posts a redirect event with the given path', () => {
+    redirectInParent({ path: 'aiBuild:knowledge' });
+
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      {
+        event: 'redirect',
+        path: 'aiBuild:knowledge',
+        openInNew: false,
+      },
+      '*',
+    );
+  });
+
+  it('includes query and openInNew when provided', () => {
+    redirectInParent({
+      path: 'aiConversations:conversations',
+      query: { uuid: 'conversation-uuid-1' },
+      openInNew: true,
+    });
+
+    expect(window.parent.postMessage).toHaveBeenCalledWith(
+      {
+        event: 'redirect',
+        path: 'aiConversations:conversations',
+        query: { uuid: 'conversation-uuid-1' },
+        openInNew: true,
+      },
+      '*',
+    );
+  });
+});

--- a/src/utils/parentRedirect.js
+++ b/src/utils/parentRedirect.js
@@ -1,0 +1,20 @@
+/**
+ * Asks the host (weni-webapp) to navigate to a module route.
+ * Use openInNew when the target must open outside the current iframe tab.
+ *
+ * @param {object} options
+ * @param {string} options.path - Host path in the form `module:internal/path`
+ * @param {Record<string, string>} [options.query] - Query params for the host route
+ * @param {boolean} [options.openInNew=false] - Open the route in a new browser tab
+ */
+export function redirectInParent({ path, query, openInNew = false }) {
+  window.parent.postMessage(
+    {
+      event: 'redirect',
+      path,
+      ...(query && { query }),
+      openInNew,
+    },
+    '*',
+  );
+}


### PR DESCRIPTION
### Type of Change

- [ ] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Tests
- [ ] Chore
- [ ] Locales

### Why

For a better user experience, all CTA buttons in the backlog audit feature should open a new browser tab instead of taking the user away from the improvements screen.

### What Changed

A `redirectInParent` utility function was introduced in `src/utils/parentRedirect.js` that wraps `window.parent.postMessage` with a standard `redirect` event shape, supporting `path`, `query`, and `openInNew` options.

- `AffectedConversationsSection` now uses `redirectInParent` to open a conversation in a new tab via the parent host, replacing the previous flow that set state on the Supervisor store, emitted `close-drawer`, and navigated via Vue Router.
- The `close-drawer` event and its handler in `ImprovementDrawer` were removed since the drawer no longer needs to close when viewing a conversation.
- `SuggestedSolutionSection` replaced its inline `window.parent.postMessage` calls with `redirectInParent`.
- Tests for `AffectedConversationsSection` and `ImprovementDrawer` were updated to reflect the removed event and store dependencies.
- New test suites were added for `SuggestedSolutionSection` and the `parentRedirect` utility.

### Diagram

```mermaid
flowchart TD
    A[AffectedConversationsSection] -->|handleViewFullConversation| U[redirectInParent]
    B[SuggestedSolutionSection] -->|handleCtaClick - knowledge| U
    B -->|handleCtaClick - behavior| U
    U -->|postMessage redirect event| P[window.parent / weni-webapp]
    P -->|openInNew: true| T[New browser tab]
```