### PR TITLE
feat: Add rename category modal with scroll-to-group behavior and tests

### DIFF
--- a/src/components/Instructions/InstructionsCategorization/__tests__/CategoriesView.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/CategoriesView.spec.js
@@ -1,5 +1,6 @@
 import { shallowMount } from '@vue/test-utils';
 import { describe, it, expect, afterEach, vi } from 'vitest';
+import { nextTick } from 'vue';
 import { createTestingPinia } from '@pinia/testing';
 
 import CategoriesView from '../CategoriesView.vue';
@@ -23,7 +24,7 @@ vi.mock('@/store/FeatureFlags', () => ({
 describe('CategoriesView.vue', () => {
   let wrapper;
 
-  const createWrapper = ({ instructionsState = {} } = {}) => {
+  const createWrapper = ({ instructionsState = {}, props = {} } = {}) => {
     const pinia = createTestingPinia({
       initialState: {
         Instructions: {
@@ -39,6 +40,7 @@ describe('CategoriesView.vue', () => {
     useInstructionsStore();
 
     return shallowMount(CategoriesView, {
+      props,
       global: { plugins: [pinia] },
     });
   };
@@ -162,6 +164,65 @@ describe('CategoriesView.vue', () => {
       .vm.$emit('delete-category', group);
 
     expect(wrapper.emitted('delete-category')).toEqual([[group]]);
+  });
+
+  it('forwards the rename-category event from an accordion', async () => {
+    wrapper = createWrapper({
+      instructionsState: {
+        instructions: {
+          data: [
+            { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+          ],
+          status: 'complete',
+        },
+        categories: [{ id: 10, name: 'Sales' }],
+      },
+    });
+
+    const group = { key: 'category-10' };
+    await wrapper
+      .findComponent(CategoryAccordion)
+      .vm.$emit('rename-category', group);
+
+    expect(wrapper.emitted('rename-category')).toEqual([[group]]);
+  });
+
+  it('scrolls the target accordion into view when scrollToGroupKey changes', async () => {
+    wrapper = createWrapper({
+      instructionsState: {
+        instructions: {
+          data: [
+            { id: 1, text: 'Sales A', category: { id: 10, name: 'Sales' } },
+            { id: 2, text: 'Support A', category: { id: 20, name: 'Support' } },
+          ],
+          status: 'complete',
+        },
+        categories: [
+          { id: 10, name: 'Sales' },
+          { id: 20, name: 'Support' },
+        ],
+      },
+    });
+
+    await nextTick();
+
+    const scrollIntoView = vi.fn();
+    const accordion = wrapper
+      .findAllComponents(CategoryAccordion)
+      .find((component) => component.props('group').key === 'category-10');
+
+    Object.defineProperty(accordion.vm.$el, 'scrollIntoView', {
+      value: scrollIntoView,
+      configurable: true,
+    });
+
+    await wrapper.setProps({ scrollToGroupKey: 'category-10' });
+    await nextTick();
+
+    expect(scrollIntoView).toHaveBeenCalledWith({
+      block: 'nearest',
+      behavior: 'smooth',
+    });
   });
 
   it('renders SafetyGuardrails when the customGuardrails flag is enabled', () => {

--- a/src/components/Instructions/InstructionsCategorization/__tests__/CategoryAccordion.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/CategoryAccordion.spec.js
@@ -103,6 +103,17 @@ describe('CategoryAccordion.vue', () => {
     expect(wrapper.emitted('delete-category')).toEqual([[group]]);
   });
 
+  it('emits rename-category with the group when the rename action is clicked', async () => {
+    const group = customGroup();
+    wrapper = createWrapper(group);
+
+    await wrapper
+      .find(`[data-test="${viewT('rename_category')}"]`)
+      .trigger('click');
+
+    expect(wrapper.emitted('rename-category')).toEqual([[group]]);
+  });
+
   it('renders a locked tag with tooltip and no menu for default groups', () => {
     wrapper = createWrapper(lockedGroup());
 

--- a/src/components/Instructions/InstructionsCategorization/__tests__/index.spec.js
+++ b/src/components/Instructions/InstructionsCategorization/__tests__/index.spec.js
@@ -5,6 +5,7 @@ import { createTestingPinia } from '@pinia/testing';
 import InstructionsCategorization from '../index.vue';
 import InstructionsResultsCount from '../InstructionsResultsCount.vue';
 import ModalRemoveCategory from '@/components/Instructions/ModalRemoveCategory.vue';
+import ModalRenameCategory from '@/components/Instructions/ModalRenameCategory.vue';
 import { useInstructionsStore } from '@/store/Instructions';
 import i18n from '@/utils/plugins/i18n';
 
@@ -142,6 +143,56 @@ describe('InstructionsCategorization/index.vue', () => {
       await removeModal().vm.$emit('update:model-value', false);
 
       expect(removeModal().exists()).toBe(false);
+    });
+  });
+
+  describe('Rename category', () => {
+    const renameModal = () => wrapper.findComponent(ModalRenameCategory);
+
+    it('does not render the rename category modal by default', () => {
+      expect(renameModal().exists()).toBe(false);
+    });
+
+    it('opens the rename category modal with the selected category', async () => {
+      await findComponent('categoriesView').vm.$emit('rename-category', {
+        key: 'category-10',
+        categoryId: 10,
+        label: 'Sales',
+      });
+
+      expect(renameModal().exists()).toBe(true);
+      expect(renameModal().props('category')).toEqual({
+        id: 10,
+        name: 'Sales',
+      });
+    });
+
+    it('unmounts the rename category modal when it closes', async () => {
+      await findComponent('categoriesView').vm.$emit('rename-category', {
+        key: 'category-10',
+        categoryId: 10,
+        label: 'Sales',
+      });
+
+      expect(renameModal().exists()).toBe(true);
+
+      await renameModal().vm.$emit('update:model-value', false);
+
+      expect(renameModal().exists()).toBe(false);
+    });
+
+    it('passes the scroll key to CategoriesView after a successful rename', async () => {
+      await findComponent('categoriesView').vm.$emit('rename-category', {
+        key: 'category-10',
+        categoryId: 10,
+        label: 'Sales',
+      });
+
+      await renameModal().vm.$emit('renamed', 10);
+
+      expect(findComponent('categoriesView').props('scrollToGroupKey')).toBe(
+        'category-10',
+      );
     });
   });
 

--- a/src/components/Instructions/__tests__/ModalRenameCategory.spec.js
+++ b/src/components/Instructions/__tests__/ModalRenameCategory.spec.js
@@ -1,0 +1,187 @@
+import { shallowMount, flushPromises } from '@vue/test-utils';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { nextTick } from 'vue';
+import { createTestingPinia } from '@pinia/testing';
+
+import ModalRenameCategory from '../ModalRenameCategory.vue';
+import i18n from '@/utils/plugins/i18n';
+import { useInstructionsStore } from '@/store/Instructions';
+
+describe('ModalRenameCategory.vue', () => {
+  let wrapper;
+  let instructionsStore;
+
+  const category = { id: 10, name: 'Sales' };
+
+  const renameT = (key) =>
+    i18n.global.t(`agents.instructions.rename_category.${key}`);
+
+  const SELECTORS = {
+    modal: '[data-testid="modal"]',
+    input: '[data-testid="name-input"]',
+    disclaimer: '[data-testid="disclaimer"]',
+    cancel: '[data-testid="cancel-button"]',
+    confirm: '[data-testid="confirm-button"]',
+  };
+  const findComponent = (selector) =>
+    wrapper.findComponent(SELECTORS[selector]);
+
+  const createWrapper = ({
+    categories = [
+      { id: 10, name: 'Sales' },
+      { id: 20, name: 'Support' },
+    ],
+    modelValue = true,
+  } = {}) => {
+    const pinia = createTestingPinia({
+      initialState: {
+        Instructions: {
+          categories,
+          sessionCategories: [],
+          instructions: { data: [] },
+        },
+      },
+    });
+
+    instructionsStore = useInstructionsStore(pinia);
+    instructionsStore.renameCategory = vi
+      .fn()
+      .mockResolvedValue({ status: null });
+
+    return shallowMount(ModalRenameCategory, {
+      props: { modelValue, category },
+      global: {
+        plugins: [pinia],
+        stubs: {
+          UnnnicDialogClose: { template: '<div><slot /></div>' },
+        },
+      },
+    });
+  };
+
+  const setName = async (value) => {
+    await findComponent('input').vm.$emit('update:modelValue', value);
+    await nextTick();
+  };
+
+  beforeEach(async () => {
+    wrapper = createWrapper();
+    await nextTick();
+  });
+
+  afterEach(() => {
+    wrapper.unmount();
+    vi.clearAllMocks();
+  });
+
+  describe('Rendering', () => {
+    it('renders the dialog open with the title and pre-filled name', () => {
+      expect(findComponent('modal').props('open')).toBe(true);
+      expect(wrapper.text()).toContain(renameT('modal_title'));
+      expect(findComponent('input').props('modelValue')).toBe(category.name);
+    });
+
+    it('renders the informational disclaimer', () => {
+      expect(findComponent('disclaimer').props('type')).toBe('informational');
+      expect(findComponent('disclaimer').props('description')).toBe(
+        renameT('disclaimer'),
+      );
+    });
+
+    it('renders cancel and save buttons with the correct labels', () => {
+      expect(findComponent('cancel').props('text')).toBe(renameT('cancel'));
+      expect(findComponent('confirm').props('text')).toBe(renameT('confirm'));
+      expect(findComponent('confirm').props('type')).toBe('primary');
+    });
+  });
+
+  describe('Validation', () => {
+    it('disables Save when the name is unchanged', () => {
+      expect(findComponent('confirm').props('disabled')).toBe(true);
+    });
+
+    it('disables Save when the name is empty or whitespace', async () => {
+      await setName('');
+      expect(findComponent('confirm').props('disabled')).toBe(true);
+
+      await setName('   ');
+      expect(findComponent('confirm').props('disabled')).toBe(true);
+    });
+
+    it('disables Save when the name has invalid characters', async () => {
+      await setName('Sales!');
+      expect(findComponent('confirm').props('disabled')).toBe(true);
+    });
+
+    it('enables Save when the name is a valid new name', async () => {
+      await setName('Marketing');
+      expect(findComponent('confirm').props('disabled')).toBe(false);
+    });
+
+    it('allows a case-only change of the current category name', async () => {
+      await setName('sales');
+      expect(findComponent('confirm').props('disabled')).toBe(false);
+    });
+  });
+
+  describe('Interactions', () => {
+    it('emits update:modelValue false when cancel is clicked', async () => {
+      await findComponent('cancel').vm.$emit('click');
+
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+    });
+
+    it('calls renameCategory with the id and trimmed name and closes on success', async () => {
+      await setName('  Marketing  ');
+      await findComponent('confirm').vm.$emit('click');
+      await flushPromises();
+
+      expect(instructionsStore.renameCategory).toHaveBeenCalledWith(
+        category.id,
+        'Marketing',
+      );
+      expect(wrapper.emitted('renamed')).toEqual([[category.id]]);
+      expect(wrapper.emitted('update:modelValue')).toEqual([[false]]);
+    });
+
+    it('keeps the modal open on error', async () => {
+      instructionsStore.renameCategory.mockResolvedValue({ status: 'error' });
+
+      await setName('Marketing');
+      await findComponent('confirm').vm.$emit('click');
+      await flushPromises();
+
+      expect(wrapper.emitted('update:modelValue')).toBeFalsy();
+      expect(wrapper.emitted('renamed')).toBeFalsy();
+    });
+
+    it('shows loading on the save button while renaming', async () => {
+      let resolveRename;
+      instructionsStore.renameCategory.mockImplementation(
+        () => new Promise((resolve) => (resolveRename = resolve)),
+      );
+
+      await setName('Marketing');
+      findComponent('confirm').vm.$emit('click');
+      await nextTick();
+
+      expect(findComponent('confirm').props('loading')).toBe(true);
+
+      resolveRename({ status: null });
+      await flushPromises();
+
+      expect(findComponent('confirm').props('loading')).toBe(false);
+    });
+
+    it('discards the draft when the modal is closed and reopened', async () => {
+      await setName('Marketing');
+      await findComponent('cancel').vm.$emit('click');
+
+      await wrapper.setProps({ modelValue: false });
+      await wrapper.setProps({ modelValue: true });
+      await nextTick();
+
+      expect(findComponent('input').props('modelValue')).toBe(category.name);
+    });
+  });
+});

--- a/src/store/__tests__/Instructions.unit.spec.js
+++ b/src/store/__tests__/Instructions.unit.spec.js
@@ -19,6 +19,7 @@ vi.mock('@/api/nexusaiAPI', () => ({
         update: vi.fn(),
         deleteInstruction: vi.fn(),
         deleteCategory: vi.fn(),
+        renameCategory: vi.fn(),
         getSuggestionByAI: vi.fn(),
         export: vi.fn(),
       },
@@ -651,6 +652,87 @@ describe('Instructions Store', () => {
           ),
           description: i18n.global.t(
             'agents.instructions.delete_category.error_description',
+          ),
+        });
+        expect(result).toEqual({ status: 'error' });
+      });
+    });
+
+    describe('renameCategory', () => {
+      beforeEach(() => {
+        store.categories = [
+          { id: 10, name: 'Sales' },
+          { id: 20, name: 'Support' },
+        ];
+        store.instructions.data = [
+          { id: 1, text: 'A', category: { id: 10, name: 'Sales' } },
+          { id: 2, text: 'B', category: { id: 10, name: 'Sales' } },
+          { id: 3, text: 'C', category: { id: 20, name: 'Support' } },
+        ];
+      });
+
+      it('updates the category name in categories and instructions', async () => {
+        nexusaiAPI.agent_builder.instructions.renameCategory.mockResolvedValue();
+
+        const result = await store.renameCategory(10, 'Marketing');
+
+        expect(
+          nexusaiAPI.agent_builder.instructions.renameCategory,
+        ).toHaveBeenCalledWith({
+          projectUuid: 'test-project-uuid',
+          id: 10,
+          name: 'Marketing',
+        });
+        expect(store.categories).toEqual([
+          { id: 10, name: 'Marketing' },
+          { id: 20, name: 'Support' },
+        ]);
+        expect(
+          store.instructions.data.find((i) => i.id === 1).category,
+        ).toEqual({ id: 10, name: 'Marketing' });
+        expect(
+          store.instructions.data.find((i) => i.id === 2).category,
+        ).toEqual({ id: 10, name: 'Marketing' });
+        expect(
+          store.instructions.data.find((i) => i.id === 3).category,
+        ).toEqual({ id: 20, name: 'Support' });
+        expect(result).toEqual({ status: null });
+      });
+
+      it('shows a success toast without a description', async () => {
+        nexusaiAPI.agent_builder.instructions.renameCategory.mockResolvedValue();
+
+        await store.renameCategory(10, 'Marketing');
+
+        expect(alertStore.add).toHaveBeenCalledWith({
+          type: 'success',
+          text: i18n.global.t(
+            'agents.instructions.rename_category.success_title',
+          ),
+        });
+      });
+
+      it('keeps state and shows an error toast on failure', async () => {
+        nexusaiAPI.agent_builder.instructions.renameCategory.mockRejectedValue(
+          new Error('API Error'),
+        );
+
+        const result = await store.renameCategory(10, 'Marketing');
+
+        expect(store.categories).toEqual([
+          { id: 10, name: 'Sales' },
+          { id: 20, name: 'Support' },
+        ]);
+        expect(
+          store.instructions.data.find((i) => i.id === 1).category,
+        ).toEqual({ id: 10, name: 'Sales' });
+        expect(alertStore.add).toHaveBeenCalledWith({
+          type: 'error',
+          text: i18n.global.t(
+            'agents.instructions.rename_category.error_title',
+          ),
+          description: i18n.global.t(
+            'agents.instructions.rename_category.error_description',
           ),
         });
         expect(result).toEqual({ status: 'error' });


### PR DESCRIPTION
### Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [x] Tests
- [ ] Chore
- [ ] Locales

### Why

Users need the ability to rename instruction categories directly from the categorization view, without having to delete and recreate them.

### What Changed

- Added unit tests for `ModalRenameCategory` covering rendering, name validation, save/cancel interactions, loading state, and error handling
- Added store tests for `renameCategory` covering API call, local state updates, and success/error toasts
- Extended categorization view tests to cover rename event forwarding, modal open/close lifecycle, and scroll restoration after a successful rename