### PR TITLE
Add and update translations from PR#218

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -357,7 +357,7 @@
       },
       "delete_category": {
         "modal_title": "Delete category",
-        "modal_description": "{count} from {name} to Uncategorized. Nothing will be deleted, only the category label is removed.",
+        "modal_description": "Move {count} from {name} to Uncategorized. Nothing will be deleted, only the category label will be removed.",
         "modal_description_empty": "{name} has no instructions. Deleting it will only remove it from your list",
         "instructions_count": "{count, plural, one {{count} instruction will be moved} other {{count} instructions will be moved}}",
         "cancel": "Cancel",
@@ -366,7 +366,7 @@
         "success_description": "{count, plural, one {{count} instruction moved to Uncategorized} other {{count} instructions moved to Uncategorized}}",
         "success_description_empty": "Removed from your list",
         "error_title": "Couldn't delete category",
-        "error_description": "Something went wrong and nothing was changed. Try again."
+        "error_description": "Something went wrong. Try again."
       },
       "view": {
         "default_instruction": "Default instruction",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instrucciones",
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
+      "new_instruction": "Nueva instrucción",
       "export_instructions": {
         "title": "Exportar instrucciones",
         "cancel_button": "Cancelar",
@@ -354,19 +355,18 @@
         "success_alert_description": "El archivo CSV está listo en la carpeta de descargas",
         "success_alert_title": "Instrucciones exportadas"
       },
-      "new_instruction": "Nueva instrucción",
       "delete_category": {
         "modal_title": "Eliminar categoría",
-        "modal_description": "{count} de {name} a Sin categoría. No se eliminará nada, solo se quita la etiqueta de la categoría.",
+        "modal_description": "Mover {count} de {name} a Sin categoría. No se eliminará nada, solo se removerá la etiqueta de categoría.",
         "modal_description_empty": "{name} no tiene instrucciones. Eliminarla solo la quitará de tu lista",
-        "instructions_count": "{count, plural, one {{count} instrucción se moverá} other {{count} instrucciones se moverán}}",
+        "instructions_count": "{count, plural, one {Se moverá {count} instrucción} other {Se moverán {count} instrucciones}}",
         "cancel": "Cancelar",
         "confirm": "Eliminar categoría",
         "success_title": "Categoría eliminada",
-        "success_description": "{count, plural, one {{count} instrucción movida a Sin categoría} other {{count} instrucciones movidas a Sin categoría}}",
+        "success_description": "{count, plural, one {Se movió {count} instrucción a Sin categoría} other {Se movieron {count} instrucciones a Sin categoría}}",
         "success_description_empty": "Eliminada de tu lista",
         "error_title": "No se pudo eliminar la categoría",
-        "error_description": "Algo salió mal y no se cambió nada. Inténtalo de nuevo."
+        "error_description": "Se produjo un error. Vuelve a intentarlo."
       },
       "view": {
         "default_instruction": "Instrucción predeterminada",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instruções",
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
+      "new_instruction": "Nova instrução",
       "export_instructions": {
         "title": "Exportar instruções",
         "cancel_button": "Cancelar",
@@ -354,10 +355,9 @@
         "success_alert_description": "O arquivo CSV está pronto na pasta de downloads",
         "success_alert_title": "Instruções exportadas"
       },
-      "new_instruction": "Nova instrução",
       "delete_category": {
         "modal_title": "Excluir categoria",
-        "modal_description": "{count} de {name} para Sem categoria. Nada será excluído, apenas o rótulo da categoria é removido.",
+        "modal_description": "Mover {count} de {name} para Sem Categoria. Nada será excluído, apenas o rótulo da categoria será removido.",
         "modal_description_empty": "{name} não tem instruções. Excluí-la só a removerá da sua lista",
         "instructions_count": "{count, plural, one {{count} instrução será movida} other {{count} instruções serão movidas}}",
         "cancel": "Cancelar",
@@ -366,7 +366,7 @@
         "success_description": "{count, plural, one {{count} instrução movida para Sem categoria} other {{count} instruções movidas para Sem categoria}}",
         "success_description_empty": "Removida da sua lista",
         "error_title": "Não foi possível excluir a categoria",
-        "error_description": "Algo deu errado e nada foi alterado. Tente novamente."
+        "error_description": "Algo deu errado. Tente novamente."
       },
       "view": {
         "default_instruction": "Instrução padrão",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -356,7 +356,7 @@
       "new_instruction": "Instrucțiune nouă",
       "delete_category": {
         "modal_title": "Șterge categoria",
-        "modal_description": "{count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
+        "modal_description": "Mută {count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
         "modal_description_empty": "{name} nu are instrucțiuni. Ștergerea o va elimina doar din listă",
         "instructions_count": "{count, plural, one {{count} instrucțiune va fi mutată} other {{count} instrucțiuni vor fi mutate}}",
         "cancel": "Anulează",
@@ -365,7 +365,7 @@
         "success_description": "{count, plural, one {{count} instrucțiune mutată în Fără categorie} other {{count} instrucțiuni mutate în Fără categorie}}",
         "success_description_empty": "Eliminată din listă",
         "error_title": "Categoria nu a putut fi ștearsă",
-        "error_description": "Ceva nu a funcționat și nimic nu a fost modificat. Încearcă din nou."
+        "error_description": "Ceva nu a funcționat. Încearcă din nou."
       },
       "view": {
         "default_instruction": "Instrucțiune implicită",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -356,7 +356,7 @@
       "new_instruction": "Instrucțiune nouă",
       "delete_category": {
         "modal_title": "Șterge categoria",
-        "modal_description": "Mută {count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
+        "modal_description": "Mută {count} din {name} în Fără categorie. Nu se va șterge nimic, se va elimina doar eticheta categoriei.",
         "modal_description_empty": "{name} nu are instrucțiuni. Ștergerea o va elimina doar din listă",
         "instructions_count": "{count, plural, one {{count} instrucțiune va fi mutată} other {{count} instrucțiuni vor fi mutate}}",
         "cancel": "Anulează",


### PR DESCRIPTION
Add and update translations from [PR#218](https://github.com/weni-ai/agent-builder-webapp/pull/218). Tracked in [LOC-27562](https://vtex-dev.atlassian.net/browse/LOC-27562).

Updates approved Crowdin strings in en, pt-BR, es-MX, and ro.