### PR TITLE
feat: Replace `UnnnicSelect` with `UnnnicRadioGroup` in FilterAnalysis

### DIFF
--- a/src/views/Supervisor/SupervisorFilters/FilterAnalysis.vue
+++ b/src/views/Supervisor/SupervisorFilters/FilterAnalysis.vue
@@ -1,12 +1,18 @@
 <template>
-  <UnnnicFormElement :label="$t('audit.conversations.filters.analysis.label')">
-    <UnnnicSelect
-      v-model:modelValue="analysisFilter"
-      data-testid="analysis-select"
-      :options="analysisOptions"
-      :optionsLines="2"
+  <UnnnicRadioGroup
+    v-model:modelValue="analysisFilter"
+    state="vertical"
+    data-testid="analysis-radio-group"
+    :label="$t('audit.conversations.filters.analysis.label')"
+  >
+    <UnnnicRadio
+      v-for="option in analysisOptions"
+      :key="option.value"
+      :data-testid="`analysis-radio-${option.value}`"
+      :label="option.label"
+      :value="option.value"
     />
-  </UnnnicFormElement>
+  </UnnnicRadioGroup>
 </template>
 
 <script setup>

--- a/src/views/Supervisor/SupervisorFilters/__tests__/FilterAnalysis.spec.js
+++ b/src/views/Supervisor/SupervisorFilters/__tests__/FilterAnalysis.spec.js
@@ -17,8 +17,8 @@ describe('FilterAnalysis.vue', () => {
   let wrapper;
   let store;
 
-  const analysisSelect = () =>
-    wrapper.findComponent('[data-testid="analysis-select"]');
+  const analysisRadioGroup = () =>
+    wrapper.findComponent('[data-testid="analysis-radio-group"]');
 
   const createWrapper = (isAmazing = null) => {
     const pinia = createTestingPinia({
@@ -50,46 +50,53 @@ describe('FilterAnalysis.vue', () => {
   });
 
   describe('Component rendering', () => {
-    it('renders the analysis select', () => {
-      expect(analysisSelect().exists()).toBe(true);
+    it('renders the analysis radio group', () => {
+      expect(analysisRadioGroup().exists()).toBe(true);
     });
 
     it('initializes with all conversations when isAmazing is null', () => {
-      expect(analysisSelect().props('modelValue')).toBe('all_conversations');
+      expect(analysisRadioGroup().props('modelValue')).toBe(
+        'all_conversations',
+      );
     });
 
     it('initializes with amazing conversations when isAmazing is true', () => {
       wrapper.unmount();
       createWrapper(true);
 
-      expect(analysisSelect().props('modelValue')).toBe(
+      expect(analysisRadioGroup().props('modelValue')).toBe(
         'amazing_conversations',
       );
     });
 
     it('provides correct analysis options', () => {
-      const options = analysisSelect().props('options');
+      const allConversationsRadio = wrapper.findComponent(
+        '[data-testid="analysis-radio-all_conversations"]',
+      );
+      const amazingConversationsRadio = wrapper.findComponent(
+        '[data-testid="analysis-radio-amazing_conversations"]',
+      );
 
-      expect(options).toStrictEqual([
-        {
-          label: i18n.global.t(
-            'audit.conversations.filters.analysis.all_conversations',
-          ),
-          value: 'all_conversations',
-        },
-        {
-          label: i18n.global.t(
-            'audit.conversations.filters.analysis.amazing_conversations',
-          ),
-          value: 'amazing_conversations',
-        },
-      ]);
+      expect(allConversationsRadio.props('label')).toBe(
+        i18n.global.t(
+          'audit.conversations.filters.analysis.all_conversations',
+        ),
+      );
+      expect(allConversationsRadio.props('value')).toBe('all_conversations');
+      expect(amazingConversationsRadio.props('label')).toBe(
+        i18n.global.t(
+          'audit.conversations.filters.analysis.amazing_conversations',
+        ),
+      );
+      expect(amazingConversationsRadio.props('value')).toBe(
+        'amazing_conversations',
+      );
     });
   });
 
   describe('Analysis selection functionality', () => {
     it('sets isAmazing to true when amazing conversations is selected', async () => {
-      await analysisSelect().vm.$emit(
+      await analysisRadioGroup().vm.$emit(
         'update:modelValue',
         'amazing_conversations',
       );
@@ -102,7 +109,10 @@ describe('FilterAnalysis.vue', () => {
       wrapper.unmount();
       createWrapper(true);
 
-      await analysisSelect().vm.$emit('update:modelValue', 'all_conversations');
+      await analysisRadioGroup().vm.$emit(
+        'update:modelValue',
+        'all_conversations',
+      );
       await nextTick();
 
       expect(store.temporaryFilters.isAmazing).toBeNull();
@@ -115,7 +125,7 @@ describe('FilterAnalysis.vue', () => {
       store.temporaryFilters.isAmazing = null;
       await nextTick();
 
-      expect(analysisSelect().props('modelValue')).toBe('all_conversations');
+      expect(analysisRadioGroup().props('modelValue')).toBe('all_conversations');
       expect(store.temporaryFilters.isAmazing).toBeNull();
     });
   });

--- a/src/views/Supervisor/SupervisorFilters/index.vue
+++ b/src/views/Supervisor/SupervisorFilters/index.vue
@@ -123,7 +123,8 @@ onMounted(async () => {
 <style lang="scss">
 .supervisor-filters__drawer {
   &.unnnic-drawer__container .unnnic-drawer__content {
-    overflow: visible;
+    overflow-x: visible;
+    overflow-y: auto;
 
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
### Type of Change

- [x] Feature
- [ ] Bug fix
- [x] Refactor
- [x] Tests
- [ ] Chore
- [ ] Locales

### Why

The analysis filter in the Supervisor Filters drawer was using a dropdown select component, which was causing overflow visibility issues. Replacing it with a radio group improves usability and fits better within the drawer layout. Additionally, the drawer's overflow behavior needed adjustment to allow horizontal overflow while enabling vertical scrolling.

### What Changed

- Replaced `UnnnicSelect` with `UnnnicRadioGroup` and individual `UnnnicRadio` components for the analysis filter, rendering each option as a radio button in a vertical layout.
- Updated the drawer's overflow style from `overflow: visible` to `overflow-x: visible` and `overflow-y: auto` to prevent layout issues while keeping the drawer scrollable.
- Updated tests to reflect the new radio group structure, including individual radio button assertions for labels and values.

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/c44957be-d3f4-446c-923d-580e56b9306d.png)

