### PR TITLE
feat: Add prompt injection filter to SafetyGuardrails drawer

### DIFF
--- a/src/api/adapters/guardrails/__tests__/promptInjectionFilter.spec.js
+++ b/src/api/adapters/guardrails/__tests__/promptInjectionFilter.spec.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { PromptInjectionFilterAdapter } from '@/api/adapters/guardrails/promptInjectionFilter';
+
+describe('PromptInjectionFilterAdapter', () => {
+  describe('fromApi', () => {
+    it('maps enabled and strips writable', () => {
+      expect(
+        PromptInjectionFilterAdapter.fromApi({
+          enabled: true,
+          writable: true,
+        }),
+      ).toEqual({
+        enabled: true,
+      });
+    });
+
+    it('coerces enabled to boolean and defaults missing fields', () => {
+      expect(PromptInjectionFilterAdapter.fromApi({})).toEqual({
+        enabled: false,
+      });
+      expect(PromptInjectionFilterAdapter.fromApi({ enabled: 1 })).toEqual({
+        enabled: true,
+      });
+    });
+  });
+
+  describe('toApi', () => {
+    it('maps enabled to the API payload', () => {
+      expect(PromptInjectionFilterAdapter.toApi({ enabled: false })).toEqual({
+        enabled: false,
+      });
+    });
+  });
+});

--- a/src/api/adapters/guardrails/promptInjectionFilter.js
+++ b/src/api/adapters/guardrails/promptInjectionFilter.js
@@ -1,0 +1,11 @@
+export const PromptInjectionFilterAdapter = {
+  fromApi(apiData = {}) {
+    return {
+      enabled: Boolean(apiData.enabled),
+    };
+  },
+
+  toApi({ enabled } = {}) {
+    return { enabled };
+  },
+};

--- a/src/api/nexus/PromptInjectionFilter.js
+++ b/src/api/nexus/PromptInjectionFilter.js
@@ -1,0 +1,25 @@
+import request from '@/api/nexusaiRequest';
+import { PromptInjectionFilterAdapter } from '@/api/adapters/guardrails/promptInjectionFilter';
+
+export const PromptInjectionFilter = {
+  async read({ projectUuid }) {
+    const response = await request.$http.get(
+      `api/${projectUuid}/prompt-injection-filter/`,
+    );
+
+    return PromptInjectionFilterAdapter.fromApi(response.data);
+  },
+
+  async update({ projectUuid, data, requestOptions = {} }) {
+    const response = await request.$http.patch(
+      `api/${projectUuid}/prompt-injection-filter/`,
+      PromptInjectionFilterAdapter.toApi(data),
+      {
+        hideGenericErrorAlert: true,
+        ...requestOptions,
+      },
+    );
+
+    return PromptInjectionFilterAdapter.fromApi(response.data);
+  },
+};

--- a/src/api/nexus/__tests__/PromptInjectionFilter.spec.js
+++ b/src/api/nexus/__tests__/PromptInjectionFilter.spec.js
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { PromptInjectionFilter } from '@/api/nexus/PromptInjectionFilter';
+import request from '@/api/nexusaiRequest';
+
+vi.mock('@/api/nexusaiRequest', () => ({
+  default: {
+    $http: {
+      get: vi.fn(),
+      patch: vi.fn(),
+    },
+  },
+}));
+
+const apiFilter = {
+  enabled: true,
+  writable: true,
+};
+
+describe('PromptInjectionFilter API', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requests and normalizes the prompt injection filter', async () => {
+    request.$http.get.mockResolvedValue({ data: apiFilter });
+
+    const result = await PromptInjectionFilter.read({
+      projectUuid: 'project-uuid',
+    });
+
+    expect(request.$http.get).toHaveBeenCalledWith(
+      'api/project-uuid/prompt-injection-filter/',
+    );
+    expect(result).toEqual({
+      enabled: true,
+    });
+  });
+
+  it('patches with enabled and returns normalized filter without writable', async () => {
+    request.$http.patch.mockResolvedValue({ data: apiFilter });
+
+    const result = await PromptInjectionFilter.update({
+      projectUuid: 'project-uuid',
+      data: { enabled: false },
+    });
+
+    expect(request.$http.patch).toHaveBeenCalledWith(
+      'api/project-uuid/prompt-injection-filter/',
+      { enabled: false },
+      { hideGenericErrorAlert: true },
+    );
+    expect(result).toEqual({ enabled: true });
+    expect(result).not.toHaveProperty('writable');
+  });
+});

--- a/src/api/nexusaiAPI.js
+++ b/src/api/nexusaiAPI.js
@@ -6,6 +6,7 @@ import { Knowledge } from './nexus/Knowledge';
 import { Simulation } from './nexus/Simulation';
 import { FeatureFlags } from './nexus/FeatureFlags';
 import { GuardrailsConfig } from './nexus/GuardrailsConfig';
+import { PromptInjectionFilter } from './nexus/PromptInjectionFilter';
 
 import { ProgressiveFeedbackAdapter } from './adapters/tunings/progressiveFeedback';
 import { ComponentsAdapter } from './adapters/tunings/components';
@@ -238,6 +239,7 @@ export default {
     },
 
     guardrails_config: GuardrailsConfig,
+    prompt_injection_filter: PromptInjectionFilter,
 
     profile: {
       read({ projectUuid }) {

--- a/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsAllowTopicsDialog.vue
+++ b/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsAllowTopicsDialog.vue
@@ -61,6 +61,10 @@ const props = defineProps({
     type: Array,
     required: true,
   },
+  promptInjectionOnly: {
+    type: Boolean,
+    default: false,
+  },
   loading: {
     type: Boolean,
     default: false,
@@ -87,7 +91,16 @@ function translateAllowTopics(key) {
 }
 
 const title = computed(() => translateAllowTopics('title'));
-const description = computed(() => translateAllowTopics('description'));
+
+const description = computed(() => {
+  if (props.promptInjectionOnly) {
+    return t(
+      'agents.instructions.safety_guardrails.allow_topics.prompt_injection.description',
+    );
+  }
+
+  return translateAllowTopics('description');
+});
 </script>
 
 <style scoped lang="scss">

--- a/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue
+++ b/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsDrawer.vue
@@ -78,6 +78,12 @@
           v-model="draftBlockMessage"
           :maxLength="BLOCK_MESSAGE_MAX_LENGTH"
         />
+
+        <SafetyGuardrailsManipulationAttempts
+          v-if="!guardrailsStore.isLoading"
+          :modelValue="draftPromptInjectionEnabled"
+          @update:model-value="onPromptInjectionEnabledChange"
+        />
       </section>
 
       <UnnnicDrawerFooter>
@@ -105,6 +111,7 @@
   <SafetyGuardrailsAllowTopicsDialog
     v-model:open="isAllowTopicsDialogOpen"
     :topicNames="unblockedTopicNames"
+    :promptInjectionOnly="isPromptInjectionOnlyRemoval"
     :loading="guardrailsStore.isSaving"
     @confirm="onConfirmAllowTopics"
   />
@@ -118,6 +125,7 @@ import { useGuardrailsConfigStore } from '@/store/GuardrailsConfig';
 
 import SafetyGuardrailsAllowTopicsDialog from './SafetyGuardrailsAllowTopicsDialog.vue';
 import SafetyGuardrailsBlockMessage from './SafetyGuardrailsBlockMessage.vue';
+import SafetyGuardrailsManipulationAttempts from './SafetyGuardrailsManipulationAttempts.vue';
 import SafetyGuardrailsTopicList from './SafetyGuardrailsTopicList.vue';
 
 const BLOCK_MESSAGE_MAX_LENGTH = 250;
@@ -132,19 +140,42 @@ const guardrailsStore = useGuardrailsConfigStore();
 
 const draftTopics = ref([]);
 const draftBlockMessage = ref('');
+const draftPromptInjectionEnabled = ref(false);
 const snapshotTopics = ref([]);
 const snapshotBlockMessage = ref('');
+const snapshotPromptInjectionEnabled = ref(false);
 const isAllowTopicsDialogOpen = ref(false);
 const unblockedTopicIds = ref([]);
+const isPromptInjectionUnblocked = ref(false);
 
 const unblockedTopicNames = computed(() => {
-  return unblockedTopicIds.value.map((id) =>
+  const names = unblockedTopicIds.value.map((id) =>
     t(`agents.instructions.safety_guardrails.topics.${id}.name`),
   );
+
+  if (isPromptInjectionUnblocked.value) {
+    names.push(
+      t(
+        'agents.instructions.safety_guardrails.manipulation_attempts.prompt_injection.name',
+      ),
+    );
+  }
+
+  return names;
 });
+
+const isPromptInjectionOnlyRemoval = computed(
+  () =>
+    isPromptInjectionUnblocked.value && unblockedTopicIds.value.length === 0,
+);
 
 const isDirty = computed(() => {
   if (draftBlockMessage.value !== snapshotBlockMessage.value) return true;
+  if (
+    draftPromptInjectionEnabled.value !== snapshotPromptInjectionEnabled.value
+  ) {
+    return true;
+  }
 
   return draftTopics.value.some((topic, index) => {
     return topic.enabled !== snapshotTopics.value[index]?.enabled;
@@ -186,18 +217,24 @@ function getUnblockedTopicIds() {
 async function loadDraft() {
   draftTopics.value = [];
   draftBlockMessage.value = '';
+  draftPromptInjectionEnabled.value = false;
   snapshotTopics.value = [];
   snapshotBlockMessage.value = '';
+  snapshotPromptInjectionEnabled.value = false;
   isAllowTopicsDialogOpen.value = false;
   unblockedTopicIds.value = [];
+  isPromptInjectionUnblocked.value = false;
 
   try {
     await guardrailsStore.fetchConfig();
 
     draftTopics.value = cloneTopics(guardrailsStore.topics);
     draftBlockMessage.value = guardrailsStore.blockingMessage;
+    draftPromptInjectionEnabled.value = guardrailsStore.promptInjectionEnabled;
     snapshotTopics.value = cloneTopics(guardrailsStore.topics);
     snapshotBlockMessage.value = guardrailsStore.blockingMessage;
+    snapshotPromptInjectionEnabled.value =
+      guardrailsStore.promptInjectionEnabled;
   } catch {
     close();
   }
@@ -210,6 +247,12 @@ function onTopicEnabledChange({ id, enabled }) {
   if (topic) topic.enabled = enabled;
 }
 
+function onPromptInjectionEnabledChange(enabled) {
+  if (!guardrailsStore.writable) return;
+
+  draftPromptInjectionEnabled.value = enabled;
+}
+
 async function persistChanges() {
   const categoryStates = guardrailsStore.buildCategoryStatesDiff(
     draftTopics.value,
@@ -217,8 +260,14 @@ async function persistChanges() {
   );
   const blockingMessageChanged =
     draftBlockMessage.value !== snapshotBlockMessage.value;
+  const promptInjectionChanged =
+    draftPromptInjectionEnabled.value !== snapshotPromptInjectionEnabled.value;
 
-  if (Object.keys(categoryStates).length === 0 && !blockingMessageChanged) {
+  if (
+    Object.keys(categoryStates).length === 0 &&
+    !blockingMessageChanged &&
+    !promptInjectionChanged
+  ) {
     return;
   }
 
@@ -232,6 +281,10 @@ async function persistChanges() {
     payload.blockingMessage = draftBlockMessage.value;
   }
 
+  if (promptInjectionChanged) {
+    payload.promptInjectionEnabled = draftPromptInjectionEnabled.value;
+  }
+
   await guardrailsStore.updateConfig(payload);
   close();
 }
@@ -240,9 +293,13 @@ async function save() {
   if (!canSave.value) return;
 
   const unblockedIds = getUnblockedTopicIds();
+  const promptInjectionWasUnblocked =
+    snapshotPromptInjectionEnabled.value === true &&
+    draftPromptInjectionEnabled.value === false;
 
-  if (unblockedIds.length > 0) {
+  if (unblockedIds.length > 0 || promptInjectionWasUnblocked) {
     unblockedTopicIds.value = unblockedIds;
+    isPromptInjectionUnblocked.value = promptInjectionWasUnblocked;
     isAllowTopicsDialogOpen.value = true;
     return;
   }

--- a/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsManipulationAttempts.vue
+++ b/src/components/Instructions/SafetyGuardrails/SafetyGuardrailsManipulationAttempts.vue
@@ -1,0 +1,89 @@
+<template>
+  <section
+    class="safety-guardrails-manipulation-attempts"
+    data-testid="safety-guardrails-manipulation-attempts"
+  >
+    <h3
+      class="safety-guardrails-manipulation-attempts__title"
+      data-testid="safety-guardrails-manipulation-attempts-title"
+    >
+      {{
+        $t('agents.instructions.safety_guardrails.manipulation_attempts.title')
+      }}
+    </h3>
+
+    <div class="safety-guardrails-manipulation-attempts__row">
+      <UnnnicSwitch
+        class="safety-guardrails-manipulation-attempts__switch"
+        :modelValue="modelValue"
+        :textRight="
+          $t(
+            'agents.instructions.safety_guardrails.manipulation_attempts.prompt_injection.name',
+          )
+        "
+        :helper="
+          $t(
+            'agents.instructions.safety_guardrails.manipulation_attempts.prompt_injection.description',
+          )
+        "
+        data-testid="safety-guardrails-manipulation-attempts-switch"
+        @update:model-value="emit('update:modelValue', $event)"
+      />
+
+      <p
+        class="safety-guardrails-manipulation-attempts__status"
+        data-testid="safety-guardrails-manipulation-attempts-status"
+      >
+        {{
+          $t(
+            `agents.instructions.safety_guardrails.${
+              modelValue ? 'blocked' : 'allowed'
+            }`,
+          )
+        }}
+      </p>
+    </div>
+  </section>
+</template>
+
+<script setup>
+defineProps({
+  modelValue: {
+    type: Boolean,
+    default: false,
+  },
+});
+
+const emit = defineEmits(['update:modelValue']);
+</script>
+
+<style lang="scss" scoped>
+.safety-guardrails-manipulation-attempts {
+  padding-top: $unnnic-space-6;
+
+  display: flex;
+  flex-direction: column;
+  gap: $unnnic-space-4;
+
+  border-top: 1px solid $unnnic-color-border-base;
+
+  &__title {
+    @include unnnic-font-action;
+    color: $unnnic-color-fg-emphasized;
+  }
+
+  &__row {
+    display: flex;
+    gap: $unnnic-space-4;
+  }
+
+  &__switch {
+    flex: 1;
+  }
+
+  &__status {
+    @include unnnic-font-caption-1;
+    color: $unnnic-color-fg-muted;
+  }
+}
+</style>

--- a/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsAllowTopicsDialog.spec.js
+++ b/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsAllowTopicsDialog.spec.js
@@ -65,6 +65,21 @@ describe('SafetyGuardrailsAllowTopicsDialog.vue', () => {
     );
   });
 
+  it('renders prompt injection description when promptInjectionOnly is true', () => {
+    wrapper = createWrapper({
+      topicNames: ['Prompt injection'],
+      promptInjectionOnly: true,
+    });
+
+    expect(findTitle().text()).toBe(
+      allowTopicsT('title_single', { topic: 'Prompt injection' }),
+    );
+    expect(findDescription().text()).toBe(
+      allowTopicsT('prompt_injection.description'),
+    );
+    expect(findAllow().props('text')).toBe(allowTopicsT('confirm_button'));
+  });
+
   it('emits confirm when confirm button is clicked', async () => {
     wrapper = createWrapper();
 

--- a/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsDrawer.spec.js
+++ b/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsDrawer.spec.js
@@ -7,6 +7,7 @@ import SafetyGuardrailsDrawer from '../SafetyGuardrailsDrawer.vue';
 import SafetyGuardrailsTopicList from '../SafetyGuardrailsTopicList.vue';
 import SafetyGuardrailsBlockMessage from '../SafetyGuardrailsBlockMessage.vue';
 import SafetyGuardrailsAllowTopicsDialog from '../SafetyGuardrailsAllowTopicsDialog.vue';
+import SafetyGuardrailsManipulationAttempts from '../SafetyGuardrailsManipulationAttempts.vue';
 
 import nexusaiAPI from '@/api/nexusaiAPI';
 import i18n from '@/utils/plugins/i18n';
@@ -15,6 +16,10 @@ vi.mock('@/api/nexusaiAPI', () => ({
   default: {
     router: {
       guardrails_config: {
+        read: vi.fn(),
+        update: vi.fn(),
+      },
+      prompt_injection_filter: {
         read: vi.fn(),
         update: vi.fn(),
       },
@@ -41,11 +46,26 @@ const storeConfig = {
   writable: true,
 };
 
+const filterConfig = {
+  enabled: true,
+};
+
+const drawerStubs = {
+  UnnnicDrawerNext: false,
+  SafetyGuardrailsTopicList: true,
+  SafetyGuardrailsBlockMessage: true,
+  SafetyGuardrailsAllowTopicsDialog: true,
+  SafetyGuardrailsManipulationAttempts: true,
+};
+
 describe('SafetyGuardrailsDrawer.vue', () => {
   let wrapper;
 
   const createWrapper = async (props = {}) => {
     nexusaiAPI.router.guardrails_config.read.mockResolvedValue(storeConfig);
+    nexusaiAPI.router.prompt_injection_filter.read.mockResolvedValue(
+      filterConfig,
+    );
 
     wrapper = mount(SafetyGuardrailsDrawer, {
       props: {
@@ -59,12 +79,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
             stubActions: false,
           }),
         ],
-        stubs: {
-          UnnnicDrawerNext: false,
-          SafetyGuardrailsTopicList: true,
-          SafetyGuardrailsBlockMessage: true,
-          SafetyGuardrailsAllowTopicsDialog: true,
-        },
+        stubs: drawerStubs,
       },
     });
 
@@ -79,6 +94,8 @@ describe('SafetyGuardrailsDrawer.vue', () => {
   const findTopicList = () => wrapper.findComponent(SafetyGuardrailsTopicList);
   const findBlockMessage = () =>
     wrapper.findComponent(SafetyGuardrailsBlockMessage);
+  const findManipulationAttempts = () =>
+    wrapper.findComponent(SafetyGuardrailsManipulationAttempts);
   const findAllowTopicsDialog = () =>
     wrapper.findComponent(SafetyGuardrailsAllowTopicsDialog);
   const findDescriptionSkeleton = () =>
@@ -94,8 +111,13 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     vi.clearAllMocks();
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     wrapper?.unmount();
+    wrapper = undefined;
+    await flushPromises();
+    vi.useFakeTimers();
+    vi.runAllTimers();
+    vi.useRealTimers();
   });
 
   it('renders drawer title, description, topics, and block message from the store', async () => {
@@ -123,19 +145,27 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     );
 
     expect(nexusaiAPI.router.guardrails_config.read).toHaveBeenCalled();
+    expect(nexusaiAPI.router.prompt_injection_filter.read).toHaveBeenCalled();
     expect(findTopicList().props('topics')).toEqual(storeConfig.topics);
     expect(findTopicList().props('loading')).toBe(false);
     expect(findBlockMessage().props('modelValue')).toBe(
       storeConfig.blockingMessage,
     );
     expect(findBlockMessage().props('maxLength')).toBe(250);
+    expect(findManipulationAttempts().props('modelValue')).toBe(true);
   });
 
   it('passes loading true to the topic list while fetching', async () => {
     let resolveFetch;
+    let resolveFilter;
     nexusaiAPI.router.guardrails_config.read.mockReturnValue(
       new Promise((resolve) => {
         resolveFetch = resolve;
+      }),
+    );
+    nexusaiAPI.router.prompt_injection_filter.read.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFilter = resolve;
       }),
     );
 
@@ -148,12 +178,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
             stubActions: false,
           }),
         ],
-        stubs: {
-          UnnnicDrawerNext: false,
-          SafetyGuardrailsTopicList: true,
-          SafetyGuardrailsBlockMessage: true,
-          SafetyGuardrailsAllowTopicsDialog: true,
-        },
+        stubs: drawerStubs,
       },
     });
 
@@ -162,13 +187,16 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     expect(findTopicList().props('loading')).toBe(true);
     expect(findDescriptionSkeleton().exists()).toBe(true);
     expect(findBlockMessage().exists()).toBe(false);
+    expect(findManipulationAttempts().exists()).toBe(false);
 
     resolveFetch(storeConfig);
+    resolveFilter(filterConfig);
     await flushPromises();
 
     expect(findTopicList().props('loading')).toBe(false);
     expect(findDescriptionSkeleton().exists()).toBe(false);
     expect(findBlockMessage().exists()).toBe(true);
+    expect(findManipulationAttempts().exists()).toBe(true);
   });
 
   it('keeps Save disabled until a draft change is made', async () => {
@@ -196,6 +224,17 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     expect(findSave().props('disabled')).toBe(false);
   });
 
+  it('enables Save when the prompt injection switch changes', async () => {
+    await createWrapper();
+
+    expect(findSave().props('disabled')).toBe(true);
+
+    findManipulationAttempts().vm.$emit('update:modelValue', false);
+    await nextTick();
+
+    expect(findSave().props('disabled')).toBe(false);
+  });
+
   it('opens confirm dialog when saving with unblocked topics', async () => {
     await createWrapper();
 
@@ -211,6 +250,47 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     expect(nexusaiAPI.router.guardrails_config.update).not.toHaveBeenCalled();
     expect(findAllowTopicsDialog().props('open')).toBe(true);
     expect(findAllowTopicsDialog().props('topicNames')).toEqual(['Politics']);
+    expect(findAllowTopicsDialog().props('promptInjectionOnly')).toBe(false);
+  });
+
+  it('opens confirm dialog listing Prompt injection when it is turned off', async () => {
+    await createWrapper();
+
+    findManipulationAttempts().vm.$emit('update:modelValue', false);
+    await nextTick();
+
+    await findSave().trigger('click');
+    await nextTick();
+
+    expect(
+      nexusaiAPI.router.prompt_injection_filter.update,
+    ).not.toHaveBeenCalled();
+    expect(findAllowTopicsDialog().props('open')).toBe(true);
+    expect(findAllowTopicsDialog().props('topicNames')).toEqual([
+      'Prompt injection',
+    ]);
+    expect(findAllowTopicsDialog().props('promptInjectionOnly')).toBe(true);
+  });
+
+  it('sets promptInjectionOnly false when a topic is also unblocked', async () => {
+    await createWrapper();
+
+    findTopicList().vm.$emit('update:topic-enabled', {
+      id: 'politics',
+      enabled: false,
+    });
+    findManipulationAttempts().vm.$emit('update:modelValue', false);
+    await nextTick();
+
+    await findSave().trigger('click');
+    await nextTick();
+
+    expect(findAllowTopicsDialog().props('open')).toBe(true);
+    expect(findAllowTopicsDialog().props('topicNames')).toEqual([
+      'Politics',
+      'Prompt injection',
+    ]);
+    expect(findAllowTopicsDialog().props('promptInjectionOnly')).toBe(false);
   });
 
   it('saves after confirming allow topics dialog', async () => {
@@ -282,6 +362,31 @@ describe('SafetyGuardrailsDrawer.vue', () => {
     expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
   });
 
+  it('saves promptInjectionEnabled in the PATCH payload', async () => {
+    await createWrapper();
+    nexusaiAPI.router.prompt_injection_filter.update.mockResolvedValue({
+      enabled: false,
+    });
+
+    findManipulationAttempts().vm.$emit('update:modelValue', false);
+    await nextTick();
+
+    await findSave().trigger('click');
+    await nextTick();
+
+    findAllowTopicsDialog().vm.$emit('confirm');
+    await flushPromises();
+
+    expect(
+      nexusaiAPI.router.prompt_injection_filter.update,
+    ).toHaveBeenCalledWith({
+      projectUuid: 'project-uuid',
+      data: { enabled: false },
+    });
+    expect(nexusaiAPI.router.guardrails_config.update).not.toHaveBeenCalled();
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+  });
+
   it('emits update:modelValue false when Cancel is clicked', async () => {
     await createWrapper();
 
@@ -293,6 +398,9 @@ describe('SafetyGuardrailsDrawer.vue', () => {
   it('closes the drawer when fetch fails', async () => {
     nexusaiAPI.router.guardrails_config.read.mockRejectedValue(
       new Error('failed'),
+    );
+    nexusaiAPI.router.prompt_injection_filter.read.mockResolvedValue(
+      filterConfig,
     );
     const consoleError = vi
       .spyOn(console, 'error')
@@ -307,12 +415,7 @@ describe('SafetyGuardrailsDrawer.vue', () => {
             stubActions: false,
           }),
         ],
-        stubs: {
-          UnnnicDrawerNext: false,
-          SafetyGuardrailsTopicList: true,
-          SafetyGuardrailsBlockMessage: true,
-          SafetyGuardrailsAllowTopicsDialog: true,
-        },
+        stubs: drawerStubs,
       },
     });
 

--- a/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsManipulationAttempts.spec.js
+++ b/src/components/Instructions/SafetyGuardrails/__tests__/SafetyGuardrailsManipulationAttempts.spec.js
@@ -1,0 +1,74 @@
+import { shallowMount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import SafetyGuardrailsManipulationAttempts from '../SafetyGuardrailsManipulationAttempts.vue';
+import i18n from '@/utils/plugins/i18n.js';
+
+describe('SafetyGuardrailsManipulationAttempts.vue', () => {
+  let wrapper;
+
+  const createWrapper = (props = {}) =>
+    shallowMount(SafetyGuardrailsManipulationAttempts, {
+      props: {
+        modelValue: true,
+        ...props,
+      },
+    });
+
+  const findTitle = () =>
+    wrapper.find(
+      '[data-testid="safety-guardrails-manipulation-attempts-title"]',
+    );
+  const findSwitch = () =>
+    wrapper.findComponent(
+      '[data-testid="safety-guardrails-manipulation-attempts-switch"]',
+    );
+  const findStatus = () =>
+    wrapper.find(
+      '[data-testid="safety-guardrails-manipulation-attempts-status"]',
+    );
+
+  afterEach(() => {
+    wrapper?.unmount();
+  });
+
+  it('renders title, switch label, helper, and blocked status when enabled', () => {
+    wrapper = createWrapper({ modelValue: true });
+
+    expect(findTitle().text()).toBe(
+      i18n.global.t(
+        'agents.instructions.safety_guardrails.manipulation_attempts.title',
+      ),
+    );
+    expect(findSwitch().props('textRight')).toBe(
+      i18n.global.t(
+        'agents.instructions.safety_guardrails.manipulation_attempts.prompt_injection.name',
+      ),
+    );
+    expect(findSwitch().props('helper')).toBe(
+      i18n.global.t(
+        'agents.instructions.safety_guardrails.manipulation_attempts.prompt_injection.description',
+      ),
+    );
+    expect(findSwitch().props('modelValue')).toBe(true);
+    expect(findStatus().text()).toBe(
+      i18n.global.t('agents.instructions.safety_guardrails.blocked'),
+    );
+  });
+
+  it('renders allowed status when disabled', () => {
+    wrapper = createWrapper({ modelValue: false });
+
+    expect(findStatus().text()).toBe(
+      i18n.global.t('agents.instructions.safety_guardrails.allowed'),
+    );
+  });
+
+  it('emits update:modelValue when the switch changes', async () => {
+    wrapper = createWrapper({ modelValue: true });
+
+    await findSwitch().vm.$emit('update:model-value', false);
+
+    expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+  });
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -435,6 +435,9 @@
           "confirm_button": "Remove",
           "description_multiple": "Manager will be able to answer questions about {topics}. You can reactivate these extra blocks anytime",
           "description_single": "Manager will be able to answer questions about {topic}. You can reactivate this extra block anytime",
+          "prompt_injection": {
+            "description": "Removes the extra protection against tampering attempts. The Manager's native resistance remains in effect, but this lock won't catch attempts that the model allows to pass"
+          },
           "title_multiple": "Remove {count} extra blocks",
           "title_single": "Remove extra block for {topic}"
         },
@@ -453,6 +456,13 @@
             "on": "On: Manager refuses the topic and shows your block message."
           },
           "title": "Extra safety guardrails"
+        },
+        "manipulation_attempts": {
+          "prompt_injection": {
+            "description": "Attempts to override the Manager's instructions or make it act outside its role",
+            "name": "Prompt injection"
+          },
+          "title": "Manipulation attempts"
         },
         "save": "Save",
         "save_error": "Extra safety guardrails couldn't be updated due to a technical issue",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -435,6 +435,9 @@
           "confirm_button": "Eliminar",
           "description_multiple": "Manager podrá responder preguntas sobre {topics}. Puedes reactivar estos bloqueos adicionales en cualquier momento",
           "description_single": "Manager podrá responder preguntas sobre {topic}. Puedes reactivar este bloqueo adicional en cualquier momento",
+          "prompt_injection": {
+            "description": "Elimina la protección extra contra intentos de manipulación. La resistencia nativa del Manager sigue vigente, pero este bloqueo no detendrá los intentos que el modelo deje pasar"
+          },
           "title_multiple": "Eliminar {count} bloqueos adicionales",
           "title_single": "Eliminar bloqueo adicional para {topic}"
         },
@@ -453,6 +456,13 @@
             "on": "Activado: Manager se niega a discutir el tema y muestra tu mensaje de bloqueo."
           },
           "title": "Capas adicionales de seguridad"
+        },
+        "manipulation_attempts": {
+          "prompt_injection": {
+            "description": "Intentos de anular las instrucciones del Manager o hacerlo actuar fuera de su función",
+            "name": "Inyección de prompt"
+          },
+          "title": "Intentos de manipulación"
         },
         "save": "Guardar",
         "save_error": "No se pudieron actualizar las capas adicionales de seguridad debido a un problema técnico",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -435,6 +435,9 @@
           "confirm_button": "Remover",
           "description_multiple": "O Manager poderá responder perguntas sobre {topics}. Você pode reativar esses bloqueios extras a qualquer momento",
           "description_single": "O Manager poderá responder perguntas sobre {topic}. Você pode reativar esse bloqueio extra a qualquer momento",
+          "prompt_injection": {
+            "description": "Remove a proteção extra contra tentativas de manipulação. A resistência nativa do Manager continua em vigor, mas esse bloqueio não vai barrar tentativas que o modelo deixar passar"
+          },
           "title_multiple": "Remover {count} bloqueios extras",
           "title_single": "Remover bloqueio extra para {topic}"
         },
@@ -453,6 +456,13 @@
             "on": "Ativado: o Manager se recusa a discutir o tópico e mostra sua mensagem de bloqueio."
           },
           "title": "Camadas extras de segurança"
+        },
+        "manipulation_attempts": {
+          "prompt_injection": {
+            "description": "Tentativas de substituir as instruções do Manager ou fazê-lo agir fora de sua função",
+            "name": "Injeção de prompt"
+          },
+          "title": "Tentativas de manipulação"
         },
         "save": "Salvar",
         "save_error": "Não foi possível atualizar as camadas extras de segurança devido a um problema técnico",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -434,6 +434,9 @@
           "confirm_button": "Elimină",
           "description_multiple": "Manager va putea răspunde la întrebări despre {topics}. Poți reactiva aceste blocări suplimentare oricând",
           "description_single": "Manager va putea răspunde la întrebări despre {topic}. Poți reactiva această blocare suplimentară oricând",
+          "prompt_injection": {
+            "description": "Elimină protecția suplimentară împotriva tentativelor de manipulare. Rezistența nativă a Manager-ului rămâne în vigoare, dar această blocare nu va opri tentativele pe care modelul le lasă să treacă"
+          },
           "title_multiple": "Elimină {count} blocări suplimentare",
           "title_single": "Elimină blocarea suplimentară pentru {topic}"
         },
@@ -452,6 +455,13 @@
             "on": "Activat: Manager refuză să discute subiectul și afișează mesajul tău de blocare."
           },
           "title": "Măsuri suplimentare de siguranță"
+        },
+        "manipulation_attempts": {
+          "prompt_injection": {
+            "description": "Tentative de a înlocui instrucțiunile Manager-ului sau de a-l face să acționeze în afara rolului său",
+            "name": "Injecție de prompt"
+          },
+          "title": "Tentative de manipulare"
         },
         "save": "Salva",
         "save_error": "Măsuri suplimentare de siguranță nu au putut fi actualizate din cauza unei probleme tehnice",

--- a/src/store/GuardrailsConfig.js
+++ b/src/store/GuardrailsConfig.js
@@ -14,6 +14,7 @@ export const useGuardrailsConfigStore = defineStore('GuardrailsConfig', () => {
   const topics = ref([]);
   const blockingMessage = ref('');
   const writable = ref(false);
+  const promptInjectionEnabled = ref(false);
   const status = ref(null);
 
   const isLoading = computed(() => status.value === 'loading');
@@ -29,11 +30,17 @@ export const useGuardrailsConfigStore = defineStore('GuardrailsConfig', () => {
     status.value = 'loading';
 
     try {
-      const config = await nexusaiAPI.router.guardrails_config.read({
-        projectUuid: projectUuid.value,
-      });
+      const [config, filter] = await Promise.all([
+        nexusaiAPI.router.guardrails_config.read({
+          projectUuid: projectUuid.value,
+        }),
+        nexusaiAPI.router.prompt_injection_filter.read({
+          projectUuid: projectUuid.value,
+        }),
+      ]);
 
       setConfig(config);
+      promptInjectionEnabled.value = filter.enabled;
       status.value = 'success';
       return config;
     } catch (error) {
@@ -43,35 +50,61 @@ export const useGuardrailsConfigStore = defineStore('GuardrailsConfig', () => {
     }
   }
 
+  async function saveGuardrailsConfig({
+    categoryStates,
+    blockingMessage: nextBlockingMessage,
+  }) {
+    const data = {};
+
+    if (categoryStates) data.categoryStates = categoryStates;
+    if (typeof nextBlockingMessage === 'string') {
+      data.blockingMessage = nextBlockingMessage;
+    }
+
+    if (Object.keys(data).length === 0) return;
+
+    setConfig(
+      await nexusaiAPI.router.guardrails_config.update({
+        projectUuid: projectUuid.value,
+        data,
+      }),
+    );
+  }
+
+  async function savePromptInjectionFilter(enabled) {
+    if (typeof enabled !== 'boolean') return;
+
+    const filter = await nexusaiAPI.router.prompt_injection_filter.update({
+      projectUuid: projectUuid.value,
+      data: { enabled },
+    });
+
+    promptInjectionEnabled.value = filter.enabled;
+  }
+
   /**
    * @param {{
    *   categoryStates?: Record<string, boolean>,
    *   blockingMessage?: string,
+   *   promptInjectionEnabled?: boolean,
    * }} params
    */
   async function updateConfig({
     categoryStates,
     blockingMessage: nextBlockingMessage,
+    promptInjectionEnabled: enabled,
   } = {}) {
     status.value = 'saving';
 
-    const data = {};
-
-    if (categoryStates) {
-      data.categoryStates = categoryStates;
-    }
-
-    if (typeof nextBlockingMessage === 'string') {
-      data.blockingMessage = nextBlockingMessage;
-    }
-
     try {
-      const config = await nexusaiAPI.router.guardrails_config.update({
-        projectUuid: projectUuid.value,
-        data,
-      });
+      await Promise.all([
+        saveGuardrailsConfig({
+          categoryStates,
+          blockingMessage: nextBlockingMessage,
+        }),
+        savePromptInjectionFilter(enabled),
+      ]);
 
-      setConfig(config);
       status.value = 'success';
 
       alertStore.add({
@@ -80,8 +113,6 @@ export const useGuardrailsConfigStore = defineStore('GuardrailsConfig', () => {
           'agents.instructions.safety_guardrails.save_success',
         ),
       });
-
-      return config;
     } catch (error) {
       status.value = 'error';
 
@@ -116,6 +147,7 @@ export const useGuardrailsConfigStore = defineStore('GuardrailsConfig', () => {
     topics,
     blockingMessage,
     writable,
+    promptInjectionEnabled,
     status,
     isLoading,
     isSaving,

--- a/src/store/__tests__/GuardrailsConfig.unit.spec.js
+++ b/src/store/__tests__/GuardrailsConfig.unit.spec.js
@@ -21,6 +21,10 @@ vi.mock('@/api/nexusaiAPI', () => ({
         read: vi.fn(),
         update: vi.fn(),
       },
+      prompt_injection_filter: {
+        read: vi.fn(),
+        update: vi.fn(),
+      },
     },
   },
 }));
@@ -32,6 +36,10 @@ const storeConfig = {
   ],
   blockingMessage: 'Blocked message',
   writable: true,
+};
+
+const filterConfig = {
+  enabled: true,
 };
 
 describe('GuardrailsConfig store', () => {
@@ -50,29 +58,40 @@ describe('GuardrailsConfig store', () => {
     expect(store.topics).toEqual([]);
     expect(store.blockingMessage).toBe('');
     expect(store.writable).toBe(false);
+    expect(store.promptInjectionEnabled).toBe(false);
     expect(store.status).toBeNull();
   });
 
   describe('fetchConfig', () => {
-    it('loads normalized config into the store', async () => {
+    it('loads normalized config and filter in parallel', async () => {
       nexusaiAPI.router.guardrails_config.read.mockResolvedValue(storeConfig);
+      nexusaiAPI.router.prompt_injection_filter.read.mockResolvedValue(
+        filterConfig,
+      );
 
       await store.fetchConfig();
 
       expect(nexusaiAPI.router.guardrails_config.read).toHaveBeenCalledWith({
         projectUuid: 'project-uuid',
       });
+      expect(
+        nexusaiAPI.router.prompt_injection_filter.read,
+      ).toHaveBeenCalledWith({
+        projectUuid: 'project-uuid',
+      });
       expect(store.topics).toEqual(storeConfig.topics);
       expect(store.blockingMessage).toBe('Blocked message');
       expect(store.writable).toBe(true);
+      expect(store.promptInjectionEnabled).toBe(true);
       expect(store.status).toBe('success');
     });
 
-    it('sets error status when the request fails', async () => {
+    it('sets error status when either request fails', async () => {
       const consoleError = vi
         .spyOn(console, 'error')
         .mockImplementation(() => {});
-      nexusaiAPI.router.guardrails_config.read.mockRejectedValue(
+      nexusaiAPI.router.guardrails_config.read.mockResolvedValue(storeConfig);
+      nexusaiAPI.router.prompt_injection_filter.read.mockRejectedValue(
         new Error('failed'),
       );
 
@@ -84,7 +103,7 @@ describe('GuardrailsConfig store', () => {
   });
 
   describe('updateConfig', () => {
-    it('sends camelCase data and updates local state', async () => {
+    it('patches only the guardrails config when categories change', async () => {
       nexusaiAPI.router.guardrails_config.update.mockResolvedValue({
         ...storeConfig,
         topics: [
@@ -103,6 +122,9 @@ describe('GuardrailsConfig store', () => {
           categoryStates: { politics: false },
         },
       });
+      expect(
+        nexusaiAPI.router.prompt_injection_filter.update,
+      ).not.toHaveBeenCalled();
       expect(store.topics).toEqual([
         { id: 'politics', enabled: false },
         { id: 'hate', enabled: false },
@@ -110,7 +132,45 @@ describe('GuardrailsConfig store', () => {
       expect(store.status).toBe('success');
     });
 
-    it('shows an error alert and rethrows when the request fails', async () => {
+    it('patches only the prompt injection filter when enabled changes', async () => {
+      nexusaiAPI.router.prompt_injection_filter.update.mockResolvedValue({
+        enabled: false,
+      });
+
+      await store.updateConfig({
+        promptInjectionEnabled: false,
+      });
+
+      expect(
+        nexusaiAPI.router.prompt_injection_filter.update,
+      ).toHaveBeenCalledWith({
+        projectUuid: 'project-uuid',
+        data: { enabled: false },
+      });
+      expect(nexusaiAPI.router.guardrails_config.update).not.toHaveBeenCalled();
+      expect(store.promptInjectionEnabled).toBe(false);
+      expect(store.status).toBe('success');
+    });
+
+    it('patches both endpoints when both change', async () => {
+      nexusaiAPI.router.guardrails_config.update.mockResolvedValue(storeConfig);
+      nexusaiAPI.router.prompt_injection_filter.update.mockResolvedValue({
+        enabled: true,
+      });
+
+      await store.updateConfig({
+        blockingMessage: 'Updated message',
+        promptInjectionEnabled: true,
+      });
+
+      expect(nexusaiAPI.router.guardrails_config.update).toHaveBeenCalled();
+      expect(
+        nexusaiAPI.router.prompt_injection_filter.update,
+      ).toHaveBeenCalled();
+      expect(store.status).toBe('success');
+    });
+
+    it('shows an error alert and rethrows when either request fails', async () => {
       const error = new Error('failed');
       nexusaiAPI.router.guardrails_config.update.mockRejectedValue(error);
 


### PR DESCRIPTION
### Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [x] Locales

### Why

Agents can be vulnerable to prompt injection attacks, where users attempt to override the Manager's instructions or make it act outside its defined role. This change introduces a toggleable guardrail that allows users to enable or disable prompt injection detection directly from the Safety Guardrails drawer.

### What Changed

- Added a `PromptInjectionFilterAdapter` that normalizes API data by coercing `enabled` to a boolean and stripping non-writable fields.
- Added a `PromptInjectionFilter` API module exposing `read` and `update` methods against the `prompt-injection-filter/` endpoint.
- Exposed `prompt_injection_filter` through the central `nexusaiAPI` router.
- Extended the `GuardrailsConfig` store to fetch the prompt injection filter in parallel with the guardrails config, store `promptInjectionEnabled`, and save it independently via a dedicated `savePromptInjectionFilter` helper. The `updateConfig` action now calls both endpoints concurrently only when each has changed.
- Added a `SafetyGuardrailsManipulationAttempts` component that renders a titled section with a toggle switch and a blocked/allowed status label for the prompt injection guardrail.
- Integrated `SafetyGuardrailsManipulationAttempts` into `SafetyGuardrailsDrawer`, wiring up draft/snapshot state, dirty detection, the confirmation dialog (which now lists "Prompt injection" when it is turned off), and the save payload.
- Added locale strings for the new "Manipulation attempts" section and "Prompt injection" entry in English, Spanish, Portuguese, and Romanian.

### Diagram

```mermaid
flowchart TD
    Drawer["SafetyGuardrailsDrawer"]
    ManipComp["SafetyGuardrailsManipulationAttempts"]
    Store["GuardrailsConfig Store"]
    GCApi["guardrails_config API"]
    PIApi["prompt_injection_filter API"]

    Drawer --> ManipComp
    Drawer --> Store
    Store -->|Promise.all| GCApi
    Store -->|Promise.all| PIApi
    Store -->|saveGuardrailsConfig| GCApi
    Store -->|savePromptInjectionFilter| PIApi
```

### Demonstration  
![image.png](https://app.graphite.com/user-attachments/assets/ae7e0a4d-0d0c-4f5b-9b7b-f2012312bc8a.png)

