### PR TITLE
Add and update translations from PR#200

### DIFF
--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instrucciones",
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
+      "new_instruction": "Nueva instrucción",
       "export_instructions": {
         "title": "Exportar instrucciones",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "El archivo CSV está listo en la carpeta de descargas",
         "success_alert_title": "Instrucciones exportadas"
       },
-      "new_instruction": "Nueva instrucción",
       "delete_category": {
         "modal_title": "Eliminar categoría",
         "modal_description": "{count} de {name} a Sin categoría. No se eliminará nada, solo se quita la etiqueta de la categoría.",
@@ -402,10 +402,10 @@
           "suggested_category": "Categoría sugerida",
           "issues": "Problemas encontrados",
           "issues_types": {
-            "duplicate": "Duplicado",
-            "conflicts": "Conflicto",
+            "duplicate": "Duplicación",
+            "conflicts": "Conflicto de instrucciones",
             "ambiguity": "Ambigüedad",
-            "lack_of_clarity": "Claridad",
+            "lack_of_clarity": "Falta de claridad",
             "no_issues_found": "Todo bien. No se encontraron problemas."
           },
           "suggested_rewrite": "Reescritura sugerida",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instruções",
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
+      "new_instruction": "Nova instrução",
       "export_instructions": {
         "title": "Exportar instruções",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "O arquivo CSV está pronto na pasta de downloads",
         "success_alert_title": "Instruções exportadas"
       },
-      "new_instruction": "Nova instrução",
       "delete_category": {
         "modal_title": "Excluir categoria",
         "modal_description": "{count} de {name} para Sem categoria. Nada será excluído, apenas o rótulo da categoria é removido.",
@@ -397,15 +397,15 @@
         "cancel": "Cancelar",
         "ai_analysis": {
           "error": "Não foi possível validar a instrução. Tente novamente.",
-          "title": "Análise de IA",
+          "title": "Análise da IA",
           "validating": "Validando instrução...",
           "suggested_category": "Categoria sugerida",
           "issues": "Problemas encontrados",
           "issues_types": {
-            "duplicate": "Duplicado",
-            "conflicts": "Conflitos",
+            "duplicate": "Duplicação",
+            "conflicts": "Conflito de instruções",
             "ambiguity": "Ambiguidade",
-            "lack_of_clarity": "Clareza",
+            "lack_of_clarity": "Falta de clareza",
             "no_issues_found": "Tudo certo. Nenhum problema encontrado."
           },
           "suggested_rewrite": "Reescrita sugerida",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -344,6 +344,7 @@
     "instructions": {
       "title": "Instrucțiuni",
       "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
+      "new_instruction": "Instrucțiune nouă",
       "export_instructions": {
         "title": "Exportă instrucțiuni",
         "cancel_button": "Anulează",
@@ -353,7 +354,6 @@
         "success_alert_description": "Fișierul CSV este gata în folderul de descărcări",
         "success_alert_title": "Instrucțiuni exportate"
       },
-      "new_instruction": "Instrucțiune nouă",
       "delete_category": {
         "modal_title": "Șterge categoria",
         "modal_description": "{count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
@@ -396,7 +396,7 @@
         "cancel": "Anulează",
         "ai_analysis": {
           "error": "Instrucțiunea nu a putut fi validată. Încearcă din nou.",
-          "title": "Analiză AI",
+          "title": "Analiză IA",
           "validating": "Se validează instrucțiunea...",
           "suggested_category": "Categorie sugerată",
           "issues": "Probleme găsite",


### PR DESCRIPTION
Add and update translations from [PR#200](https://github.com/weni-ai/agent-builder-webapp/pull/200). Tracked in [LOC-27378](https://vtex-dev.atlassian.net/browse/LOC-27378).

Updates approved Crowdin strings in en, pt-BR, es-MX, and ro.