### PR TITLE
Add and update translations from PR#278

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -621,7 +621,7 @@
         "clear_filters": "Clear filters",
         "analysis": {
           "all_conversations": "All conversations",
-          "amazing_conversations": "Amazing conversations",
+          "amazing_conversations": "Excellent conversations",
           "label": "Analysis"
         },
         "period": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instrucciones",
       "description": "Define las reglas que guían cómo el Manager responde, se comunica y toma decisiones",
+      "new_instruction": "Nueva instrucción",
       "export_instructions": {
         "title": "Exportar instrucciones",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "El archivo CSV está listo en la carpeta de descargas",
         "success_alert_title": "Instrucciones exportadas"
       },
-      "new_instruction": "Nueva instrucción",
       "delete_category": {
         "modal_title": "Eliminar categoría",
         "modal_description": "{count} de {name} a Sin categoría. No se eliminará nada, solo se quita la etiqueta de la categoría.",
@@ -621,7 +621,7 @@
         "clear_filters": "Limpiar filtros",
         "analysis": {
           "all_conversations": "Todas las conversaciones",
-          "amazing_conversations": "Conversaciones increíbles",
+          "amazing_conversations": "Conversaciones excelentes",
           "label": "Análisis"
         },
         "period": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -345,6 +345,7 @@
     "instructions": {
       "title": "Instruções",
       "description": "Defina as regras que orientam como o Manager responde, se comunica e toma decisões",
+      "new_instruction": "Nova instrução",
       "export_instructions": {
         "title": "Exportar instruções",
         "cancel_button": "Cancelar",
@@ -354,7 +355,6 @@
         "success_alert_description": "O arquivo CSV está pronto na pasta de downloads",
         "success_alert_title": "Instruções exportadas"
       },
-      "new_instruction": "Nova instrução",
       "delete_category": {
         "modal_title": "Excluir categoria",
         "modal_description": "{count} de {name} para Sem categoria. Nada será excluído, apenas o rótulo da categoria é removido.",
@@ -621,7 +621,7 @@
         "clear_filters": "Limpar filtros",
         "analysis": {
           "all_conversations": "Todas as conversas",
-          "amazing_conversations": "Conversas incríveis",
+          "amazing_conversations": "Conversas excelentes",
           "label": "Análise"
         },
         "period": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -344,6 +344,7 @@
     "instructions": {
       "title": "Instrucțiuni",
       "description": "Definește regulile care ghidează modul în care Manager răspunde, comunică și ia decizii",
+      "new_instruction": "Instrucțiune nouă",
       "export_instructions": {
         "title": "Exportă instrucțiuni",
         "cancel_button": "Anulează",
@@ -353,7 +354,6 @@
         "success_alert_description": "Fișierul CSV este gata în folderul de descărcări",
         "success_alert_title": "Instrucțiuni exportate"
       },
-      "new_instruction": "Instrucțiune nouă",
       "delete_category": {
         "modal_title": "Șterge categoria",
         "modal_description": "{count} din {name} în Fără categorie. Nu se șterge nimic, se elimină doar eticheta categoriei.",
@@ -620,7 +620,7 @@
         "clear_filters": "Elimină filtrele",
         "analysis": {
           "all_conversations": "Toate conversațiile",
-          "amazing_conversations": "Conversații extraordinare",
+          "amazing_conversations": "Conversații excelente",
           "label": "Analiză"
         },
         "period": {


### PR DESCRIPTION
Add and update translations from [PR#278](https://github.com/weni-ai/agent-builder-webapp/pull/278). Tracked in [LOC-28044](https://vtex-dev.atlassian.net/browse/LOC-28044).

Updates approved Crowdin strings in en, pt-BR, es-MX, and ro.