### PR TITLE
feat: Add rename category modal and API integration for instructions

### DIFF
--- a/src/api/adapters/instructions/__tests__/grouped.spec.js
+++ b/src/api/adapters/instructions/__tests__/grouped.spec.js
@@ -65,3 +65,16 @@ describe('InstructionsGroupedAdapter.toUpdateApi', () => {
     });
   });
 });
+
+describe('InstructionsGroupedAdapter.toRenameCategoryApi', () => {
+  it('builds a categories payload with id and trimmed name', () => {
+    expect(
+      InstructionsGroupedAdapter.toRenameCategoryApi({
+        id: 10,
+        name: '  Marketing  ',
+      }),
+    ).toEqual({
+      categories: [{ id: 10, name: 'Marketing' }],
+    });
+  });
+});

--- a/src/api/adapters/instructions/grouped.js
+++ b/src/api/adapters/instructions/grouped.js
@@ -65,4 +65,8 @@ export const InstructionsGroupedAdapter = {
       ],
     };
   },
+
+  toRenameCategoryApi({ id, name }) {
+    return { categories: [{ id, name: name.trim() }] };
+  },
 };

--- a/src/api/nexus/Instructions.js
+++ b/src/api/nexus/Instructions.js
@@ -42,6 +42,14 @@ export const Instructions = {
     return InstructionsGroupedAdapter.fromApi(response.data);
   },
 
+  async renameCategory({ projectUuid, id, name }) {
+    await request.$http.patch(
+      `api/${projectUuid}/instructions/`,
+      InstructionsGroupedAdapter.toRenameCategoryApi({ id, name }),
+      { hideGenericErrorAlert: true },
+    );
+  },
+
   async deleteInstruction({ projectUuid, id }) {
     await request.$http.delete(`api/${projectUuid}/instructions/?id=${id}`);
   },

--- a/src/components/Instructions/InstructionsCategorization/CategoriesView.vue
+++ b/src/components/Instructions/InstructionsCategorization/CategoriesView.vue
@@ -6,11 +6,13 @@
     <CategoryAccordion
       v-for="(group, index) in groups"
       :key="group.key"
+      :ref="(el) => setGroupRef(group.key, el)"
       :group="group"
       :initiallyExpanded="index === 0"
       :forceExpanded="instructionsStore.isSearching"
       :data-testid="`categories-view-group-${group.key}`"
       @delete-category="$emit('delete-category', $event)"
+      @rename-category="$emit('rename-category', $event)"
       @edit="$emit('edit', $event)"
     />
 
@@ -19,7 +21,7 @@
 </template>
 
 <script setup>
-import { computed } from 'vue';
+import { computed, nextTick, watch } from 'vue';
 
 import { useFeatureFlagsStore } from '@/store/FeatureFlags';
 import { useInstructionsStore } from '@/store/Instructions';
@@ -27,13 +29,44 @@ import { useInstructionsStore } from '@/store/Instructions';
 import CategoryAccordion from './CategoryAccordion.vue';
 import SafetyGuardrails from './SafetyGuardrails.vue';
 
-defineEmits(['delete-category', 'edit']);
+const props = defineProps({
+  scrollToGroupKey: {
+    type: String,
+    default: null,
+  },
+});
+
+defineEmits(['delete-category', 'edit', 'rename-category']);
 
 const featureFlagsStore = useFeatureFlagsStore();
 const instructionsStore = useInstructionsStore();
 
 const featureFlags = computed(() => featureFlagsStore.flags);
 const groups = computed(() => instructionsStore.groupedInstructions);
+
+const groupRefs = {};
+
+function setGroupRef(key, el) {
+  if (el) {
+    groupRefs[key] = el;
+  } else {
+    delete groupRefs[key];
+  }
+}
+
+watch(
+  () => props.scrollToGroupKey,
+  (key) => {
+    if (!key) return;
+
+    nextTick(() => {
+      groupRefs[key]?.$el?.scrollIntoView?.({
+        block: 'nearest',
+        behavior: 'smooth',
+      });
+    });
+  },
+);
 </script>
 
 <style lang="scss" scoped>

--- a/src/components/Instructions/InstructionsCategorization/CategoryAccordion.vue
+++ b/src/components/Instructions/InstructionsCategorization/CategoryAccordion.vue
@@ -101,7 +101,7 @@ const props = defineProps({
   },
 });
 
-const emit = defineEmits(['delete-category', 'edit']);
+const emit = defineEmits(['delete-category', 'edit', 'rename-category']);
 
 const { t } = useI18n();
 const viewT = (key) => t(`agents.instructions.view.${key}`);
@@ -127,6 +127,11 @@ const lockedTooltip = computed(() => {
 const emptyText = computed(() => viewT('empty_category'));
 
 const actions = computed(() => [
+  {
+    text: viewT('rename_category'),
+    icon: 'edit_square',
+    onClick: () => emit('rename-category', props.group),
+  },
   {
     text: viewT('delete_category'),
     icon: 'delete',

--- a/src/components/Instructions/InstructionsCategorization/index.vue
+++ b/src/components/Instructions/InstructionsCategorization/index.vue
@@ -43,8 +43,10 @@
 
       <CategoriesView
         v-if="showCategoriesView"
+        :scrollToGroupKey="scrollToCategoryKey"
         data-testid="instructions-categories-view"
         @delete-category="onDeleteCategory"
+        @rename-category="onRenameCategory"
         @edit="instructionsStore.startEditingInstruction"
       />
 
@@ -62,6 +64,15 @@
       data-testid="instructions-remove-category-modal"
       @update:model-value="onRemoveCategoryModalOpenChange"
     />
+
+    <ModalRenameCategory
+      v-if="categoryToRename"
+      v-model="isRenameCategoryModalOpen"
+      :category="categoryToRename"
+      data-testid="instructions-rename-category-modal"
+      @renamed="onCategoryRenamed"
+      @update:model-value="onRenameCategoryModalOpenChange"
+    />
   </section>
 </template>
 
@@ -74,6 +85,7 @@ import InstructionsResultsCount from './InstructionsResultsCount.vue';
 import CategoriesView from './CategoriesView.vue';
 import ListView from './ListView.vue';
 import ModalRemoveCategory from '@/components/Instructions/ModalRemoveCategory.vue';
+import ModalRenameCategory from '@/components/Instructions/ModalRenameCategory.vue';
 
 const views = ['categories', 'list'];
 
@@ -85,6 +97,10 @@ if (instructionsStore.instructions.status === null) {
 
 const categoryToDelete = ref(null);
 const isRemoveCategoryModalOpen = ref(false);
+
+const categoryToRename = ref(null);
+const isRenameCategoryModalOpen = ref(false);
+const scrollToCategoryKey = ref(null);
 
 const isLoading = computed(
   () => instructionsStore.instructions.status === 'loading',
@@ -113,6 +129,21 @@ function onRemoveCategoryModalOpenChange(open) {
   if (!open) {
     categoryToDelete.value = null;
   }
+}
+
+function onRenameCategory(group) {
+  categoryToRename.value = { id: group.categoryId, name: group.label };
+  isRenameCategoryModalOpen.value = true;
+}
+
+function onRenameCategoryModalOpenChange(open) {
+  if (!open) {
+    categoryToRename.value = null;
+  }
+}
+
+function onCategoryRenamed(id) {
+  scrollToCategoryKey.value = `category-${id}`;
 }
 </script>
 

--- a/src/components/Instructions/ModalRenameCategory.vue
+++ b/src/components/Instructions/ModalRenameCategory.vue
@@ -1,0 +1,163 @@
+<template>
+  <UnnnicDialog
+    data-testid="modal"
+    :open="modelValue"
+    lazyMount
+    @update:open="onUpdateOpen"
+  >
+    <UnnnicDialogContent>
+      <UnnnicDialogHeader>
+        <UnnnicDialogTitle>
+          {{ renameT('modal_title') }}
+        </UnnnicDialogTitle>
+      </UnnnicDialogHeader>
+
+      <section class="modal-rename-category__body">
+        <UnnnicInput
+          ref="inputRef"
+          v-model="name"
+          :label="renameT('name_label')"
+          :maxlength="MAX_LENGTH"
+          showMaxlengthCounter
+          :errors="displayedErrors"
+          data-testid="name-input"
+          @blur="touched = true"
+          @keyup.enter="submit"
+        />
+
+        <UnnnicDisclaimer
+          type="informational"
+          :description="renameT('disclaimer')"
+          data-testid="disclaimer"
+        />
+      </section>
+
+      <UnnnicDialogFooter>
+        <UnnnicDialogClose>
+          <UnnnicButton
+            data-testid="cancel-button"
+            :text="renameT('cancel')"
+            type="tertiary"
+            :disabled="isSaving"
+            @click="close"
+          />
+        </UnnnicDialogClose>
+        <UnnnicButton
+          data-testid="confirm-button"
+          :text="renameT('confirm')"
+          type="primary"
+          :disabled="!canSave"
+          :loading="isSaving"
+          @click="submit"
+        />
+      </UnnnicDialogFooter>
+    </UnnnicDialogContent>
+  </UnnnicDialog>
+</template>
+
+<script setup>
+import { computed, nextTick, ref, watch } from 'vue';
+import { useI18n } from 'vue-i18n';
+
+import { useInstructionsStore } from '@/store/Instructions';
+import { useCategoryValidation } from '@/components/Instructions/NewInstructionDrawer/useCategoryValidation';
+
+const MAX_LENGTH = 50;
+
+const props = defineProps({
+  category: {
+    type: Object,
+    required: true,
+  },
+});
+
+const modelValue = defineModel('modelValue', {
+  type: Boolean,
+  required: true,
+});
+
+const emit = defineEmits(['renamed']);
+
+const { t } = useI18n();
+const renameT = (key) => t(`agents.instructions.rename_category.${key}`);
+
+const instructionsStore = useInstructionsStore();
+
+const inputRef = ref(null);
+const name = ref('');
+const touched = ref(false);
+const isSaving = ref(false);
+
+const otherNames = computed(() =>
+  instructionsStore.categoryOptions
+    .map((option) => option.name)
+    .filter((existing) => existing !== props.category.name),
+);
+
+const { error, isValid } = useCategoryValidation(name, otherNames);
+
+const isUnchanged = computed(() => name.value.trim() === props.category.name);
+
+const canSave = computed(() => isValid.value && !isUnchanged.value);
+
+const displayedErrors = computed(() =>
+  touched.value && error.value ? [error.value] : [],
+);
+
+function close() {
+  modelValue.value = false;
+}
+
+function onUpdateOpen(open) {
+  if (isSaving.value) return;
+  if (!open) close();
+}
+
+function focusInput() {
+  const root = inputRef.value?.$el ?? inputRef.value;
+  root?.querySelector?.('input')?.focus();
+}
+
+watch(
+  modelValue,
+  async (open) => {
+    if (!open) return;
+
+    name.value = props.category.name;
+    touched.value = false;
+    await nextTick();
+    focusInput();
+  },
+  { immediate: true },
+);
+
+async function submit() {
+  touched.value = true;
+  if (!canSave.value || isSaving.value) return;
+
+  isSaving.value = true;
+  const trimmedName = name.value.trim();
+  const { status } = await instructionsStore.renameCategory(
+    props.category.id,
+    trimmedName,
+  );
+  isSaving.value = false;
+
+  if (status === 'error') return;
+
+  emit('renamed', props.category.id);
+  close();
+}
+</script>
+
+<style lang="scss" scoped>
+.modal-rename-category {
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: $unnnic-space-4;
+
+    margin: $unnnic-space-6;
+  }
+}
+</style>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -368,6 +368,16 @@
         "error_title": "Couldn't delete category",
         "error_description": "Something went wrong. Try again."
       },
+      "rename_category": {
+        "cancel": "Cancel",
+        "confirm": "Save",
+        "disclaimer": "Only the name changes. Instructions in this category stay grouped, and the new name appears in the list, the category selector, and the CSV export.",
+        "error_description": "Something went wrong. Try again.",
+        "error_title": "Couldn't rename category",
+        "modal_title": "Rename category",
+        "name_label": "Category name",
+        "success_title": "Category renamed"
+      },
       "view": {
         "default_instruction": "Default instruction",
         "default_instructions": "Default instructions",
@@ -378,6 +388,7 @@
           "instruction": "Instruction"
         },
         "locked_tooltip": "Default instructions can't be edited or deleted",
+        "rename_category": "Rename category",
         "results_count": "{count, plural, =0 {No instructions found} one {{count} instruction found} other {{count} instructions found}}",
         "search_placeholder": "Search...",
         "segmented": {

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -368,6 +368,16 @@
         "error_title": "No se pudo eliminar la categoría",
         "error_description": "Se produjo un error. Vuelve a intentarlo."
       },
+      "rename_category": {
+        "cancel": "Cancelar",
+        "confirm": "Guardar",
+        "disclaimer": "Solo el nombre cambiará. Las instrucciones de esta categoría permanecen agrupadas, y el nuevo nombre aparecerá en la lista, el selector de categorías y la exportación CSV.",
+        "error_description": "Se produjo un error. Inténtalo de nuevo.",
+        "error_title": "No se pudo renombrar la categoría",
+        "modal_title": "Renombrar categoría",
+        "name_label": "Nombre de la categoría",
+        "success_title": "Categoría renombrada"
+      },
       "view": {
         "default_instruction": "Instrucción predeterminada",
         "default_instructions": "Instrucciones predeterminadas",
@@ -378,6 +388,7 @@
           "instruction": "Instrucción"
         },
         "locked_tooltip": "Las instrucciones predeterminadas no se pueden editar ni eliminar",
+        "rename_category": "Renombrar categoría",
         "results_count": "{count, plural, =0 {No se encontraron instrucciones} one {{count} instrucción encontrada} other {{count} instrucciones encontradas}}",
         "search_placeholder": "Buscar...",
         "segmented": {

--- a/src/locales/pt_br.json
+++ b/src/locales/pt_br.json
@@ -368,6 +368,16 @@
         "error_title": "Não foi possível excluir a categoria",
         "error_description": "Algo deu errado. Tente novamente."
       },
+      "rename_category": {
+        "cancel": "Cancelar",
+        "confirm": "Salvar",
+        "disclaimer": "Apenas o nome será alterado. As instruções desta categoria permanecem agrupadas, e o novo nome aparece na lista, no seletor de categoria e na exportação CSV.",
+        "error_description": "Algo deu errado. Tente novamente.",
+        "error_title": "Não foi possível renomear a categoria",
+        "modal_title": "Renomear categoria",
+        "name_label": "Nome da categoria",
+        "success_title": "Categoria renomeada"
+      },
       "view": {
         "default_instruction": "Instrução padrão",
         "default_instructions": "Instruções padrão",
@@ -378,6 +388,7 @@
           "instruction": "Instrução"
         },
         "locked_tooltip": "As instruções padrão não podem ser editadas nem removidas",
+        "rename_category": "Renomear categoria",
         "results_count": "{count, plural, =0 {Nenhuma instrução encontrada} one {{count} instrução encontrada} other {{count} instruções encontradas}}",
         "search_placeholder": "Buscar...",
         "segmented": {

--- a/src/locales/ro.json
+++ b/src/locales/ro.json
@@ -367,6 +367,16 @@
         "error_title": "Categoria nu a putut fi ștearsă",
         "error_description": "Ceva nu a funcționat. Încearcă din nou."
       },
+      "rename_category": {
+        "cancel": "Anulează",
+        "confirm": "Salvează",
+        "disclaimer": "Doar numele se modifică. Instrucțiunile din această categorie rămân grupate, iar noul nume va apărea în listă, în selectorul de categorii și în exportul CSV.",
+        "error_description": "Ceva nu a funcționat corect. Încearcă din nou.",
+        "error_title": "Categoria nu a putut fi redenumită",
+        "modal_title": "Redenumește categoria",
+        "name_label": "Numele categoriei",
+        "success_title": "Categorie redenumită"
+      },
       "view": {
         "default_instruction": "Instrucțiune implicită",
         "default_instructions": "Instrucțiuni implicite",
@@ -377,6 +387,7 @@
           "instruction": "Instrucțiune"
         },
         "locked_tooltip": "Instrucțiunile implicite nu pot fi editate sau șterse",
+        "rename_category": "Redenumește categoria",
         "results_count": "{count, plural, =0 {Nu s-au găsit instrucțiuni} one {{count} instrucțiune găsită} few {{count} instrucțiuni găsite} other {{count} de instrucțiuni găsite}}",
         "search_placeholder": "Caută...",
         "segmented": {

--- a/src/store/Instructions.ts
+++ b/src/store/Instructions.ts
@@ -459,6 +459,48 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     }
   }
 
+  async function renameCategory(id: number, name: string) {
+    const alertStore = useAlertStore();
+    const categoryT = (key: string) =>
+      i18n.global.t(`agents.instructions.rename_category.${key}`);
+    const trimmedName = name.trim();
+
+    try {
+      await nexusaiAPI.agent_builder.instructions.renameCategory({
+        projectUuid: projectUuid.value,
+        id,
+        name: trimmedName,
+      });
+
+      categories.value = categories.value.map((category) =>
+        category.id === id ? { ...category, name: trimmedName } : category,
+      );
+      instructions.data = instructions.data.map((instruction) =>
+        instruction.category?.id === id
+          ? {
+              ...instruction,
+              category: { ...instruction.category, name: trimmedName },
+            }
+          : instruction,
+      );
+
+      alertStore.add({
+        type: 'success',
+        text: categoryT('success_title'),
+      });
+
+      return { status: null };
+    } catch {
+      alertStore.add({
+        type: 'error',
+        text: categoryT('error_title'),
+        description: categoryT('error_description'),
+      });
+
+      return { status: 'error' };
+    }
+  }
+
   async function getInstructionSuggestionByAI(instruction: string) {
     instructionSuggestedByAI.status = 'loading';
 
@@ -604,6 +646,7 @@ export const useInstructionsStore = defineStore('Instructions', () => {
     editInstruction,
     removeInstruction,
     deleteCategory,
+    renameCategory,
     getInstructionSuggestionByAI,
     updateValidateInstructionByAI,
     resetInstructionSuggestedByAI,


### PR DESCRIPTION
### Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Tests
- [ ] Chore
- [x] Locales

### Why

Users needed a way to rename instruction categories without having to delete and recreate them, preserving all grouped instructions while updating the category name across the UI and CSV exports.

### What Changed

- Added `toRenameCategoryApi` to `InstructionsGroupedAdapter`, which builds the PATCH payload with a trimmed category name.
- Added `Instructions.renameCategory` to the Nexus API layer, sending a PATCH request with `hideGenericErrorAlert`.
- Added `renameCategory` action to the Instructions store, which updates both the `categories` and `instructions` lists optimistically after a successful API call, and shows success/error alerts accordingly.
- Added a "Rename category" action to the `CategoryAccordion` actions menu, emitting a `rename-category` event up the component tree.
- Created `ModalRenameCategory.vue`, a dialog with a name input (max 50 chars), validation via `useCategoryValidation`, an unchanged-name guard, and a disclaimer explaining the scope of the rename.
- `CategoriesView` now accepts a `scrollToGroupKey` prop and stores refs to each `CategoryAccordion`, scrolling the renamed category into view after the modal closes.
- `InstructionsCategorization/index.vue` wires together the rename modal, the scroll-to behavior, and the event handlers.
- Locale strings for the rename category feature added in English, Spanish, Portuguese, and Romanian.

### Diagram

```mermaid
flowchart TD
    A[CategoryAccordion\nRename action clicked] -->|rename-category event| B[CategoriesView]
    B -->|rename-category event| C[InstructionsCategorization]
    C --> D[ModalRenameCategory]
    D -->|submit| E[instructionsStore.renameCategory]
    E --> F[nexusaiAPI.instructions.renameCategory\nPATCH]
    F -->|success| G[Update categories & instructions in store]
    G --> H[Emit renamed event]
    H --> C
    C --> I[scrollToCategoryKey set]
    I --> B
    B --> J[Scroll renamed category into view]
```

### Demonstration

![image.png](https://app.graphite.com/user-attachments/assets/db0df228-0a18-4e76-83f1-b4867a7d865d.png)

