### PR TITLE
Add and update translations from PR#223

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -391,7 +391,7 @@
         "title": "New instruction",
         "edit_title": "Edit instruction",
         "category_label": "Category",
-        "re_validate": "Re-validate",
+        "re_validate": "Revalidate",
         "validate": "Validate",
         "save": "Save",
         "cancel": "Cancel",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instrucciones",
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
+      "new_instruction": "Nueva instrucción",
       "export_instructions": {
         "title": "Exportar instrucciones",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "El archivo CSV está listo en la carpeta de descargas",
         "success_alert_title": "Instrucciones exportadas"
       },
-      "new_instruction": "Nueva instrucción",
       "delete_category": {
         "modal_title": "Eliminar categoría",
         "modal_description": "{count} de {name} a Sin categoría. No se eliminará nada, solo se quita la etiqueta de la categoría.",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instruções",
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
+      "new_instruction": "Nova instrução",
       "export_instructions": {
         "title": "Exportar instruções",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "O arquivo CSV está pronto na pasta de downloads",
         "success_alert_title": "Instruções exportadas"
       },
-      "new_instruction": "Nova instrução",
       "delete_category": {
         "modal_title": "Excluir categoria",
         "modal_description": "{count} de {name} para Sem categoria. Nada será excluído, apenas o rótulo da categoria é removido.",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -344,6 +344,7 @@
     "instructions": {
       "title": "Instrucțiuni",
       "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
+      "new_instruction": "Instrucțiune nouă",
       "export_instructions": {
         "title": "Exportă instrucțiuni",
         "cancel_button": "Anulează",
@@ -353,7 +354,6 @@
         "success_alert_description": "Fișierul CSV este gata în folderul de descărcări",
         "success_alert_title": "Instrucțiuni exportate"
       },
-      "new_instruction": "Instrucțiune nouă",
       "delete_category": {
         "modal_title": "Șterge categoria",
         "modal_description": "{count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",


### PR DESCRIPTION
Add and update translations from [PR#223](https://github.com/weni-ai/agent-builder-webapp/pull/223). Tracked in [LOC-27564](https://vtex-dev.atlassian.net/browse/LOC-27564).

Updates Agent Builder instruction strings in en, pt_br, es, and ro.