### PR TITLE
Add and update translations from PR#224

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -358,7 +358,7 @@
       "delete_category": {
         "modal_title": "Delete category",
         "modal_description": "{count} from {name} to Uncategorized. Nothing will be deleted, only the category label is removed.",
-        "modal_description_empty": "{name} has no instructions. Deleting it will only remove it from your list",
+        "modal_description_empty": "{name} has no instructions. Deleting it will only remove this category from your list.",
         "instructions_count": "{count, plural, one {{count} instruction will be moved} other {{count} instructions will be moved}}",
         "cancel": "Cancel",
         "confirm": "Delete category",
@@ -385,7 +385,7 @@
           "list": "List"
         },
         "uncategorized": "Uncategorized",
-        "uncategorized_tooltip": "Instructions without a category appear here\nThis group can't be removed"
+        "uncategorized_tooltip": "Instructions without a category appear here, and this group can't be deleted"
       },
       "new_instruction_drawer": {
         "title": "New instruction",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instrucciones",
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
+      "new_instruction": "Nueva instrucción",
       "export_instructions": {
         "title": "Exportar instrucciones",
         "cancel_button": "Cancelar",
@@ -354,17 +355,16 @@
         "success_alert_description": "El archivo CSV está listo en la carpeta de descargas",
         "success_alert_title": "Instrucciones exportadas"
       },
-      "new_instruction": "Nueva instrucción",
       "delete_category": {
         "modal_title": "Eliminar categoría",
         "modal_description": "{count} de {name} a Sin categoría. No se eliminará nada, solo se quita la etiqueta de la categoría.",
-        "modal_description_empty": "{name} no tiene instrucciones. Eliminarla solo la quitará de tu lista",
+        "modal_description_empty": "{name} no tiene instrucciones. Eliminarla solo removerá esta categoría de tu lista.",
         "instructions_count": "{count, plural, one {{count} instrucción se moverá} other {{count} instrucciones se moverán}}",
         "cancel": "Cancelar",
         "confirm": "Eliminar categoría",
         "success_title": "Categoría eliminada",
         "success_description": "{count, plural, one {{count} instrucción movida a Sin categoría} other {{count} instrucciones movidas a Sin categoría}}",
-        "success_description_empty": "Eliminada de tu lista",
+        "success_description_empty": "Removida de tu lista",
         "error_title": "No se pudo eliminar la categoría",
         "error_description": "Algo salió mal y no se cambió nada. Inténtalo de nuevo."
       },
@@ -385,7 +385,7 @@
           "list": "Lista"
         },
         "uncategorized": "Sin categoría",
-        "uncategorized_tooltip": "Las instrucciones sin categoría aparecen aquí\nEste grupo no se puede eliminar"
+        "uncategorized_tooltip": "Las instrucciones sin categoría se muestran aquí y este grupo no se puede eliminar"
       },
       "new_instruction_drawer": {
         "title": "Nueva instrucción",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instruções",
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
+      "new_instruction": "Nova instrução",
       "export_instructions": {
         "title": "Exportar instruções",
         "cancel_button": "Cancelar",
@@ -354,11 +355,10 @@
         "success_alert_description": "O arquivo CSV está pronto na pasta de downloads",
         "success_alert_title": "Instruções exportadas"
       },
-      "new_instruction": "Nova instrução",
       "delete_category": {
         "modal_title": "Excluir categoria",
         "modal_description": "{count} de {name} para Sem categoria. Nada será excluído, apenas o rótulo da categoria é removido.",
-        "modal_description_empty": "{name} não tem instruções. Excluí-la só a removerá da sua lista",
+        "modal_description_empty": "{name} não tem instruções. Excluí-la apenas removerá esta categoria da sua lista.",
         "instructions_count": "{count, plural, one {{count} instrução será movida} other {{count} instruções serão movidas}}",
         "cancel": "Cancelar",
         "confirm": "Excluir categoria",
@@ -385,7 +385,7 @@
           "list": "Lista"
         },
         "uncategorized": "Sem categoria",
-        "uncategorized_tooltip": "Instruções sem categoria aparecem aqui\nEste grupo não pode ser removido"
+        "uncategorized_tooltip": "Instruções sem categoria aparecem aqui e este grupo não pode ser excluído"
       },
       "new_instruction_drawer": {
         "title": "Nova instrução",
@@ -423,7 +423,7 @@
             "cancel": "Cancelar",
             "create": "Criar",
             "validation": {
-              "already_exists": "Insira um nome de categoria que não exista",
+              "already_exists": "Insira um nome de categoria que ainda não existe",
               "invalid_chars": "Use apenas letras, números, espaços e hifens",
               "required": "Preencha este campo"
             }

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -357,7 +357,7 @@
       "delete_category": {
         "modal_title": "Șterge categoria",
         "modal_description": "{count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
-        "modal_description_empty": "{name} nu are instrucțiuni. Ștergerea o va elimina doar din listă.",
+        "modal_description_empty": "{name} nu are instrucțiuni. Ștergerea doar va elimina această categorie din listă.",
         "instructions_count": "{count, plural, one {{count} instrucțiune va fi mutată} other {{count} instrucțiuni vor fi mutate}}",
         "cancel": "Anulează",
         "confirm": "Șterge categoria",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -344,6 +344,7 @@
     "instructions": {
       "title": "Instrucțiuni",
       "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
+      "new_instruction": "Instrucțiune nouă",
       "export_instructions": {
         "title": "Exportă instrucțiuni",
         "cancel_button": "Anulează",
@@ -353,11 +354,10 @@
         "success_alert_description": "Fișierul CSV este gata în folderul de descărcări",
         "success_alert_title": "Instrucțiuni exportate"
       },
-      "new_instruction": "Instrucțiune nouă",
       "delete_category": {
         "modal_title": "Șterge categoria",
         "modal_description": "{count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
-        "modal_description_empty": "{name} nu are instrucțiuni. Ștergerea o va elimina doar din listă",
+        "modal_description_empty": "{name} nu are instrucțiuni. Ștergerea o va elimina doar din listă.",
         "instructions_count": "{count, plural, one {{count} instrucțiune va fi mutată} other {{count} instrucțiuni vor fi mutate}}",
         "cancel": "Anulează",
         "confirm": "Șterge categoria",
@@ -384,7 +384,7 @@
           "list": "Listă"
         },
         "uncategorized": "Fără categorie",
-        "uncategorized_tooltip": "Instrucțiunile fără categorie apar aici\nAcest grup nu poate fi eliminat"
+        "uncategorized_tooltip": "Instrucțiunile fără categorie apar aici, iar acest grup nu poate fi șters"
       },
       "new_instruction_drawer": {
         "title": "Instrucțiune nouă",


### PR DESCRIPTION
Add and update translations from [PR#224](https://github.com/weni-ai/agent-builder-webapp/pull/224). Tracked in [LOC-27565](https://vtex-dev.atlassian.net/browse/LOC-27565).

Updates approved Crowdin strings in en, pt-BR, es-MX, and ro.