### PR TITLE
Add and update translations from PR#216

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -426,7 +426,8 @@
               "already_exists": "Enter a category name that doesn't already exist",
               "invalid_chars": "Use only letters, numbers, spaces, and hyphens",
               "required": "Complete this field"
-            }
+            },
+            "placeholder": "Select..."
           }
         }
       },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instrucciones",
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
+      "new_instruction": "Nueva instrucción",
       "export_instructions": {
         "title": "Exportar instrucciones",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "El archivo CSV está listo en la carpeta de descargas",
         "success_alert_title": "Instrucciones exportadas"
       },
-      "new_instruction": "Nueva instrucción",
       "delete_category": {
         "modal_title": "Eliminar categoría",
         "modal_description": "{count} de {name} a Sin categoría. No se eliminará nada, solo se quita la etiqueta de la categoría.",
@@ -426,7 +426,8 @@
               "already_exists": "Ingresa un nombre de categoría que no exista",
               "invalid_chars": "Usa solo letras, números, espacios y guiones",
               "required": "Completa este campo"
-            }
+            },
+            "placeholder": "Seleccionar..."
           }
         }
       },

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instruções",
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
+      "new_instruction": "Nova instrução",
       "export_instructions": {
         "title": "Exportar instruções",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "O arquivo CSV está pronto na pasta de downloads",
         "success_alert_title": "Instruções exportadas"
       },
-      "new_instruction": "Nova instrução",
       "delete_category": {
         "modal_title": "Excluir categoria",
         "modal_description": "{count} de {name} para Sem categoria. Nada será excluído, apenas o rótulo da categoria é removido.",
@@ -426,7 +426,8 @@
               "already_exists": "Insira um nome de categoria que não exista",
               "invalid_chars": "Use apenas letras, números, espaços e hifens",
               "required": "Preencha este campo"
-            }
+            },
+            "placeholder": "Selecionar..."
           }
         }
       },

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -344,6 +344,7 @@
     "instructions": {
       "title": "Instrucțiuni",
       "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
+      "new_instruction": "Instrucțiune nouă",
       "export_instructions": {
         "title": "Exportă instrucțiuni",
         "cancel_button": "Anulează",
@@ -353,7 +354,6 @@
         "success_alert_description": "Fișierul CSV este gata în folderul de descărcări",
         "success_alert_title": "Instrucțiuni exportate"
       },
-      "new_instruction": "Instrucțiune nouă",
       "delete_category": {
         "modal_title": "Șterge categoria",
         "modal_description": "{count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
@@ -425,7 +425,8 @@
               "already_exists": "Introdu un nume de categorie care nu există deja",
               "invalid_chars": "Folosește doar litere, cifre, spații și cratime",
               "required": "Completează acest câmp"
-            }
+            },
+            "placeholder": "Selectează..."
           }
         }
       },


### PR DESCRIPTION
Add and update translations from [PR#216](https://github.com/weni-ai/agent-builder-webapp/pull/216). Tracked in [LOC-27560](https://vtex-dev.atlassian.net/browse/LOC-27560).

Updates Agent Builder instruction strings in en, pt_br, es, and ro.