### PR TITLE
fix: Project UUID management with `moduleStorage` to reactive Pinia store

### DIFF
--- a/src/api/__tests__/nexusaiAPI.spec.js
+++ b/src/api/__tests__/nexusaiAPI.spec.js
@@ -18,10 +18,8 @@ vi.mock('@/api/utils/forceHttps', () => ({
   default: vi.fn((url) => `https://${url}`),
 }));
 
-vi.mock('@/utils/storage', () => ({
-  moduleStorage: {
-    getItem: vi.fn(() => 'project1'),
-  },
+vi.mock('@/store/Project', () => ({
+  useProjectStore: () => ({ uuid: 'project1' }),
 }));
 
 vi.mock('@/utils/env', () => ({

--- a/src/api/nexus/Knowledge.js
+++ b/src/api/nexus/Knowledge.js
@@ -1,6 +1,10 @@
+import { computed } from 'vue';
+
 import request from '@/api/nexusaiRequest';
 import forceHttps from '@/api/utils/forceHttps';
-import { moduleStorage } from '@/utils/storage';
+import { useProjectStore } from '@/store/Project';
+
+const currentProjectUuid = computed(() => useProjectStore().uuid);
 
 const INLINE_CONTENT_BASE_ENDPOINTS = {
   TEXT: 'inline-content-base-text',
@@ -16,7 +20,7 @@ const INLINE_CONTENT_BASE_ENDPOINTS = {
  * @returns {string} Generated endpoint URL
  */
 const generateContentBaseEndpoint = ({ type, itemUuid }) => {
-  const projectUuid = moduleStorage.getItem('projectUuid');
+  const projectUuid = currentProjectUuid.value;
 
   let baseEndpoint;
 

--- a/src/api/nexus/Knowledge.js
+++ b/src/api/nexus/Knowledge.js
@@ -1,10 +1,6 @@
-import { computed } from 'vue';
-
 import request from '@/api/nexusaiRequest';
 import forceHttps from '@/api/utils/forceHttps';
 import { useProjectStore } from '@/store/Project';
-
-const currentProjectUuid = computed(() => useProjectStore().uuid);
 
 const INLINE_CONTENT_BASE_ENDPOINTS = {
   TEXT: 'inline-content-base-text',
@@ -20,7 +16,7 @@ const INLINE_CONTENT_BASE_ENDPOINTS = {
  * @returns {string} Generated endpoint URL
  */
 const generateContentBaseEndpoint = ({ type, itemUuid }) => {
-  const projectUuid = currentProjectUuid.value;
+  const projectUuid = useProjectStore().uuid;
 
   let baseEndpoint;
 

--- a/src/api/nexus/__tests__/Knowledge.spec.js
+++ b/src/api/nexus/__tests__/Knowledge.spec.js
@@ -19,10 +19,8 @@ vi.mock('@/api/utils/forceHttps', () => ({
   default: vi.fn((url) => `https-forced::${url}`),
 }));
 
-vi.mock('@/utils/storage', () => ({
-  moduleStorage: {
-    getItem: vi.fn(() => 'project-uuid'),
-  },
+vi.mock('@/store/Project', () => ({
+  useProjectStore: () => ({ uuid: 'project-uuid' }),
 }));
 
 describe('Knowledge API — texts.list', () => {

--- a/src/components/FederatedWrapper.vue
+++ b/src/components/FederatedWrapper.vue
@@ -23,7 +23,7 @@ import { useI18n } from 'vue-i18n';
 import { safeImport } from '@/utils/moduleFederation';
 import { moduleStorage } from '@/utils/storage';
 
-import { useProjectStore } from '@/store/Project';
+import { setProjectUuid, useProjectStore } from '@/store/Project';
 import { useUserStore } from '@/store/User';
 import { useTuningsStore } from '@/store/Tunings';
 
@@ -75,13 +75,13 @@ onBeforeMount(async () => {
     const newProjectUuid = sharedStore.current.project.uuid;
 
     const currentToken = moduleStorage.getItem('authToken');
-    const currentProjectUuid = moduleStorage.getItem('projectUuid');
+    const currentProjectUuid = useProjectStore().uuid;
 
     const hasContextChanged =
       newToken !== currentToken || newProjectUuid !== currentProjectUuid;
 
     moduleStorage.setItem('authToken', newToken);
-    moduleStorage.setItem('projectUuid', newProjectUuid);
+    setProjectUuid(newProjectUuid);
 
     if (hasContextChanged) {
       useUserStore().setToken(newToken);

--- a/src/components/Tunings/ChangesHistory.vue
+++ b/src/components/Tunings/ChangesHistory.vue
@@ -57,7 +57,7 @@ import { handleChangeName } from '@/utils/changeNameUtils';
 import { useProjectStore } from '@/store/Project';
 
 const { t } = useI18n();
-const projectUuid = useProjectStore().uuid;
+const projectUuid = computed(() => useProjectStore().uuid);
 
 const pagination = ref(1);
 const paginationTotal = ref(0);
@@ -144,7 +144,7 @@ const getChangesHistoryData = async (page = 1, filter = '') => {
   isLoading.value = true;
   try {
     const { data } = await nexusaiAPI.router.tunings.historyChanges.read({
-      projectUuid,
+      projectUuid: projectUuid.value,
       pageSize: paginationInterval.value,
       page,
       filter: filter === 'all' ? '' : filter,

--- a/src/main.js
+++ b/src/main.js
@@ -13,7 +13,7 @@ import Unnnic from './utils/plugins/UnnnicSystem.ts';
 import env from './utils/env';
 import { isFederatedModule } from './utils/moduleFederation';
 import { getJwtToken, setupTokenRefreshListener } from './utils/jwt.js';
-import { getProjectUuid } from './utils/project.js';
+import { getProjectUuid, setupProjectUuidListener } from './utils/project.js';
 import { setupLanguageListener } from './utils/language.js';
 import { useUserStore } from './store/User.js';
 
@@ -43,6 +43,7 @@ export default async function mountAgentBuilderApp({
   if (!isFederatedModule && isInIframe) {
     const userStore = useUserStore();
     setupTokenRefreshListener(userStore);
+    setupProjectUuidListener();
   }
 
   app.use(Particles, {

--- a/src/store/ManagerSelector.ts
+++ b/src/store/ManagerSelector.ts
@@ -25,7 +25,7 @@ const parseDate = (dateString?: string | null): Date | null => {
 
 export const useManagerSelectorStore = defineStore('ManagerSelector', () => {
   const alertStore = useAlertStore();
-  const projectUuid = useProjectStore().uuid;
+  const projectUuid = computed(() => useProjectStore().uuid);
 
   const options = ref<ManagerSelector['options']>({
     currentManager: '',
@@ -155,7 +155,7 @@ export const useManagerSelectorStore = defineStore('ManagerSelector', () => {
       status.value = 'loading';
 
       const { data } = await nexusaiAPI.router.tunings.manager.read({
-        projectUuid,
+        projectUuid: projectUuid.value,
       });
 
       options.value = data;
@@ -176,7 +176,7 @@ export const useManagerSelectorStore = defineStore('ManagerSelector', () => {
       saveStatus.value = 'loading';
 
       await nexusaiAPI.router.tunings.manager.edit({
-        projectUuid,
+        projectUuid: projectUuid.value,
         manager: selectedManager.value,
       });
 

--- a/src/store/Project.ts
+++ b/src/store/Project.ts
@@ -1,8 +1,18 @@
 import { defineStore } from 'pinia';
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
 import nexusaiAPI from '@/api/nexusaiAPI';
-import { moduleStorage } from '@/utils/storage';
+
+/**
+ * Lives at module scope so the UUID survives Pinia `$dispose()` (federated
+ * remounts) and can be set during the iframe handshake before `createPinia()`.
+ * It must not go into Web Storage: that is shared across tabs.
+ */
+const currentProjectUuid = ref('');
+
+export function setProjectUuid(uuid: string) {
+  currentProjectUuid.value = uuid || '';
+}
 
 interface ProjectDetails {
   status: null | 'loading' | 'success' | 'error';
@@ -18,7 +28,8 @@ interface ProjectInfo {
 }
 
 export const useProjectStore = defineStore('Project', () => {
-  const uuid = moduleStorage.getItem('projectUuid') || '';
+  const uuid = computed(() => currentProjectUuid.value);
+
   const details = ref<ProjectDetails>({
     status: null,
   });
@@ -34,7 +45,7 @@ export const useProjectStore = defineStore('Project', () => {
 
     try {
       const { data } = await nexusaiAPI.router.project.read({
-        projectUuid: uuid,
+        projectUuid: uuid.value,
       });
 
       project.value.name = data.name ?? '';
@@ -51,7 +62,7 @@ export const useProjectStore = defineStore('Project', () => {
 
     try {
       const data = await nexusaiAPI.router.tunings.projectDetails.read({
-        projectUuid: uuid,
+        projectUuid: uuid.value,
       });
 
       details.value = { ...details.value, ...data };

--- a/src/utils/project.js
+++ b/src/utils/project.js
@@ -1,15 +1,23 @@
-import { moduleStorage } from '@/utils/storage';
+import { setProjectUuid } from '@/store/Project';
 
 export async function getProjectUuid() {
   return new Promise((resolve) => {
     const eventHandler = (event) => {
       if (event.data.event === 'updateProjectUuid') {
-        moduleStorage.setItem('projectUuid', event.data.projectUuid);
+        setProjectUuid(event.data.projectUuid);
         window.removeEventListener('message', eventHandler);
         return resolve();
       }
     };
     window.addEventListener('message', eventHandler);
     window.parent.postMessage({ event: 'getProjectUuid' }, '*');
+  });
+}
+
+export function setupProjectUuidListener() {
+  window.addEventListener('message', (event) => {
+    if (event.data.event === 'updateProjectUuid') {
+      setProjectUuid(event.data.projectUuid);
+    }
   });
 }


### PR DESCRIPTION
### Type of Change

- [ ] Feature
- [x] Bug fix
- [x] Refactor
- [x] Tests
- [ ] Chore
- [ ] Locales

### Why

The project UUID was previously read from `moduleStorage` (Web Storage), which is shared across browser tabs. This caused issues where switching projects in one tab could affect other open tabs. Additionally, the UUID was read once at store initialization time, meaning it would not react to project changes during the app's lifecycle.

### What Changed

- Introduced a module-scoped `currentProjectUuid` ref in `src/store/Project.ts` that lives outside Pinia, surviving store disposal during federated remounts and being available before `createPinia()` is called.
- Exposed a `setProjectUuid` function to update this ref, replacing all direct `moduleStorage.setItem('projectUuid', ...)` calls.
- `useProjectStore().uuid` is now a `computed` property derived from `currentProjectUuid`, making it reactive to project changes.
- Added `setupProjectUuidListener` in `src/utils/project.js` to continuously listen for `updateProjectUuid` iframe messages and update the store accordingly, registered in `main.js` for non-federated iframe contexts.
- Updated `FederatedWrapper.vue` to read the current project UUID from the store instead of storage, and to call `setProjectUuid` when the project changes.
- Updated `ManagerSelector` store and `ChangesHistory` component to use `computed(() => useProjectStore().uuid)` so they react to UUID changes.
- Updated `Knowledge.js` API module to derive the project UUID reactively via a module-level `computed`.
- Updated tests to mock `@/store/Project` instead of `@/utils/storage`.

### Diagram

```mermaid
flowchart TD
    subgraph sources["Sources"]
        A1["iframe: getProjectUuid handshake"] --> G[setProjectUuid]
        A2["iframe: updateProjectUuid listener"] --> G
        A3["federated: sharedStore"] --> G
    end

    G --> H["currentProjectUuid ref"]
    H --> I["useProjectStore().uuid"]
    I --> J[ManagerSelectorStore]
    I --> K[ChangesHistory]
    I --> L[Knowledge API]
```