### PR TITLE
Add and update translations from PR#212

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -377,7 +377,7 @@
           "category": "Category",
           "instruction": "Instruction"
         },
-        "locked_tooltip": "Default instructions can't be edited or removed",
+        "locked_tooltip": "Default instructions can't be edited or deleted",
         "results_count": "{count, plural, =0 {No instructions found} one {{count} instruction found} other {{count} instructions found}}",
         "search_placeholder": "Search...",
         "segmented": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instruções",
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
+      "new_instruction": "Nova instrução",
       "export_instructions": {
         "title": "Exportar instruções",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "O arquivo CSV está pronto na pasta de downloads",
         "success_alert_title": "Instruções exportadas"
       },
-      "new_instruction": "Nova instrução",
       "delete_category": {
         "modal_title": "Excluir categoria",
         "modal_description": "{count} de {name} para Sem categoria. Nada será excluído, apenas o rótulo da categoria é removido.",
@@ -372,7 +372,7 @@
         "default_instruction": "Instrução padrão",
         "default_instructions": "Instruções padrão",
         "delete_category": "Excluir categoria",
-        "empty_category": "Ainda não há instruções nesta categoria",
+        "empty_category": "Nenhuma instrução nesta categoria ainda",
         "list_columns": {
           "category": "Categoria",
           "instruction": "Instrução"

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -376,7 +376,7 @@
           "category": "Categorie",
           "instruction": "Instrucțiune"
         },
-        "locked_tooltip": "Instrucțiunile implicite nu pot fi editate sau eliminate",
+        "locked_tooltip": "Instrucțiunile implicite nu pot fi editate sau șterse",
         "results_count": "{count, plural, =0 {Nu s-au găsit instrucțiuni} one {{count} instrucțiune găsită} few {{count} instrucțiuni găsite} other {{count} de instrucțiuni găsite}}",
         "search_placeholder": "Caută...",
         "segmented": {


### PR DESCRIPTION
Add and update translations from [PR#212](https://github.com/weni-ai/agent-builder-webapp/pull/212). Tracked in [LOC-27382](https://vtex-dev.atlassian.net/browse/LOC-27382).

Updates approved Crowdin strings in en, pt-BR, es-MX, and ro.