### PR TITLE
Add and update translations from PR#208

### DIFF
--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instrucciones",
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
+      "new_instruction": "Nueva instrucción",
       "export_instructions": {
         "title": "Exportar instrucciones",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "El archivo CSV está listo en la carpeta de descargas",
         "success_alert_title": "Instrucciones exportadas"
       },
-      "new_instruction": "Nueva instrucción",
       "delete_category": {
         "modal_title": "Eliminar categoría",
         "modal_description": "{count} de {name} a Sin categoría. No se eliminará nada, solo se quita la etiqueta de la categoría.",
@@ -413,7 +413,7 @@
           "undo_button": "Deshacer",
           "apply_button": "Aplicar",
           "category": {
-            "new_badge": "Nueva",
+            "new_badge": "Nuevo",
             "suggested_category": "Categoría sugerida",
             "other_categories": "Otras categorías",
             "create_action": "Nueva categoría",
@@ -425,7 +425,7 @@
             "validation": {
               "already_exists": "Ingresa un nombre de categoría que no exista",
               "invalid_chars": "Usa solo letras, números, espacios y guiones",
-              "required": "Completa este campo"
+              "required": "Llena este campo"
             }
           }
         }

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instruções",
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
+      "new_instruction": "Nova instrução",
       "export_instructions": {
         "title": "Exportar instruções",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "O arquivo CSV está pronto na pasta de downloads",
         "success_alert_title": "Instruções exportadas"
       },
-      "new_instruction": "Nova instrução",
       "delete_category": {
         "modal_title": "Excluir categoria",
         "modal_description": "{count} de {name} para Sem categoria. Nada será excluído, apenas o rótulo da categoria é removido.",
@@ -424,7 +424,7 @@
             "create": "Criar",
             "validation": {
               "already_exists": "Insira um nome de categoria que não exista",
-              "invalid_chars": "Use apenas letras, números, espaços e hifens",
+              "invalid_chars": "Use apenas letras, números, espaços e hífens",
               "required": "Preencha este campo"
             }
           }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -344,6 +344,7 @@
     "instructions": {
       "title": "Instrucțiuni",
       "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
+      "new_instruction": "Instrucțiune nouă",
       "export_instructions": {
         "title": "Exportă instrucțiuni",
         "cancel_button": "Anulează",
@@ -353,7 +354,6 @@
         "success_alert_description": "Fișierul CSV este gata în folderul de descărcări",
         "success_alert_title": "Instrucțiuni exportate"
       },
-      "new_instruction": "Instrucțiune nouă",
       "delete_category": {
         "modal_title": "Șterge categoria",
         "modal_description": "{count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
@@ -412,7 +412,7 @@
           "undo_button": "Anulează",
           "apply_button": "Aplică",
           "category": {
-            "new_badge": "Nouă",
+            "new_badge": "Nou",
             "suggested_category": "Categorie sugerată",
             "other_categories": "Alte categorii",
             "create_action": "Nouă categorie",


### PR DESCRIPTION
Add and update translations from [PR#208](https://github.com/weni-ai/agent-builder-webapp/pull/208). Tracked in [LOC-27379](https://vtex-dev.atlassian.net/browse/LOC-27379).

Updates approved Crowdin strings in en, pt-BR, es-MX, and ro.