### PR TITLE
Add Pinia HMR support for Rspack/Webpack dev builds

### DIFF
--- a/build/pinia-hmr-loader.js
+++ b/build/pinia-hmr-loader.js
@@ -1,0 +1,44 @@
+/**
+ * Dev-only loader: auto-registers Pinia HMR for store modules.
+ *
+ * Finds `export const useX = defineStore(...)` and appends
+ * `registerStoreHMR(useX, import.meta.webpackHot)` so stores don't need
+ * manual boilerplate (easy to forget on new stores).
+ *
+ * Runs as a pre-loader on the original TS/JS source before SWC.
+ */
+module.exports = function piniaHmrLoader(source) {
+  if (this.cacheable) {
+    this.cacheable();
+  }
+
+  if (!/defineStore\s*\(/.test(source)) {
+    return source;
+  }
+
+  // Drop manual registration if present (idempotent / migration-safe).
+  let code = source
+    .replace(
+      /import\s*\{\s*registerStoreHMR\s*\}\s*from\s*['"]@\/utils\/hmr['"];?\r?\n?/g,
+      '',
+    )
+    .replace(
+      /registerStoreHMR\s*\(\s*\w+\s*,\s*import\.meta\.webpackHot\s*\)\s*;?\r?\n?/g,
+      '',
+    );
+
+  const storeNames = [
+    ...code.matchAll(/export\s+const\s+(\w+)\s*=\s*defineStore\s*\(/g),
+  ].map((match) => match[1]);
+
+  if (!storeNames.length) {
+    return code;
+  }
+
+  const importStatement = `import { registerStoreHMR } from '@/utils/hmr';\n`;
+  const registrations = storeNames
+    .map((name) => `registerStoreHMR(${name}, import.meta.webpackHot);`)
+    .join('\n');
+
+  return `${importStatement}${code}\n${registrations}\n`;
+};

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -9,6 +9,7 @@
       "@/*": ["src/*"]
     }
   },
+  "include": ["src/**/*", "types/**/*.d.ts"],
   "exclude": ["node_modules", "dist"],
   "lib": ["esnext", "dom", "dom.iterable", "scripthost"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@vue/eslint-config-typescript": "^14.6.0",
         "@vue/test-utils": "^2.4.6",
         "@weni/eslint-config": "^2.0.0",
+        "css-loader": "^7.1.4",
         "eslint": "^9.33.0",
         "eslint-plugin-vue": "10.4.0",
         "globals": "^16.4.0",
@@ -52,7 +53,8 @@
         "sass": "^1.89.2",
         "typescript": "~5.8.0",
         "vite": "6.3.6",
-        "vitest": "3.2.4"
+        "vitest": "3.2.4",
+        "vue-style-loader": "^4.1.3"
       },
       "engines": {
         "node": ">=22.12.0"
@@ -1852,7 +1854,6 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -1892,7 +1893,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1913,7 +1913,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1934,7 +1933,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1955,7 +1953,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1976,7 +1973,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1997,7 +1993,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2018,7 +2013,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2039,7 +2033,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2060,7 +2053,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2081,7 +2073,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2102,7 +2093,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2123,7 +2113,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2144,7 +2133,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5175,6 +5163,16 @@
         "require-from-string": "^2.0.2"
       }
     },
+    "node_modules/big.js": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+      "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -5801,6 +5799,55 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-loader": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-7.1.4.tgz",
+      "integrity": "sha512-vv3J9tlOl04WjiMvHQI/9tmIrCxVrj6PFbHemBB1iihpeRbi/I4h033eoFIhwxBBqLhI0KYFS7yvynBFhIZfTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.40",
+        "postcss-modules-extract-imports": "^3.1.0",
+        "postcss-modules-local-by-default": "^4.0.5",
+        "postcss-modules-scope": "^3.2.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": ">= 18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
+        "webpack": "^5.27.0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "webpack": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/css-loader/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/css-tree": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
@@ -6022,7 +6069,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "bin": {
@@ -6196,6 +6242,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/emojis-list": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+      "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -7500,6 +7556,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -8076,6 +8145,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/loader-utils": {
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
+      "integrity": "sha512-I5d00Pd/jwMD2QCduo657+YM/6L3KZu++pmX9VFncxaxvHcru9jx1lBaFft+r4Mt2jK0Yhp41XlRAihzPxHNCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "big.js": "^5.2.2",
+        "emojis-list": "^3.0.0",
+        "json5": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/loader-utils/node_modules/json5": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.0"
+      },
+      "bin": {
+        "json5": "lib/cli.js"
       }
     },
     "node_modules/loadjs": {
@@ -9133,6 +9230,16 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/minipass": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
@@ -9230,7 +9337,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "dev": true,
       "license": "MIT",
       "optional": true
     },
@@ -9681,6 +9787,97 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.1.0.tgz",
+      "integrity": "sha512-k3kNe0aNFQDAZGbin48pL2VNidTF0w4/eASDsxlyspobzU3wZQLOGj7L9gfRe0Jo9/4uud09DsjFNH7winGv8Q==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.2.0.tgz",
+      "integrity": "sha512-5kcJm/zk+GJDSfw+V/42fJ5fhjL5YbFDl8nVdXkJPLLW+Vf9mTD5Xe0wqIaDnLuL2U6cDNpTr+UQ+v2HWIBhzw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^7.0.0",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.2.1.tgz",
+      "integrity": "sha512-m9jZstCVaqGjTAuny8MdgE88scJnCiQSlSrOWcTQgM2t32UBe+MUmFSO5t7VMSfAf/FJKImAxBav8ooCHJXCJA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "postcss-selector-parser": "^7.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/postcss-selector-parser": {
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
@@ -9694,6 +9891,13 @@
       "engines": {
         "node": ">=4"
       }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
@@ -12075,6 +12279,24 @@
       "version": "6.6.4",
       "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
       "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
+      "license": "MIT"
+    },
+    "node_modules/vue-style-loader": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/vue-style-loader/-/vue-style-loader-4.1.3.tgz",
+      "integrity": "sha512-sFuh0xfbtpRlKfm39ss/ikqs9AbKCoXZBpHeVZ8Tx650o0k0q/YCM7FRvigtxpACezfq6af+a7JeqVTWvncqDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hash-sum": "^1.0.2",
+        "loader-utils": "^1.0.2"
+      }
+    },
+    "node_modules/vue-style-loader/node_modules/hash-sum": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-1.0.2.tgz",
+      "integrity": "sha512-fUs4B4L+mlt8/XAtSOGMUO1TXmAelItBPtJG7CyHJfYTdDjwisntGO2JQz7oUsatOY9o68+57eziUVNw/mRHmA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vue-the-mask": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "@vue/eslint-config-typescript": "^14.6.0",
     "@vue/test-utils": "^2.4.6",
     "@weni/eslint-config": "^2.0.0",
+    "css-loader": "^7.1.4",
     "eslint": "^9.33.0",
     "eslint-plugin-vue": "10.4.0",
     "globals": "^16.4.0",
@@ -58,6 +59,7 @@
     "sass": "^1.89.2",
     "typescript": "~5.8.0",
     "vite": "6.3.6",
-    "vitest": "3.2.4"
+    "vitest": "3.2.4",
+    "vue-style-loader": "^4.1.3"
   }
 }

--- a/rspack.config.mjs
+++ b/rspack.config.mjs
@@ -16,21 +16,65 @@ dotenv.config();
 // Target browsers, see: https://github.com/browserslist/browserslist
 const targets = ['chrome >= 87', 'edge >= 88', 'firefox >= 78', 'safari >= 14'];
 
+const isDev = process.env.NODE_ENV === 'development';
+const PORT = 8081;
+const PUBLIC_PATH = `${process.env.PUBLIC_PATH_URL}/`;
+const FEDERATION_NAME = 'agent_builder';
+
 const connectUrl = process.env.MODULE_FEDERATION_CONNECT_URL;
 
+const scssAdditionalData = `@use '@weni/unnnic-system/src/assets/scss/unnnic.scss' as *;`;
+
+/**
+ * Dev: vue-style-loader chain so Vue SFC blocks hot-reload.
+ * Prod: native CSS (experiments.css) for hashed standalone CSS files.
+ */
+function styleRule(test, loadersAfterCss = []) {
+  if (isDev) {
+    return {
+      test,
+      use: ['vue-style-loader', 'css-loader', ...loadersAfterCss],
+      type: 'javascript/auto',
+    };
+  }
+
+  return {
+    test,
+    use: [...loadersAfterCss],
+    type: 'css',
+  };
+}
+
 export default defineConfig({
+  ...(isDev ? { devtool: 'eval-cheap-module-source-map' } : {}),
   context: __dirname,
   devServer: {
+    port: PORT,
     historyApiFallback: true,
     hot: true,
-    liveReload: true,
+    liveReload: false,
     compress: true,
+    headers: {
+      // Module Federation cross-origin: the connect host fetches
+      // `remoteEntry.js` from this dev server during local federation testing.
+      'Access-Control-Allow-Origin': '*',
+    },
+    client: {
+      // Federated: the host page may run on another origin/port, so the HMR
+      // client must connect back to this remote's own websocket explicitly.
+      webSocketURL: `ws://localhost:${PORT}/ws`,
+    },
   },
   output: {
     path: path.resolve(__dirname, './dist'),
-    publicPath: `${process.env.PUBLIC_PATH_URL}/`,
-    filename: 'assets/js/[name]-[contenthash].js',
-    chunkFilename: 'assets/js/[name]-[contenthash].js',
+    uniqueName: FEDERATION_NAME,
+    publicPath: PUBLIC_PATH,
+    filename: isDev
+      ? 'assets/js/[name].js'
+      : 'assets/js/[name]-[contenthash].js',
+    chunkFilename: isDev
+      ? 'assets/js/[name].js'
+      : 'assets/js/[name]-[contenthash].js',
     assetModuleFilename: 'assets/[name]-[hash][ext]',
   },
   entry: {
@@ -75,14 +119,27 @@ export default defineConfig({
         },
         type: 'javascript/auto',
       },
-      {
-        test: /\.(scss|sass)$/,
-        loader: 'sass-loader',
-        type: 'css',
-        options: {
-          additionalData: `@use '@weni/unnnic-system/src/assets/scss/unnnic.scss' as *;`,
+      // Dev: inject registerStoreHMR for every defineStore export (no per-file boilerplate).
+      ...(isDev
+        ? [
+            {
+              test: /\.(js|ts)$/,
+              include: [path.resolve(__dirname, 'src/store')],
+              exclude: [/node_modules/, /\.spec\./, /\.unit\./, /__tests__/],
+              enforce: 'pre',
+              use: [path.resolve(__dirname, 'build/pinia-hmr-loader.js')],
+            },
+          ]
+        : []),
+      styleRule(/\.(scss|sass)$/, [
+        {
+          loader: 'sass-loader',
+          options: {
+            additionalData: scssAdditionalData,
+          },
         },
-      },
+      ]),
+      styleRule(/\.css$/),
       {
         test: /\.(png|jpe?g|gif|svg|webp|avif)$/i,
         type: 'asset/resource',
@@ -103,6 +160,7 @@ export default defineConfig({
     new HtmlRspackPlugin({
       template: './index.html',
       inject: 'head',
+      chunks: ['main'],
       minify: {
         removeComments: false,
         collapseWhitespace: true,
@@ -121,7 +179,7 @@ export default defineConfig({
     }),
     new VueLoaderPlugin(),
     new rspack.container.ModuleFederationPlugin({
-      name: 'agent_builder',
+      name: FEDERATION_NAME,
       filename: 'remoteEntry.js',
       exposes: {
         './main': './src/main.js',
@@ -169,6 +227,7 @@ export default defineConfig({
     ],
   },
   experiments: {
-    css: true,
+    // Native CSS is incompatible with vue-style-loader HMR; enable only in prod.
+    css: !isDev,
   },
 });

--- a/src/utils/hmr.ts
+++ b/src/utils/hmr.ts
@@ -21,6 +21,7 @@ type WebpackHotModule = {
  * `export const … = defineStore(...)` under `src/store`.
  */
 export function registerStoreHMR(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   useStore: StoreDefinition<any, any, any, any>,
   hot: WebpackHotModule | undefined,
 ) {
@@ -29,9 +30,11 @@ export function registerStoreHMR(
   hot.accept();
 
   hot.dispose((data) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     data.pinia = getActivePinia() ?? (useStore as any)._pinia;
   });
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const pinia = getActivePinia() ?? (useStore as any)._pinia ?? hot.data?.pinia;
   if (!pinia) return;
 

--- a/src/utils/hmr.ts
+++ b/src/utils/hmr.ts
@@ -1,0 +1,42 @@
+import { acceptHMRUpdate, getActivePinia, type StoreDefinition } from 'pinia';
+
+type WebpackHotModule = {
+  data?: Record<string, unknown>;
+  accept: (callback?: (err?: Error) => void) => void;
+  dispose: (callback: (data: Record<string, unknown>) => void) => void;
+  invalidate?: () => void;
+};
+
+/**
+ * Enables hot module replacement for a Pinia store under Webpack/Rspack.
+ *
+ * Pinia's `acceptHMRUpdate` is written for Vite, where
+ * `import.meta.hot.accept(cb)` calls `cb(newModule)`. Webpack/Rspack only
+ * self-accepts and re-executes the module — the accept callback is an error
+ * handler and never receives exports. Without a manual patch, edits are
+ * accepted silently and the live store keeps the old getters/actions.
+ *
+ * Do not call this from store files. In development, `build/pinia-hmr-loader.js`
+ * injects `registerStoreHMR(useStore, import.meta.webpackHot)` for every
+ * `export const … = defineStore(...)` under `src/store`.
+ */
+export function registerStoreHMR(
+  useStore: StoreDefinition<any, any, any, any>,
+  hot: WebpackHotModule | undefined,
+) {
+  if (!hot) return;
+
+  hot.accept();
+
+  hot.dispose((data) => {
+    data.pinia = getActivePinia() ?? (useStore as any)._pinia;
+  });
+
+  const pinia = getActivePinia() ?? (useStore as any)._pinia ?? hot.data?.pinia;
+  if (!pinia) return;
+
+  // Feed the re-executed store definition into Pinia's Vite-oriented updater.
+  acceptHMRUpdate(useStore, { data: { pinia }, invalidate: hot.invalidate })({
+    [useStore.$id]: useStore,
+  });
+}

--- a/types/webpackHot.d.ts
+++ b/types/webpackHot.d.ts
@@ -1,0 +1,12 @@
+interface ImportMeta {
+  webpackHot?: {
+    data?: Record<string, unknown>;
+    accept: (
+      dependencies?: string | string[] | ((err?: Error) => void),
+      callback?: (...args: any[]) => void,
+    ) => void;
+    dispose: (callback: (data: Record<string, unknown>) => void) => void;
+    decline: (dependencies?: string | string[]) => void;
+    invalidate: () => void;
+  };
+}

--- a/types/webpackHot.d.ts
+++ b/types/webpackHot.d.ts
@@ -3,6 +3,7 @@ interface ImportMeta {
     data?: Record<string, unknown>;
     accept: (
       dependencies?: string | string[] | ((err?: Error) => void),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       callback?: (...args: any[]) => void,
     ) => void;
     dispose: (callback: (data: Record<string, unknown>) => void) => void;


### PR DESCRIPTION
### Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Tests
- [x] Chore
- [ ] Locales

### Why

Pinia's `acceptHMRUpdate` is designed for Vite's HMR model, where the accept callback receives the new module. Webpack/Rspack self-accepts and re-executes the module instead, meaning store edits were silently accepted without actually updating live getters and actions. This caused a poor DX where store changes required a full page reload to take effect.

### What Changed

- Added `src/utils/hmr.ts` with a `registerStoreHMR` function that bridges Pinia's Vite-oriented HMR updater to Webpack/Rspack's self-accept model, preserving the active Pinia instance across hot reloads via `hot.dispose`.
- Added `build/pinia-hmr-loader.js`, a dev-only Rspack pre-loader that automatically injects `registerStoreHMR(useX, import.meta.webpackHot)` for every `export const useX = defineStore(...)` found under `src/store`, removing the need for per-file boilerplate and stripping any previously manual registrations idempotently.
- Updated `rspack.config.mjs` to:
    - Register the Pinia HMR pre-loader in development only.
    - Switch style handling to `vue-style-loader` + `css-loader` in development (enabling Vue SFC `<style>` block hot-reload) and native CSS (`experiments.css`) in production.
    - Disable `liveReload` in favour of true HMR, add CORS headers and an explicit `webSocketURL` for Module Federation cross-origin dev scenarios, and use non-hashed output filenames in development.
    - Disable `experiments.css` in development since it is incompatible with `vue-style-loader`.
- Added `types/webpackHot.d.ts` to declare `import.meta.webpackHot` on `ImportMeta`.
- Added `css-loader` and `vue-style-loader` as dev dependencies.
- Updated `jsconfig.json` to explicitly include `src/**/*` and `types/**/*.d.ts`