### PR TITLE
fix: Update insufficient volume messages to reference yesterday's conversations

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -740,12 +740,12 @@
         "description_today": "Ran today at {time}",
         "run_analysis": "Run analysis",
         "run_analysis_already_run_today_tooltip": "Analysis has already run in the last 24 hours and will be available again at {time}",
-        "run_analysis_insufficient_volume_tooltip": "Insufficient conversation volume to run analysis\nMinimum of {min} conversations required",
+        "run_analysis_insufficient_volume_tooltip": "Not enough conversations yesterday to run analysis. At least {min} conversations are required.",
         "title": "{count, plural, =0 {Analysis of conversations from {date}} one {Analysis of conversations from {date} · {count} improvement identified} other {Analysis of conversations from {date} · {count} improvements identified}}"
       },
       "insufficient_volume": {
-        "description": "Minimum of {min} conversations required to run analysis",
-        "title": "Insufficient conversation volume"
+        "description": "Analysis runs on yesterday's conversations. At least {min} conversations are required.",
+        "title": "Not enough conversations yesterday to run analysis"
       },
       "intro_modal": {
         "step_of": "Step {step} of {total}",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -740,12 +740,12 @@
         "description_today": "Ejecutado hoy a las {time}",
         "run_analysis": "Ejecutar análisis",
         "run_analysis_already_run_today_tooltip": "El análisis ya se ejecutó en las últimas 24 horas y volverá a estar disponible a las {time}",
-        "run_analysis_insufficient_volume_tooltip": "Volumen de conversaciones insuficiente para ejecutar análisis\nMínimo de {min} conversaciones requeridas",
+        "run_analysis_insufficient_volume_tooltip": "No hay suficientes conversaciones de ayer para ejecutar el análisis. Se requieren al menos {min} conversaciones.",
         "title": "{count, plural, =0 {Análisis de conversaciones de {date}} one {Análisis de conversaciones de {date} · {count} mejora identificada} other {Análisis de conversaciones de {date} · {count} mejoras identificadas}}"
       },
       "insufficient_volume": {
-        "description": "Mínimo de {min} conversaciones necesarias para ejecutar el análisis",
-        "title": "Volumen insuficiente de conversaciones"
+        "description": "El análisis se ejecuta en las conversaciones de ayer. Se requieren al menos {min} conversaciones.",
+        "title": "No hay suficientes conversaciones de ayer para ejecutar el análisis"
       },
       "intro_modal": {
         "step_of": "Paso {step} de {total}",

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -740,12 +740,12 @@
         "description_today": "Executada hoje às {time}",
         "run_analysis": "Executar análise",
         "run_analysis_already_run_today_tooltip": "A análise já foi executada nas últimas 24h e ficará disponível novamente às {time}",
-        "run_analysis_insufficient_volume_tooltip": "Volume de conversas insuficiente para executar análise\nMínimo de {min} conversas necessárias",
+        "run_analysis_insufficient_volume_tooltip": "Não há conversas suficientes de ontem para executar a análise. São necessárias pelo menos {min} conversas.",
         "title": "{count, plural, =0 {Análise das conversas de {date}} one {Análise das conversas de {date} · {count} melhoria identificada} other {Análise das conversas de {date} · {count} melhorias identificadas}}"
       },
       "insufficient_volume": {
-        "description": "Mínimo de {min} conversas necessárias para executar a análise",
-        "title": "Volume insuficiente de conversas"
+        "description": "A análise é executada nas conversas de ontem. São necessárias pelo menos {min} conversas.",
+        "title": "Não há conversas suficientes de ontem para executar a análise"
       },
       "intro_modal": {
         "step_of": "Passo {step} de {total}",

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -739,12 +739,12 @@
         "description_today": "Rulată astăzi la {time}",
         "run_analysis": "Rulează analiza",
         "run_analysis_already_run_today_tooltip": "Analiza a fost deja executată în ultimele 24h și va fi disponibilă din nou la {time}",
-        "run_analysis_insufficient_volume_tooltip": "Volum insuficient de conversații pentru a rula analiza\nMinim {min} conversații necesare",
+        "run_analysis_insufficient_volume_tooltip": "Nu există suficiente conversații de ieri pentru a rula analiza. Sunt necesare cel puțin {min} conversații.",
         "title": "{count, plural, =0 {Analiza conversațiilor din {date}} one {Analiza conversațiilor din {date} · {count} îmbunătățire identificată} other {Analiza conversațiilor din {date} · {count} îmbunătățiri identificate}}"
       },
       "insufficient_volume": {
-        "description": "Minimum {min} conversații necesare pentru executarea analizei",
-        "title": "Volum insuficient de conversații"
+        "description": "Analiza rulează pe conversațiile de ieri. Sunt necesare cel puțin {min} conversații.",
+        "title": "Nu există suficiente conversații de ieri pentru a rula analiza"
       },
       "intro_modal": {
         "step_of": "Pasul {step} din {total}",


### PR DESCRIPTION
### Type of Change

- [ ] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Tests
- [ ] Chore
- [x] Locales

### Why

The previous insufficient volume messaging was vague and didn't clearly communicate that the analysis runs on yesterday's conversations specifically. The wording also used technical phrasing ("insufficient conversation volume") that was less user-friendly.

### What Changed

Updated the insufficient volume tooltip and section title/description across all supported locales (English, Spanish, Portuguese, Romanian) to:

- Clarify that analysis runs on **yesterday's** conversations
- Replace "Insufficient conversation volume" with "Not enough conversations yesterday to run analysis"
- Rewrite descriptions to use plain, direct language (e.g., "At least {min} conversations are required" instead of "Minimum of {min} conversations required")
- Remove the newline character (`\n`) from the tooltip string in favor of a full sentence with a period

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/f2174689-76e4-458e-b2e6-311d64f4dbc2.png)

